### PR TITLE
fix: resolve 13 Claude Code plugin startup errors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
       url = "github:kepano/obsidian-skills";
       flake = false;
     };
-    obsidian-visual-skills = {
+    axton-obsidian-visual-skills = {
       url = "github:axtonliu/axton-obsidian-visual-skills";
       flake = false;
     };
@@ -103,7 +103,7 @@
       jacobpevans-cc-plugins,
       lunar-claude,
       obsidian-skills,
-      obsidian-visual-skills,
+      axton-obsidian-visual-skills,
       superpowers-marketplace,
       wakatime,
       ...
@@ -122,7 +122,7 @@
           jacobpevans-cc-plugins
           lunar-claude
           obsidian-skills
-          obsidian-visual-skills
+          axton-obsidian-visual-skills
           superpowers-marketplace
           wakatime
           ;

--- a/modules/claude/plugins/community.nix
+++ b/modules/claude/plugins/community.nix
@@ -21,16 +21,12 @@ _:
     "superpowers-developing-for-claude-code@superpowers-marketplace" = true; # User requested restore
 
     # Obsidian Skills - Canonical (kepano/obsidian-skills)
-    "obsidian-markdown@obsidian-skills" = true; # Create/edit Obsidian Flavored Markdown
-    "obsidian-bases@obsidian-skills" = true; # Work with Obsidian Base files (databases)
-    "json-canvas@obsidian-skills" = true; # Handle JSON Canvas file structure
-    "obsidian-cli@obsidian-skills" = true; # Vault interactions and plugin/theme dev
-    "defuddle@obsidian-skills" = true; # Extract clean markdown from web pages
+    # Marketplace declares single plugin "obsidian" bundling 5 skills
+    "obsidian@obsidian-skills" = true;
 
     # Obsidian Visual Skills - Diagrams (axtonliu/axton-obsidian-visual-skills)
-    "excalidraw-diagram-generator@obsidian-visual-skills" = true; # Hand-drawn style diagrams
-    "mermaid-visualizer@obsidian-visual-skills" = true; # Professional diagrams
-    "obsidian-canvas-creator@obsidian-visual-skills" = true; # Interactive Canvas files
+    # Marketplace declares single plugin "obsidian-visual-skills" bundling 3 skills
+    "obsidian-visual-skills@axton-obsidian-visual-skills" = true;
 
     # REMOVED - redundant or unused:
     # double-check - unnecessary

--- a/modules/claude/plugins/development.nix
+++ b/modules/claude/plugins/development.nix
@@ -33,6 +33,8 @@ let
         "schemas"
         ".claude-plugin"
         ".github"
+        "scripts"
+        "tests"
       ];
       isPluginDir =
         name: type: type == "directory" && !(lib.hasPrefix "." name) && !(builtins.elem name nonPluginDirs);

--- a/modules/claude/plugins/marketplaces.nix
+++ b/modules/claude/plugins/marketplaces.nix
@@ -185,7 +185,7 @@ let
     };
 
     # Independent visual diagram skills (Excalidraw, Mermaid, Canvas Creator)
-    "obsidian-visual-skills" = {
+    "axton-obsidian-visual-skills" = {
       source = {
         type = "github";
         url = "axtonliu/axton-obsidian-visual-skills";

--- a/modules/claude/plugins/official.nix
+++ b/modules/claude/plugins/official.nix
@@ -56,9 +56,6 @@ _:
     # DISABLED - New Opus 4.6 and Agent Teams sort of handle this
     "ralph-loop@claude-plugins-official" = false;
 
-    # Explicitly disabled - tracked for visibility
-    "example-plugin@claude-plugins-official" = false;
-
     # External plugins (GitHub, Slack, Context7, etc.) moved to external.nix
   };
 }


### PR DESCRIPTION
## Summary

Fixes all 13 plugin errors seen on Claude Code startup. Each error was a name/path mismatch between the Nix config and the actual marketplace or plugin manifests.

**Errors 1-3: obsidian-visual-skills marketplace key wrong**
- Rename flake input `obsidian-visual-skills` → `axton-obsidian-visual-skills` to match `marketplace.json` `name` field
- Update `marketplaces.nix` key accordingly
- Fix `community.nix`: replace 3 individual skill names with `"obsidian-visual-skills@axton-obsidian-visual-skills"`

**Errors 4-8: obsidian-skills plugin names wrong**
- Fix `community.nix`: replace 5 individual skill names with `"obsidian@obsidian-skills"` (the actual plugin name in marketplace.json)

**Errors 9-10: jacobpevans-cc-plugins auto-discovery picks up non-plugin dirs**
- Add `"scripts"` and `"tests"` to `nonPluginDirs` in `development.nix`

**Error 11: claude-plugins-official non-existent plugin**
- Remove `"example-plugin@claude-plugins-official" = false` from `official.nix`

**Errors 12-13: codeql-resolver skill paths missing .md extension**
- Companion fix: [JacobPEvans/claude-code-plugins#59](https://github.com/JacobPEvans/claude-code-plugins/pull/59)
- After that PR merges: `nix flake update jacobpevans-cc-plugins` then rebuild

## Post-merge steps

1. Merge [claude-code-plugins#59](https://github.com/JacobPEvans/claude-code-plugins/pull/59) first
2. Merge this PR
3. Run `nix flake update jacobpevans-cc-plugins axton-obsidian-visual-skills` to update lock file for renamed input and new commit
4. Run `darwin-rebuild switch --flake .`
5. Restart Claude Code — should show 0 plugin errors

## Test plan

- [ ] Claude Code starts with 0 plugin errors
- [ ] `obsidian@obsidian-skills` loads (markdown, bases, canvas, CLI, defuddle skills)
- [ ] `obsidian-visual-skills@axton-obsidian-visual-skills` loads (excalidraw, mermaid, canvas-creator skills)
- [ ] codeql-resolver skills load without path errors
- [ ] `settings.json` has no `scripts@`, `tests@`, or `example-plugin@` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 13 Claude Code startup errors by resolving plugin name/path mismatches in Nix configuration.
> 
>   - **Behavior**:
>     - Fixes 13 startup errors in Claude Code by resolving name/path mismatches in Nix config.
>     - Renames `obsidian-visual-skills` to `axton-obsidian-visual-skills` in `flake.nix`, `marketplaces.nix`, and `community.nix`.
>     - Updates `community.nix` to replace individual skill names with `obsidian@obsidian-skills` and `obsidian-visual-skills@axton-obsidian-visual-skills`.
>     - Adds `scripts` and `tests` to `nonPluginDirs` in `development.nix` to prevent auto-discovery of non-plugin directories.
>     - Removes non-existent `example-plugin@claude-plugins-official` from `official.nix`.
>   - **Post-merge steps**:
>     - Merge related PR `JacobPEvans/claude-code-plugins#59` first.
>     - Run `nix flake update` and `darwin-rebuild switch --flake .` after merging.
>     - Restart Claude Code to ensure 0 plugin errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for 889d0a0f6aa8337b5d0d67d7f7e8973f121c6951. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->