### PR TITLE
docs: update repo URL after rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,4 +57,4 @@ sudo darwin-rebuild switch --flake . --override-input nix-ai /Users/you/git/nix-
 | ---- | ------- |
 | **nix-ai** (this repo) | AI coding tools |
 | [nix-home](https://github.com/JacobPEvans/nix-home) | Dev environment (git, zsh, VS Code, tmux) |
-| [nix-config](https://github.com/JacobPEvans/nix) | macOS system config (consumes both) |
+| [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes both) |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This repo is one of three that work together:
 | ---- | ------------ |
 | **nix-ai** (you are here) | AI coding tools |
 | [nix-home](https://github.com/JacobPEvans/nix-home) | Dev environment (git, zsh, VS Code, tmux) |
-| [nix-config](https://github.com/JacobPEvans/nix-config) | macOS system config (consumes both) |
+| [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes both) |
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update nix-config references to nix-darwin after repo rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update repository URL references from `nix-config` to `nix-darwin` in documentation files after repo rename.
> 
>   - **Docs**:
>     - Update repository URL from `nix-config` to `nix-darwin` in `CLAUDE.md` and `README.md` after repository rename.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for 3d5822a7ba565b6fe3e9b4cf266a89dbf2bb1869. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->