### PR TITLE
feat(statusline): reorder line 1 segments to git-first layout

### DIFF
--- a/modules/claude/statusline/claude-powerline.json
+++ b/modules/claude/statusline/claude-powerline.json
@@ -7,9 +7,6 @@
     "lines": [
       {
         "segments": {
-          "directory": { "enabled": true, "style": "fish" },
-          "model": { "enabled": true },
-          "context": { "enabled": true, "showPercentageOnly": false },
           "git": {
             "enabled": true,
             "showRepoName": true,
@@ -22,6 +19,9 @@
             "showUpstream": false,
             "showStash": false
           },
+          "directory": { "enabled": true, "style": "fish" },
+          "model": { "enabled": true },
+          "context": { "enabled": true, "showPercentageOnly": false },
           "metrics": {
             "enabled": true,
             "showResponseTime": false,


### PR DESCRIPTION
## Summary

- Move `git` segment to the front of line 1
- New order: git → directory → model → context → metrics
- Line 2 unchanged

## Test plan

- [x] `nix flake check` passes
- [ ] Restart Claude Code session and verify new segment order renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorders line 1 segments in `claude-powerline.json` to prioritize `git` segment first.
> 
>   - **Behavior**:
>     - Reorders line 1 segments in `claude-powerline.json` to `git`, `directory`, `model`, `context`, `metrics`.
>     - Line 2 segments remain unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for 85363c48bc72b6eee424995f798802703aaeeac1. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->