### PR TITLE
feat(statusline): expand to 3-line layout

### DIFF
--- a/modules/claude/statusline/claude-powerline.json
+++ b/modules/claude/statusline/claude-powerline.json
@@ -12,6 +12,23 @@
             "showRepoName": true,
             "showWorktree": true,
             "showBranch": true,
+            "showBehind": false,
+            "showClean": false,
+            "showChanges": false,
+            "showSha": false,
+            "showUpstream": false,
+            "showStash": false
+          },
+          "directory": { "enabled": true, "style": "fish" }
+        }
+      },
+      {
+        "segments": {
+          "git": {
+            "enabled": true,
+            "showRepoName": false,
+            "showWorktree": false,
+            "showBranch": false,
             "showBehind": true,
             "showClean": true,
             "showChanges": true,
@@ -19,7 +36,6 @@
             "showUpstream": false,
             "showStash": false
           },
-          "directory": { "enabled": true, "style": "fish" },
           "model": { "enabled": true },
           "context": { "enabled": true, "showPercentageOnly": false },
           "metrics": {


### PR DESCRIPTION
## Summary

- Splits the 2-line statusline into 3 lines for better information density
- Line 1: git identity (repo, branch, worktree) + directory
- Line 2: git status (behind/clean/changes) + model, context, metrics
- Line 3: time, session cost, today breakdown (unchanged from previous line 2)

## Test plan

- [ ] Run `nix flake check` to validate
- [ ] Test with `darwin-rebuild switch` using `--override-input nix-ai`
- [ ] Verify all 3 lines render correctly in Claude Code statusline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expands statusline to 3 lines in `claude-powerline.json` for enhanced information density, with specific configurations for git identity, status, and metrics.
> 
>   - **Behavior**:
>     - Expands statusline from 2 lines to 3 lines in `claude-powerline.json`.
>     - Line 1: Displays git identity (repo, branch, worktree) and directory.
>     - Line 2: Displays git status (behind, clean, changes) and additional metrics (model, context, metrics).
>     - Line 3: Unchanged, displays time, session cost, and today's breakdown.
>   - **Configuration**:
>     - Updates `claude-powerline.json` to reflect new 3-line layout with specific segment configurations for each line.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for b14d500f10e2e69fa3aa24206c07189277563b64. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->