### PR TITLE
chore: add module-eval, shellcheck checks, markdownlint config for v1.0.0

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "default": true,
+    "MD013": {
+      "line_length": 160,
+      "heading_line_length": 120,
+      "code_block_line_length": 160,
+      "tables": false
+    },
+    // MD060 (table-column-style) disabled: GitHub Actions markdownlint-cli2-action
+    // uses markdownlint v0.39.0 (with MD060), but nixpkgs markdownlint-cli2 v0.18.1
+    // includes markdownlint v0.38.0 (without MD060). Re-enable when nixpkgs updates.
+    "MD060": false
+  },
+  "fix": true,
+  "gitignore": true
+}

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -5,12 +5,9 @@ config:
     heading_line_length: 120
     code_block_line_length: 160
     tables: false
-  MD033:
-    allowed_elements:
-      - br
-      - details
-      - summary
-  MD041: true
+  # MD060 (table-column-style) disabled: GitHub Actions markdownlint-cli2-action
+  # uses markdownlint v0.39.0 (with MD060), but nixpkgs markdownlint-cli2 v0.18.1
+  # includes markdownlint v0.38.0 (without MD060). Re-enable when nixpkgs updates.
   MD060: false
 fix: true
 gitignore: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ One command rebuilds everything, identically, every time.
 | **AI Dev Tools** | cclint, doppler-mcp, claude-flow, sync-ollama-models |
 | **Ollama** | Local model management with macOS launchd integration |
 
+## Prerequisites
+
+- [Nix](https://nixos.org/) (Determinate Nix recommended)
+- [home-manager](https://github.com/nix-community/home-manager)
+- Compatible platform: `aarch64-darwin` or `x86_64-linux`
+
 ## Quick start
 
 Add to your Nix flake:
@@ -65,6 +71,42 @@ inputs.home-manager.follows = "home-manager";
 ```
 
 No AI-specific inputs to wire up. No extra configuration. It just works.
+
+## Available module options
+
+Key enable toggles exposed by the default module:
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `programs.claude.enable` | bool | — | Enable Claude Code configuration |
+| `programs.claude.apiKeyHelper.enable` | bool | false | Headless API key authentication via Bitwarden |
+| `programs.claudeStatusline.enable` | bool | true | Claude Code powerline statusline |
+| `programs.claude.settings.sandbox.enabled` | bool | false | Filesystem/network sandbox isolation |
+| `programs.claude.settings.alwaysThinkingEnabled` | bool | true | Extended thinking mode |
+| `programs.claude.remoteControlAtStartup` | bool or null | null | Remote Control auto-start |
+| `programs.claude.model` | string or null | null | Override default model (e.g. `"opus"`, `"sonnet"`) |
+| `programs.claude.effortLevel` | enum | `"high"` | Adaptive reasoning effort (`"low"`, `"medium"`, `"high"`) |
+| `programs.claude.trustedProjectDirs` | list of str | `[]` | Base directories for auto-trust of CLAUDE.md imports |
+
+For the full option set, see [`modules/claude/options.nix`](modules/claude/options.nix).
+
+## Testing and validation
+
+Run quality checks locally:
+
+```bash
+nix flake check
+```
+
+This runs formatting (nixfmt), static analysis (statix), dead code detection (deadnix),
+shell script linting (shellcheck), and full module evaluation (module-eval) to verify
+the home-manager module instantiates correctly with real inputs.
+
+Fix formatting automatically:
+
+```bash
+nix fmt
+```
 
 ## Repository structure
 

--- a/cspell.json
+++ b/cspell.json
@@ -3,11 +3,15 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "Bitwarden",
     "cclint",
     "deadnix",
+    "nixfmt",
     "nixpkgs",
     "ollama",
     "Ollama",
+    "powerline",
+    "shellcheck",
     "statix",
     "worktree",
     "worktrees"

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       home-manager,
       claude-code-plugins,
@@ -208,15 +209,16 @@
         versions = import ./lib/versions.nix;
       };
 
-      # Quality checks (formatting, linting, dead code)
+      # Quality checks (formatting, linting, dead code, shellcheck, module-eval)
       checks = forAllSystems (
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
         import ./lib/checks.nix {
-          inherit pkgs;
+          inherit pkgs home-manager;
           src = ./.;
+          aiModule = self.homeManagerModules.default;
         }
       );
 

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -2,6 +2,8 @@
 {
   pkgs,
   src,
+  home-manager,
+  aiModule,
 }:
 {
   formatting =
@@ -28,4 +30,48 @@
     ${pkgs.lib.getExe pkgs.deadnix} -L --fail .
     touch $out
   '';
+
+  # Lint shell scripts with shellcheck
+  # Catches common bugs: unquoted variables, undefined vars, useless use of cat, etc.
+  # Excludes .git directories and nix store paths
+  # --severity=warning: Only fail on warning/error level (not info style suggestions)
+  # SC1091: Exclude "not following" errors for external sources (can't resolve in Nix sandbox)
+  # Excludes zsh scripts (shellcheck only supports sh/bash/dash/ksh)
+  # Uses find with -print0 and xargs -0 for robustness with filenames containing spaces and special characters
+  shellcheck = pkgs.runCommand "check-shellcheck" { } ''
+    cd ${src}
+    find . -name "*.sh" -not -path "./.git/*" -not -path "./result/*" -print0 | \
+    xargs -0 bash -c '
+      for script in "$@"; do
+        # Skip zsh scripts (shellcheck does not support them)
+        if head -1 "$script" | grep -q "zsh"; then
+          echo "Skipping zsh script: $script"
+        else
+          echo "Checking $script..."
+          ${pkgs.lib.getExe pkgs.shellcheck} --severity=warning --exclude=SC1091 "$script"
+        fi
+      done
+    ' bash
+    touch $out
+  '';
+
+  # Evaluate the real home-manager module with real inputs to catch import errors
+  # This ensures the module can be instantiated without failures
+  module-eval =
+    let
+      hmConfig = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        modules = [
+          aiModule
+          {
+            home = {
+              username = "test-user";
+              homeDirectory = "/home/test-user";
+              stateVersion = "24.11";
+            };
+          }
+        ];
+      };
+    in
+    hmConfig.activationPackage;
 }


### PR DESCRIPTION
## Summary

- **lib/checks.nix**: Expanded signature to `{ pkgs, src, home-manager, aiModule }:`; added `shellcheck` check (ported from nix-home) and `module-eval` check that instantiates `homeManagerModules.default` with real inputs to catch import errors at CI time
- **flake.nix**: Added `self` to outputs function args; updated `checks` invocation to pass `home-manager` and `aiModule = self.homeManagerModules.default`
- **.markdownlint-cli2.yaml / .markdownlint-cli2.jsonc**: Added standard markdownlint config (line_length: 160, MD060: false) matching nix-darwin/nix-home
- **README.md**: Added Prerequisites section, Available module options table, and Testing/validation section
- **cspell.json**: Added `Bitwarden`, `nixfmt`, `powerline`, `shellcheck` to the word list

## Test plan

- [ ] All pre-commit hooks pass (formatting, statix, deadnix, markdownlint, cspell) — verified locally
- [ ] `nix flake check` passes on CI (runs the new shellcheck and module-eval checks)
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add shellcheck and module-eval checks, markdownlint configuration, and update README for v1.0.0.
> 
>   - **Checks**:
>     - Added `shellcheck` and `module-eval` checks in `lib/checks.nix` to lint shell scripts and evaluate home-manager modules.
>     - Updated `flake.nix` to pass `home-manager` and `aiModule` to `checks`.
>   - **Configurations**:
>     - Added `.markdownlint-cli2.yaml` and `.markdownlint-cli2.jsonc` for markdown linting with specific rules (e.g., line length 160, MD060 disabled).
>     - Updated `cspell.json` to include new words: `Bitwarden`, `nixfmt`, `powerline`, `shellcheck`.
>   - **Documentation**:
>     - Enhanced `README.md` with Prerequisites, Available module options, and Testing/validation sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for 20f6d496a358d66316b0a943cb647047a334ce5c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->