### PR TITLE
fix(ci): use drvPath in module-eval to avoid full activation build

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -64,6 +64,9 @@
         modules = [
           aiModule
           {
+            _module.args.userConfig = {
+              ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
+            };
             home = {
               username = "test-user";
               homeDirectory = "/home/test-user";
@@ -73,5 +76,7 @@
         ];
       };
     in
-    hmConfig.activationPackage;
+    pkgs.runCommand "check-module-eval" { } ''
+      echo ${hmConfig.activationPackage.drvPath} > $out
+    '';
 }


### PR DESCRIPTION
## Summary
- Changes module-eval check from `hmConfig.activationPackage` to `hmConfig.activationPackage.drvPath` wrapped in `pkgs.runCommand`
- Adds `_module.args.userConfig` in the test module so the `validateClaudeSettings` activation script resolves its schema URL without hitting a missing-arg error

## Why
`hmConfig.activationPackage` triggers a full build of all packages (including VSCode which requires unfree config and network access). Using `.drvPath` forces Nix to evaluate the module derivation without building anything, catching import errors and type errors while avoiding sandbox/unfree issues.

The `userConfig` fix was also required: `modules/default.nix` uses `userConfig` as a module argument with a default, but in the home-manager module system it must be provided via `_module.args` when the module is instantiated in isolation (the default only applies to regular Nix function calls, not the module evaluation machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modifies `module-eval` in `lib/checks.nix` to use `drvPath` and adds `userConfig` to resolve schema URL issues.
> 
>   - **Behavior**:
>     - Changes `module-eval` check in `lib/checks.nix` from `hmConfig.activationPackage` to `hmConfig.activationPackage.drvPath` wrapped in `pkgs.runCommand`.
>     - Adds `_module.args.userConfig` in `lib/checks.nix` to resolve schema URL in `validateClaudeSettings` activation script.
>   - **Rationale**:
>     - Using `.drvPath` avoids full package builds, preventing sandbox/unfree issues.
>     - `userConfig` fix ensures module instantiation without missing-arg errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for 9375eba8317b1baf24129a6eb430b8e6e2d28ad7. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->