### PR TITLE
fix(ci): use @v0 floating tag for ai-workflows references

### DIFF
--- a/.github/workflows/ai-all.yml
+++ b/.github/workflows/ai-all.yml
@@ -49,7 +49,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0.8.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@v0
     with:
       caller_event: ${{ github.event_name }}
       review_prompt: "Focus on Nix flake patterns, home-manager module structure, AI tool configuration best practices"

--- a/.github/workflows/ai-ci.yml
+++ b/.github/workflows/ai-ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   ci-suite:
-    uses: JacobPEvans/ai-workflows/.github/workflows/suite-ci.yml@v0.8.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/suite-ci.yml@v0
     with:
       repo_context: "Nix home-manager modules for AI CLI tools (Claude, Gemini, Copilot, MCP servers)"
       ci_structure: "ci-gate.yml (dorny/paths-filter + nix-check + markdown-lint + alls-green gate)"

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -64,7 +64,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -75,7 +75,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.7.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0
     secrets: inherit
     with:
       repo_context: "Nix AI tools configuration using home-manager modules"


### PR DESCRIPTION
All ai-workflows references were pinned to @v0.8.0 (doesn't exist) or @v0.7.0. Switch to the @v0 floating major version tag so consuming repos automatically pick up new releases without per-repo bumps.

The v0 tag is auto-updated by ai-workflows' update-version-tags.yml workflow on every release via cssnr/update-version-tags-action@v2.

Prerequisite: ai-workflows must release v0.8.0 to include suite-all and suite-ci workflows (currently only on main, not in any tag).

https://claude.ai/code/session_01QTJNsr3xa1GyZBZx1xjmNZ
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update GitHub Actions workflows to use floating `v0` tag for ai-workflows references.
> 
>   - **Workflows**:
>     - Update `ai-all.yml` to use `suite-all.yml@v0` instead of `@v0.8.0`.
>     - Update `ai-ci.yml` to use `suite-ci.yml@v0` instead of `@v0.8.0`.
>     - Update `issue-auto-resolve.yml` to use `issue-triage.yml@v0` and `issue-resolver.yml@v0` instead of `@v0.7.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for 0873a36074ae234c30f00e0319e557035766ec6c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->