### PR TITLE
chore(plugins): remove code-simplifier plugin (now bundled as /simplify)

### DIFF
--- a/modules/claude/plugins/official.nix
+++ b/modules/claude/plugins/official.nix
@@ -31,7 +31,6 @@ _:
 
     # Code Review (essential)
     "code-review@claude-plugins-official" = true;
-    "code-simplifier@claude-plugins-official" = true;
     "pr-review-toolkit@claude-plugins-official" = true;
 
     # Feature Development (useful)


### PR DESCRIPTION
## Summary
- Removes `code-simplifier@claude-plugins-official` from the official plugins list
- Claude Code now bundles `/simplify` natively, so the plugin is no longer needed

## Test plan
- [ ] Verify no `code-simplifier` references remain in official.nix
- [ ] Nix evaluation still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `code-simplifier` plugin from `official.nix` as `/simplify` is now bundled natively in Claude Code.
> 
>   - **Plugins**:
>     - Remove `code-simplifier@claude-plugins-official` from `official.nix` as `/simplify` is now bundled natively in Claude Code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for f60d0e198a0bac8a51c549bb40284255ecf6d6e3. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->