### PR TITLE
feat(claude): make effortLevel optional, add adaptive thinking env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Key enable toggles exposed by the default module:
 | `programs.claude.settings.alwaysThinkingEnabled` | bool | true | Extended thinking mode |
 | `programs.claude.remoteControlAtStartup` | bool or null | null | Remote Control auto-start |
 | `programs.claude.model` | string or null | null | Override default model (e.g. `"opus"`, `"sonnet"`) |
-| `programs.claude.effortLevel` | enum | `"high"` | Adaptive reasoning effort (`"low"`, `"medium"`, `"high"`) |
+| `programs.claude.effortLevel` | enum or null | `null` | Adaptive reasoning effort (`"low"`, `"medium"`, `"high"`); null = upstream default (medium for Max/Team as of v2.1.68) |
 | `programs.claude.trustedProjectDirs` | list of str | `[]` | Base directories for auto-trust of CLAUDE.md imports |
 
 For the full option set, see [`modules/claude/options.nix`](modules/claude/options.nix).

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -87,7 +87,10 @@ in
   # for each ~/git/<repo>/main path found at home-manager activation time (runtime) via claude-json-merge.sh.
   trustedProjectDirs = [ "~/git" ];
 
-  effortLevel = "medium";
+  # effortLevel = "medium";
+  # Claude Code v2.1.68+ defaults to medium effort for Max/Team subscribers.
+  # Use /model effort slider or "ultrathink" keyword to override per-session.
+  # Uncomment to pin a specific effort level.
 
   # Minimal commit attribution — replaces verbose Co-Authored-By trailer
   # Claude Code appends this string to every commit message automatically
@@ -161,6 +164,9 @@ in
       # No native settings.json key exists; env var removes only 1M variants
       CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
 
+      # Adaptive thinking for Opus 4.6/Sonnet 4.6 (explicitly enabled)
+      CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0";
+
       # DEFAULT VALUES (upstream) - reference only, do not uncomment unless tuning
       # MAX_THINKING_TOKENS = "31999";
       # CLAUDE_CODE_MAX_OUTPUT_TOKENS = "32000";
@@ -169,6 +175,15 @@ in
       # SLASH_COMMAND_TOOL_CHAR_BUDGET = "16000";
       # BASH_DEFAULT_TIMEOUT_MS = "120000";  # 2 minutes
       # BASH_MAX_TIMEOUT_MS = "600000";      # 10 minutes
+
+      # Claude.ai MCP servers (enabled by default for logged-in users)
+      # ENABLE_CLAUDEAI_MCP_SERVERS = "true";
+
+      # Plugin git operations timeout (default: 120000ms / 2 minutes)
+      # CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS = "120000";
+
+      # Effort level via env var (alternative to settings.json key)
+      # CLAUDE_CODE_EFFORT_LEVEL = "medium";
     };
 
     # Permissions from unified ai-assistant-instructions system

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -272,18 +272,21 @@ in
     };
 
     effortLevel = mkOption {
-      type = types.enum [
-        "low"
-        "medium"
-        "high"
-      ];
-      default = "high";
+      type = types.nullOr (
+        types.enum [
+          "low"
+          "medium"
+          "high"
+        ]
+      );
+      default = null;
       description = ''
-        Adaptive reasoning effort for Opus 4.6.
-        - "high": Full reasoning (upstream default)
-        - "medium": Balanced cost/quality for routine tasks
+        Adaptive reasoning effort for Opus 4.6 and Sonnet 4.6.
+        - null: Use upstream default (medium for Max/Team as of v2.1.68)
+        - "high": Full reasoning
+        - "medium": Balanced cost/quality
         - "low": Minimal reasoning, fastest and cheapest
-        Override per-session via /model effort slider.
+        Override per-session via /model effort slider or "ultrathink" keyword.
       '';
     };
 

--- a/modules/claude/settings.nix
+++ b/modules/claude/settings.nix
@@ -83,9 +83,9 @@ let
       autoUpdatesChannel
       teammateMode
       showTurnDuration
-      effortLevel
       ;
   }
+  // lib.optionalAttrs (cfg.effortLevel != null) { inherit (cfg) effortLevel; }
   // lib.optionalAttrs (cfg.attribution != { }) { inherit (cfg) attribution; }
   // {
 


### PR DESCRIPTION
## Summary

- **`effortLevel` is now optional** (`nullOr enum`, default `null`): Claude Code v2.1.68+ defaults Opus/Sonnet 4.6 to medium effort for Max/Team subscribers, making the pinned value redundant. The option type now reflects this — `null` means "let upstream decide."
- **Conditional emission in settings**: `effortLevel` is only written to `settings.json` when non-null, via `optionalAttrs`.
- **Commented out in config**: `effortLevel = "medium"` replaced with a comment explaining the upstream default and how to override (per-session via `/model effort slider` or `"ultrathink"` keyword).
- **Adaptive thinking explicitly enabled**: `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0"` added as an active env var.
- **New reference env vars** (commented): `ENABLE_CLAUDEAI_MCP_SERVERS`, `CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS`, `CLAUDE_CODE_EFFORT_LEVEL` for 2026 Q1 features.
- **README updated**: `effortLevel` default corrected from `"high"` to `null`.

## Test plan

- [x] `nix flake check` passes (formatting, statix, deadnix, shellcheck, module-eval)
- [x] `nix fmt` applied (1 file reformatted: `options.nix` nullOr wrapping)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR makes `effortLevel` optional, adds an environment variable for adaptive thinking, and updates documentation accordingly.
> 
>   - **Behavior**:
>     - `effortLevel` is now optional (`nullOr enum`, default `null`) in `options.nix`, reflecting upstream default behavior.
>     - `effortLevel` only written to `settings.json` when non-null in `settings.nix`.
>     - `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` set to "0" in `claude-config.nix` to enable adaptive thinking.
>   - **Configuration**:
>     - Commented out `effortLevel = "medium"` in `claude-config.nix` with explanation on upstream default.
>     - Added commented reference env vars in `claude-config.nix` for future features.
>   - **Documentation**:
>     - Updated `README.md` to correct `effortLevel` default from "high" to `null`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-ai&utm_source=github&utm_medium=referral)<sup> for dc33e813a91f92d16af0cd65c3b094db5b5dd7d1. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->