### PR TITLE
feat(claude): make settings.json writable via activation-time merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ inputs.nix-ai.inputs.home-manager.follows = "home-manager";
 - `modules/claude/` — Claude Code settings, plugins, statusline, auto-claude
 - `modules/mcp/` — MCP server definitions
 - `modules/common/` — Shared permission engine and formatters
-- `lib/claude-settings.nix` — Pure settings generator
+- `lib/claude-settings.nix` — Pure settings generator (CI-only; deployment uses modules/claude/settings.nix)
 - `lib/claude-registry.nix` — Marketplace format functions
 
 ## Testing Locally

--- a/cspell.json
+++ b/cspell.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
   "version": "0.2",
   "language": "en",
-  "words": ["agentic", "backdoors", "Exfiltration", "exfiltration", "toolsets", "tinyurl", "unshallow", "unsanitized",
+  "words": ["agentic", "backdoors", "Exfiltration", "exfiltration", "toolsets", "tinyurl", "unshallow", "unsanitized", "PYTHONPATH",
     "Bitwarden",
     "cclint",
     "deadnix",

--- a/lib/claude-settings.nix
+++ b/lib/claude-settings.nix
@@ -2,7 +2,7 @@
 #
 # Generates the settings attrset without any derivations or platform-specific code.
 # Used by:
-#   - modules/home-manager/ai-cli/claude.nix (for deployment with jq pretty-printing)
+#   - modules/claude/settings.nix (for deployment with jq pretty-printing)
 #   - flake.nix CI output (for cross-platform schema validation)
 #
 # This separation enables pure Nix evaluation for CI while keeping
@@ -59,6 +59,5 @@ in
 
   # NOTE: MCP servers are NOT configured in settings.json
   # Claude Code reads MCP servers from ~/.claude.json (user scope) or .mcp.json (project scope)
-  # Use `claude mcp add --scope user` to add servers declaratively
-  # Available servers: pal, github, terraform (add via CLI as needed)
+  # Nix manages MCP servers in ~/.claude.json via the claudeJsonMerge activation script
 }

--- a/modules/claude/TESTING.md
+++ b/modules/claude/TESTING.md
@@ -17,7 +17,7 @@ Testing procedures for the auto-claude.sh autonomous maintenance script.
 Verify the script has valid zsh syntax:
 
 ```bash
-zsh -n modules/home-manager/ai-cli/claude/auto-claude.sh && echo "Syntax OK"
+zsh -n modules/claude/auto-claude.sh && echo "Syntax OK"
 ```
 
 Expected: `Syntax OK`
@@ -27,7 +27,7 @@ Expected: `Syntax OK`
 Run without arguments to verify usage message:
 
 ```bash
-zsh modules/home-manager/ai-cli/claude/auto-claude.sh
+zsh modules/claude/auto-claude.sh
 ```
 
 Expected output:
@@ -43,7 +43,7 @@ Exit code: 1
 Test directory validation:
 
 ```bash
-zsh modules/home-manager/ai-cli/claude/auto-claude.sh /nonexistent 10
+zsh modules/claude/auto-claude.sh /nonexistent 10
 ```
 
 Expected output:
@@ -59,7 +59,7 @@ Exit code: 1
 Test budget validation with negative number:
 
 ```bash
-zsh modules/home-manager/ai-cli/claude/auto-claude.sh /tmp -5
+zsh modules/claude/auto-claude.sh /tmp -5
 ```
 
 Expected output:
@@ -75,7 +75,7 @@ Exit code: 1
 Test that decimal budgets are accepted:
 
 ```bash
-zsh modules/home-manager/ai-cli/claude/auto-claude.sh /tmp 0.5 2>&1 | head -5
+zsh modules/claude/auto-claude.sh /tmp 0.5 2>&1 | head -5
 ```
 
 Expected: Script starts executing (shows Claude initialization output)

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -144,9 +144,8 @@ in
       };
     };
 
-    # Hooks (Phase 2 - not yet implemented)
-    # These options are declared for future hook support.
-    # Implementation will generate ~/.claude/hooks/ scripts.
+    # Hooks - fully implemented in modules/claude/settings.nix
+    # Generates executable scripts in ~/.claude/hooks/ via home.file.
     hooks = {
       preToolUse = mkOption {
         type = hookType;

--- a/modules/claude/settings.nix
+++ b/modules/claude/settings.nix
@@ -1,7 +1,7 @@
 # Claude Code Settings
 #
-# Generates ~/.claude/settings.json with all configuration.
-# Merges plugin marketplaces, permissions, MCP servers, etc.
+# Manages ~/.claude/settings.json via activation-time merge (not home.file symlink).
+# Merges plugin marketplaces, permissions, hooks, etc.
 #
 # NOTE: Uses toClaudeMarketplaceFormat from lib/claude-registry.nix as
 # SINGLE SOURCE OF TRUTH for marketplace format transformation.
@@ -206,6 +206,13 @@ in
         TRUSTED_PROJECT_DIRS=${lib.escapeShellArg (builtins.toJSON cfg.trustedProjectDirs)}
         . ${./scripts/claude-json-merge.sh}
       '';
+
+      claudeSettingsMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+          "${settingsJson}" \
+          "${homeDir}/.claude/settings.json" \
+          "${lib.getExe pkgs.jq}"
+      '';
     };
 
     # Validate configuration before generating settings.json
@@ -238,14 +245,7 @@ in
       }
     ];
 
-    home.file = {
-      ".claude/settings.json" = {
-        source = settingsJson;
-        force = true;
-      };
-    }
-    // statusLineScript
-    // hookFiles;
+    home.file = { } // statusLineScript // hookFiles;
 
   };
 }


### PR DESCRIPTION
## Summary

- Replace read-only `home.file` symlink for `~/.claude/settings.json` with activation-time merge using existing `merge-json-settings.sh` (same pattern Gemini uses)
- Fixes runtime write failures for `/voice`, `/model`, interactive permission approvals, and `/plugin install`
- Clean migration: script auto-detects old symlink on first rebuild, replaces with writable file; subsequent rebuilds deep-merge (runtime state preserved, Nix keys win)
- Fix stale comments/paths across `options.nix`, `lib/claude-settings.nix`, `TESTING.md`, `CLAUDE.md`; add `PYTHONPATH` to cspell word list

## Test plan

- [ ] `nix flake check` passes (formatting, statix, deadnix, shellcheck, module-eval)
- [ ] `ls -la ~/.claude/settings.json` shows regular file (not symlink), mode 600
- [ ] `jq . ~/.claude/settings.json` returns valid JSON with all Nix-managed keys
- [ ] `/voice` command works (can write to settings.json at runtime)
- [ ] After next `darwin-rebuild switch`, Nix keys are restored and runtime-only keys preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)