### PR TITLE
feat(pal): set DEFAULT_MODEL to latest Gemini

### DIFF
--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -93,6 +93,11 @@ in
     env = {
       # Enable ALL PAL tools (default disables: analyze,refactor,testgen,secaudit,docgen,tracer)
       DISABLED_TOOLS = "";
+      # Default to latest available Gemini model.
+      # PAL has no model allowlist — DEFAULT_MODEL is the only restriction lever.
+      # gemini-3-pro-preview deprecated March 9 2026; update to gemini-3.1-pro-preview
+      # once BeehiveInnovations adds PAL support for it.
+      DEFAULT_MODEL = "gemini-3-pro-preview";
       # Conversation limits
       CONVERSATION_TIMEOUT_HOURS = "6";
       MAX_CONVERSATION_TURNS = "50";


### PR DESCRIPTION
## Summary

- PAL MCP has no model allowlist/filter env var — `DEFAULT_MODEL` is the only lever to prefer the latest Gemini model
- Sets `DEFAULT_MODEL = "gemini-3-pro-preview"` (current latest available via API)
- Adds comment noting `gemini-3-pro-preview` is deprecated March 9 2026 and should be updated to `gemini-3.1-pro-preview` once BeehiveInnovations adds PAL support for it

## Note

`gemini-3.1-pro-preview` is not yet available in PAL's model list (not in the API yet as of March 5 2026). This PR locks in the current latest. Follow-up required when `gemini-3.1-pro-preview` becomes available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)