### PR TITLE
feat(open-webui): add LaunchAgent for auto-start on login

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -93,6 +93,7 @@ in
     ./claude
     ./maestro
     ./ollama.nix
+    ./open-webui.nix
   ];
 
   config = {
@@ -110,7 +111,7 @@ in
             "${userConfig.ai.claudeSchemaUrl}"
         '';
 
-        # open-webui: installed via uv
+        # open-webui: installed via uv (nixpkgs broken on darwin — see modules/open-webui.nix)
         installOpenWebui = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           if ! ${lib.getExe pkgs.uv} tool list 2>/dev/null | grep -q "^open-webui"; then
             echo "-> Installing open-webui via uv (Python 3.12)..."

--- a/modules/open-webui.nix
+++ b/modules/open-webui.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  lib,
+  ...
+}:
+#
+# Open WebUI Configuration Module
+#
+# Manages the Open WebUI service for interacting with Ollama and other
+# OpenAI-compatible backends via a web browser.
+#
+# NOTE: open-webui is installed via `uv tool install` (not nixpkgs) because:
+#   - stable nixpkgs: open-webui → pgvector → postgresql-test-hook (badPlatforms = darwin)
+#   - unstable nixpkgs: open-webui has unfree license blocked by default allowUnfree
+#   The uv-installed binary lands at ~/.local/bin/open-webui
+#
+# Web UI: http://localhost:8080
+# Backend: http://localhost:11434 (Ollama)
+#
+{
+  # ============================================================================
+  # LaunchAgent for Auto-Start
+  # ============================================================================
+  # Start Open WebUI server on login (after Ollama is up)
+  launchd.agents.open-webui = {
+    enable = true;
+    config = {
+      Label = "app.open-webui";
+      ProgramArguments = [
+        "${config.home.homeDirectory}/.local/bin/open-webui"
+        "serve"
+      ];
+      EnvironmentVariables = {
+        OLLAMA_BASE_URL = "http://localhost:11434";
+      };
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "${config.home.homeDirectory}/Library/Logs/OpenWebUI/open-webui.log";
+      StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/OpenWebUI/open-webui.error.log";
+    };
+  };
+  # ============================================================================
+  # Notes
+  # ============================================================================
+  # - Web UI accessible at http://localhost:8080
+  # - Connects to Ollama at http://localhost:11434
+  # - Data stored at ~/.open-webui/ (not managed by Nix)
+  # - LaunchAgent starts on login (auto-restart if crashes)
+  # - Logs: ~/Library/Logs/OpenWebUI/open-webui.log
+  # - Installed via `uv tool install open-webui --python 3.12` in home.activation
+  # - Binary at ~/.local/bin/open-webui (uv tool bin directory)
+}


### PR DESCRIPTION
## Summary

- Add `modules/open-webui.nix` with a LaunchAgent that auto-starts Open WebUI on login
- LaunchAgent references the `uv`-installed binary at `~/.local/bin/open-webui`
- Connects to Ollama at `http://localhost:11434`, serves web UI on `:8080`
- Restore uv install activation hook with updated comment referencing the new module
- Import `open-webui.nix` in `default.nix`

**Why uv instead of nixpkgs:** Both stable and unstable nixpkgs are broken on darwin:
- stable: `open-webui → pgvector → postgresql-test-hook` (`badPlatforms = darwin`)
- unstable: `open-webui` has an unfree license blocked by default `allowUnfree = false`

## Test plan

- [ ] Run `darwin-rebuild switch` and verify the `app.open-webui` LaunchAgent is loaded (`launchctl list | grep open-webui`)
- [ ] Verify Open WebUI is accessible at http://localhost:8080
- [ ] Verify it connects to Ollama models at http://localhost:11434
- [ ] Check logs at `~/Library/Logs/OpenWebUI/open-webui.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)