### PR TITLE
fix: update stale nix-config references to nix-darwin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ nix fmt            # Fix formatting
 
 ## Architecture
 
-This repo exports home-manager modules consumed by nix-config (nix-darwin):
+This repo exports home-manager modules consumed by nix-darwin:
 
 - `homeManagerModules.default` — Full AI stack
 - `homeManagerModules.claude` — Claude Code only
@@ -45,7 +45,7 @@ inputs.nix-ai.inputs.home-manager.follows = "home-manager";
 
 ## Testing Locally
 
-From nix-config (nix-darwin), test changes with:
+From nix-darwin, test changes with:
 
 ```bash
 sudo darwin-rebuild switch --flake . --override-input nix-ai /Users/you/git/nix-ai/main

--- a/modules/maestro/options.nix
+++ b/modules/maestro/options.nix
@@ -34,7 +34,7 @@
 
       targetRepository = lib.mkOption {
         type = lib.types.str;
-        default = "${config.home.homeDirectory}/git/nix-config/main";
+        default = "${config.home.homeDirectory}/git/nix-darwin/main";
         description = "Target repository for issue resolution";
       };
     };


### PR DESCRIPTION
## Summary

- Updates `modules/maestro/options.nix` default `targetRepository` path from `~/git/nix-config/main` to `~/git/nix-darwin/main`
- Cleans up two stale `nix-config` references in `CLAUDE.md` documentation

## Test plan

- [x] `nix flake check` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)