### PR TITLE
feat: add scheduled AI workflow callers

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -1,0 +1,13 @@
+name: Best Practices
+on:
+  schedule:
+    - cron: "0 3 * * 2,5"
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+jobs:
+  best-practices:
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -1,0 +1,13 @@
+name: Code Simplifier
+on:
+  schedule:
+    - cron: "0 4 * * 0,3,6"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+jobs:
+  simplify:
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -1,0 +1,14 @@
+name: Issue Hygiene
+on:
+  schedule:
+    - cron: "0 7 * * 0"
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+jobs:
+  hygiene:
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -1,0 +1,14 @@
+name: Issue Sweeper
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+jobs:
+  sweep:
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -1,0 +1,14 @@
+name: Next Steps
+on:
+  schedule:
+    - cron: "0 5 * * 1,4"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+  issues: write
+jobs:
+  next-steps:
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
## Summary
- Add code-simplifier (Sun/Wed/Sat at 4am UTC), best-practices (Tue/Fri at 3am UTC), next-steps (Mon/Thu at 5am UTC)
- Add issue-sweeper and issue-hygiene (Sunday weekly)
- Staggered schedule ensures one workflow runs per day
- SHA-pinned to ai-workflows v0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)