### PR TITLE
fix: add concurrency groups to prevent duplicate PR creation

### DIFF
--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -7,6 +7,11 @@ permissions:
   contents: write
   id-token: write
   pull-requests: write
+
+concurrency:
+  group: code-simplifier
+  cancel-in-progress: true
+
 jobs:
   simplify:
     uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -8,6 +8,11 @@ permissions:
   id-token: write
   pull-requests: write
   issues: write
+
+concurrency:
+  group: next-steps
+  cancel-in-progress: true
+
 jobs:
   next-steps:
     uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0


### PR DESCRIPTION
## Summary
`code-simplifier` and `next-steps` create PRs and support `workflow_dispatch`. Without concurrency groups, overlapping scheduled and manual runs can create duplicate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)