### PR TITLE
fix: correct best-practices permissions and add concurrency

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -1,12 +1,20 @@
 name: Best Practices
+
 on:
   schedule:
     - cron: "0 3 * * 2,5"
   workflow_dispatch:
+
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: best-practices-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   best-practices:
     uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0


### PR DESCRIPTION
## Summary
- Fix permissions: add `issues: write`, change `pull-requests` from `write` to `read` (reusable workflow creates issues, not PRs)
- Add concurrency group scoped by ref to prevent cross-branch cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)