### PR TITLE
fix: disable hash pinning for trusted actions, use version tags

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -17,5 +17,5 @@ concurrency:
 
 jobs:
   best-practices:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.8.0
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -14,5 +14,5 @@ concurrency:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@v0.8.0
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,6 +8,6 @@ jobs:
     name: Copilot Setup Steps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
-      - uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6 # v12
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/flake-checker-action@v12

--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -47,13 +47,13 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -80,7 +80,7 @@ jobs:
           fi
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@73327eb48f028efaaf5013656ba216ca3cdeca7b # v3
+        uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Update flake inputs
         env:
@@ -90,7 +90,7 @@ jobs:
           nix flake update $FLAKE_INPUTS
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -10,5 +10,5 @@ permissions:
   pull-requests: read
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@v0.8.0
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -10,5 +10,5 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@v0.8.0
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@a5620445cea6a3f94143755a5a4bdea4e530c39d # v0.8.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@v0.8.0
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,18 +7,10 @@
 # To run a full audit: zizmor --persona=auditor .github/workflows/
 
 rules:
-  # IGNORED: Requires pinning all actions to SHA hashes
-  # TODO: Create a separate PR to pin all actions to commit SHAs
-  # This is a significant change requiring updates across all workflows
+  # POLICY: Well-known trusted actions use version tags, not commit hashes.
+  # Hash pinning is reserved for untrusted or lesser-known actions only.
   unpinned-uses:
-    ignore:
-      - ai-all.yml
-      - ai-ci.yml
-      - auto-merge.yml
-      - ci-gate.yml
-      - issue-auto-resolve.yml
-      - release-please.yml
-      - trigger-nix-update.yml
+    disable: true
 
   # IGNORED: workflow_run trigger is required for post-CI workflows that need
   # write permissions. These workflows only run on completed CI Gate events


### PR DESCRIPTION
## Summary

Changes policy from hash-pinned action refs to version tag refs for trusted/well-known actions.

### Changes
- **`.github/zizmor.yml`**: Disable `unpinned-uses` rule globally (replaces ever-growing per-file ignore list)
- **`.github/workflows/`**: Convert all `@<hash> # <version>` refs to `@<version>`

### Policy
Well-known trusted actions (DeterminateSystems, actions/*, peter-evans, JacobPEvans) use version tags. Hash pinning is reserved for untrusted or lesser-known actions only.

This eliminates maintenance overhead of updating hashes across many repos for every action version bump.