### PR TITLE
feat: automate gh-aw and bunx npm pin updates

### DIFF
--- a/.github/workflows/deps-update-packages.yml
+++ b/.github/workflows/deps-update-packages.yml
@@ -1,0 +1,70 @@
+# Automated custom package updates with verified commits
+#
+# Uses JacobPEvans-github-actions App for:
+# - Signed & verified commits via GitHub REST API
+# - Triggering downstream workflows (CI Gate, Review)
+#
+# Updates:
+# - gh-aw: GitHub Agentic Workflows CLI extension (Go module)
+#   Uses nix-update to automatically update version, hash, and vendorHash
+#
+# Triggers:
+# - Weekly Monday at 8am UTC (schedule)
+# - Manual (workflow_dispatch)
+name: Update Custom Packages
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"  # Weekly Monday 8am UTC
+  workflow_dispatch: {}
+
+jobs:
+  update-gh-aw:
+    name: Update gh-aw
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Update gh-aw
+        run: nix run nixpkgs#nix-update -- --flake gh-aw
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
+          branch: chore/update-gh-aw
+          delete-branch: true
+          commit-message: |
+            chore(deps): update gh-aw to latest version
+
+            Automated update via nix-update.
+          title: "chore(deps): update gh-aw"
+          body: |
+            Automated gh-aw version update via nix-update.
+
+            nix-update automatically fetches the latest release from GitHub
+            and updates the version, hash, and vendorHash in
+            `modules/gh-extensions/gh-aw.nix`.
+
+            ---
+            *Created by JacobPEvans-github-actions*
+          labels: dependencies
+          assignees: JacobPEvans
+          reviewers: JacobPEvans

--- a/flake.nix
+++ b/flake.nix
@@ -231,6 +231,17 @@
         }
       );
 
+      # Expose custom packages for nix-update automation
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          gh-aw = pkgs.callPackage ./modules/gh-extensions/gh-aw.nix { };
+        }
+      );
+
       # Formatter
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
     };

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
       "customType": "regex",
       "fileMatch": ["modules/ai-tools\\.nix"],
       "matchStrings": [
-        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d.]+)"
+        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d]+(?:\\.[\\d]+)*)"
       ],
       "datasourceTemplate": "npm"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,26 @@
   "extends": [
     "config:recommended",
     "local>JacobPEvans/.github:renovate-presets"
+  ],
+  "customManagers": [
+    {
+      "description": "bunx wrapper npm packages pinned in Nix modules",
+      "customType": "regex",
+      "fileMatch": ["modules/ai-tools\\.nix"],
+      "matchStrings": [
+        "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d.]+)"
+      ],
+      "datasourceTemplate": "npm"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Bunx wrapper npm packages - weekly updates",
+      "matchDatasources": ["npm"],
+      "matchFileNames": ["modules/ai-tools.nix"],
+      "groupName": "npm-wrappers",
+      "schedule": ["after 7am on Monday"],
+      "minimumReleaseAge": "3 days"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the automation gap for two previously manual update workflows:

- **`gh-aw` Go derivation**: no mechanism existed to automatically bump version, hash, and vendorHash
  in `modules/gh-extensions/gh-aw.nix`
- **bunx npm pins**: `cclint`, `chatgpt-cli`, and `claude-flow` versions in `modules/ai-tools.nix`
  were updated manually with no tooling support

## Changes

- **`flake.nix`**: Add `packages.<system>.gh-aw` output via `pkgs.callPackage`, giving
  `nix-update --flake gh-aw` a stable flake attribute to target
- **`.github/workflows/deps-update-packages.yml`**: Weekly Monday 8am UTC workflow — generates a
  GitHub App token, runs `nix run nixpkgs#nix-update -- --flake gh-aw`, and opens a signed PR via
  `peter-evans/create-pull-request@v8`
- **`renovate.json`**: Add `customManagers` regex matching `bunx --bun <pkg>@<version>` patterns in
  `modules/ai-tools.nix` with npm datasource; `packageRules` entry groups all npm-wrappers for
  weekly Monday updates with 3-day minimum release age; version regex tightened to
  `[\d]+(?:\.[\d]+)*` to reject malformed semver strings

## Test Plan

- [ ] `nix flake check --no-build` passes locally
- [ ] Renovate dependency dashboard shows `npm-wrappers` as a new tracked group
- [ ] Workflow YAML is valid (actionlint)
- [ ] `nix-update --flake gh-aw --dry-run` resolves the derivation correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
