### PR TITLE
fix: use absolute path for shasum in verify-cache-integrity.sh

### DIFF
--- a/modules/claude/scripts/verify-cache-integrity.sh
+++ b/modules/claude/scripts/verify-cache-integrity.sh
@@ -18,6 +18,20 @@ MARKETPLACES_DIR="$HOME_DIR/.claude/plugins/marketplaces"
 CACHE_DIR="$HOME_DIR/.claude/plugins/cache"
 HASH_FILE="$CACHE_DIR/.nix-store-hashes"
 
+# Resolve the SHA-256 hasher once at startup.
+# Prefer shasum from PATH (present on macOS and installable cross-platform),
+# fall back to the macOS system copy, then sha256sum (Linux coreutils).
+# sha256sum does not accept -a 256, so wrap the call to normalise the interface.
+if _cmd=$(command -v shasum 2>/dev/null) || { [ -x /usr/bin/shasum ] && _cmd=/usr/bin/shasum; }; then
+  sha256_string() { "$_cmd" -a 256; }
+elif _cmd=$(command -v sha256sum 2>/dev/null); then
+  sha256_string() { "$_cmd"; }
+else
+  echo "error: no shasum or sha256sum found" >&2
+  exit 1
+fi
+unset _cmd
+
 # Only run if both dirs exist
 [[ -d "$MARKETPLACES_DIR" ]] || exit 0
 [[ -d "$CACHE_DIR" ]] || exit 0
@@ -50,7 +64,7 @@ while IFS= read -r -d '' entry; do
   [[ -n "$target" ]] || continue
 
   # Hash the store path string (not file contents - that's what matters for staleness)
-  hash=$(printf '%s' "$target" | /usr/bin/shasum -a 256 | cut -d' ' -f1)
+  hash=$(printf '%s' "$target" | sha256_string | cut -d' ' -f1)
   new_hashes["$name"]="$hash"
 
   if [[ "${old_hashes[$name]:-}" != "$hash" ]]; then


### PR DESCRIPTION
## Summary
- Use `/usr/bin/shasum` instead of `shasum` in the cache integrity verification script
- During home-manager activation, `/usr/bin` is not in `$PATH`, causing `shasum: command not found`
- `shasum` is a macOS built-in located at `/usr/bin/shasum` — using the absolute path ensures it's always found
- Also fix SC2115 shellcheck warning: use `${CACHE_DIR:?}` in `rm -rf` to guard against accidental expansion to `/`

## Test plan
- [ ] `shellcheck` passes on the modified script
- [ ] `darwin-rebuild switch` runs without `shasum: command not found` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues in `modules/claude/scripts/verify-cache-integrity.sh`: it replaces the bare `shasum` call with the absolute path `/usr/bin/shasum` to handle the restricted `$PATH` during `home-manager` activation, and it adds a `${CACHE_DIR:?}` guard on the `rm -rf` to satisfy ShellCheck SC2115 and prevent catastrophic expansion if the variable is ever empty.

- **`/usr/bin/shasum` fix**: Correctly solves the `shasum: command not found` error during home-manager activation. The tradeoff is that `/usr/bin/shasum` is macOS-specific — this is intentional and acceptable for a `nix-darwin` config, but the script now silently breaks on Linux if ever reused there.
- **`${CACHE_DIR:?}` guard**: Textbook defensive shell scripting for any `rm -rf` operating on a variable path. Combined with the existing `set -euo pipefail` and the `:?` already on `HOME_DIR`, this is a solid improvement.
- Both changes are minimal, well-scoped, and fix real, reproducible bugs.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — both fixes are correct and targeted, with only a minor macOS-only portability note.
- The `rm -rf` guard and absolute `shasum` path are both valid, well-understood fixes. The only concern is that `/usr/bin/shasum` hardcodes a macOS-specific path, which is fine for this darwin-focused repo but would silently fail on Linux. No logic regressions introduced.
- No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/claude/scripts/verify-cache-integrity.sh | Two targeted fixes: replaces bare `shasum` with the absolute `/usr/bin/shasum` to survive limited `$PATH` during home-manager activation, and adds `${CACHE_DIR:?}` guard on `rm -rf` to satisfy SC2115 and prevent accidental root deletion. Logic is correct; the macOS-specific absolute path is a minor portability concern if the script is ever run on Linux. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["home-manager activation triggers\nverify-cache-integrity.sh &lt;home-dir&gt;"] --> B{marketplaces &\ncache dirs exist?}
    B -- No --> Z[exit 0]
    B -- Yes --> C[Load old hashes\nfrom .nix-store-hashes]
    C --> D[find marketplace dirs]
    D --> E[For each marketplace dir\nfind first /nix/store symlink]
    E --> F["Hash store path string\nvia /usr/bin/shasum -a 256\n✅ absolute path — works\neven with restricted PATH"]
    F --> G{hash changed\nsince last run?}
    G -- No change --> H[keep cache]
    G -- Changed --> I{"cache dir\nexists?"}
    I -- No --> H
    I -- Yes --> J["rm -rf ${CACHE_DIR:?}/$name\n✅ :? guard prevents\naccidental rm -rf /"]
    J --> K[log purge]
    K --> L[Write new hashes\natomically via mktemp + mv]
    H --> L
```

<sub>Last reviewed commit: 0905399</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->