### PR TITLE
fix: rename GH_APP_ID secret to GH_ACTION_JACOBPEVANS_APP_ID

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -35,7 +35,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Updates `.github/workflows/deps-update-flake.yml` to use `secrets.GH_ACTION_JACOBPEVANS_APP_ID` (distributed via secrets-sync)

## Test plan

- [ ] Verify CI passes
- [ ] Confirm secrets-sync has run and distributed `GH_ACTION_JACOBPEVANS_APP_ID` to this repo before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)