### PR TITLE
fix: update gh-aw to v0.57.2 and remove silent failure in workflow

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -78,7 +78,6 @@ jobs:
 
       - name: Update custom packages
         if: github.event_name != 'repository_dispatch'
-        continue-on-error: true
         run: nix run nixpkgs#nix-update -- --flake gh-aw
 
       - name: Create Pull Request

--- a/modules/gh-extensions/gh-aw.nix
+++ b/modules/gh-extensions/gh-aw.nix
@@ -6,16 +6,16 @@
 
 pkgs.buildGoModule rec {
   pname = "gh-aw";
-  version = "0.1.0"; # Update from https://github.com/github/gh-aw/releases
+  version = "0.57.2"; # Update from https://github.com/github/gh-aw/releases
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "gh-aw";
     rev = "v${version}"; # Use commit SHA if no tags exist
-    hash = "sha256-dOr0H8affUFwYb6WSUlQARtAKD/iM1haBZE2dAy3FQ8=";
+    hash = "sha256-wG/qxZ64LN3yUytRx7fxmCHD65bB5MCaifMPs/tpWOY=";
   };
 
-  vendorHash = "sha256-UGKScdleZXgT4F1ezu74KpyNE1kWwr2kHqeHqD4OliE=";
+  vendorHash = "sha256-XY/xXSPULshrYOFptNSaN7YTQSzq7nJVkvUk4wWu4Rs=";
 
   # Build from cmd/gh-aw directory
   subPackages = [ "cmd/gh-aw" ];


### PR DESCRIPTION
## Summary

- Bump `gh-aw` from v0.1.0 to v0.57.2 (57 versions behind)
- Update `src` hash and `vendorHash` for new version
- Remove `continue-on-error: true` from `deps-update-flake.yml` so `nix-update` failures block the workflow instead of silently continuing

## Test plan

- [x] `nix build .#gh-aw` succeeds
- [x] `./result/bin/gh-aw --help` works
- [x] `nix flake check` passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs two clean, unrelated-but-complementary maintenance fixes: bumping `gh-aw` from `v0.1.0` to `v0.57.2` (a massive 57-version leap 🚀) with correctly updated SRI hashes, and removing `continue-on-error: true` from the automated `nix-update` workflow step so failures are no longer swallowed silently.

- **`modules/gh-extensions/gh-aw.nix`**: Version, `src` hash, and `vendorHash` are all updated in lockstep. The derivation structure (`subPackages`, `meta`, etc.) is untouched.
- **`.github/workflows/deps-update-flake.yml`**: Dropping `continue-on-error: true` is a strictly better failure mode — the PR author has clearly leveled up on the "fail fast, fail loudly" philosophy. 🧠
- The stale inline comment `# Use commit SHA if no tags exist` next to `rev = "v${version}";` (line 14 of `gh-aw.nix`) was pre-existing and not introduced here, so it's noted but not a blocker.
- No other files in the repo appeared to depend on `gh-aw` in a way that would be impacted by the version bump.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — both changes are low-risk, well-scoped maintenance updates with no logic regressions.
- The Nix derivation change is a hash-verified version bump (build and binary confirmed working per the test plan). The workflow change removes a silent-failure escape hatch, which strictly improves observability. No new logic, no structural changes, no shared dependencies affected.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/gh-extensions/gh-aw.nix | Version bumped from 0.1.0 to 0.57.2 with updated src hash and vendorHash; no structural changes to the derivation. |
| .github/workflows/deps-update-flake.yml | Removed `continue-on-error: true` from the "Update custom packages" step so nix-update failures now block the workflow instead of silently succeeding. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Trigger: schedule / workflow_dispatch / repository_dispatch]) --> B[Generate GitHub App Token]
    B --> C[Checkout repository]
    C --> D{Event type?}
    D -- repository_dispatch --> E[Validate & extract flake_input_name]
    D -- schedule / workflow_dispatch --> F[inputs = empty - update all]
    E --> G[nix flake update FLAKE_INPUTS]
    F --> G
    G --> H{Event = repository_dispatch?}
    H -- No --> I["nix run nixpkgs#nix-update -- --flake gh-aw\n⛔ Now blocks on failure"]
    H -- Yes --> J[Skip nix-update step]
    I --> K[Create Pull Request]
    J --> K
    K --> L([PR opened / updated on update_flake_lock_action branch])
```

<sub>Last reviewed commit: 298947a</sub>

<!-- /greptile_comment -->