### PR TITLE
feat: add daily repo health audit agentic workflow

### DIFF
--- a/.github/workflows/repo-health-audit.md
+++ b/.github/workflows/repo-health-audit.md
@@ -1,9 +1,9 @@
 ---
 description: "Daily repository health audit"
+engine: copilot
 
 on:
-  schedule:
-    - cron: '0 5 * * *'
+  schedule: daily
   workflow_dispatch:
 
 imports:


### PR DESCRIPTION
## Summary

- Add daily repo health audit agentic workflow (Copilot engine)
- Imports shared config and prompt from JacobPEvans/.github@main
- Runs daily at 05:00 UTC + supports manual trigger
- Creates GitHub Issues for CI failures, security alerts, stale PRs, policy violations

## Test plan

- [ ] Merge JacobPEvans/.github#83 first (so @main import resolves)
- [ ] Merge this PR
- [ ] Trigger via workflow_dispatch to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new daily Copilot agentic workflow (`repo-health-audit.md`) that is intended to audit CI status, security alerts, stale PRs, and policy compliance, then open GitHub Issues for any findings — running at 05:00 UTC with a manual dispatch escape hatch. The workflow deliberately delegates its body and configuration to a shared `.github` repo (pending PR #83), keeping the file lean. However, it's missing three frontmatter fields that every peer workflow in this repo declares and that the Copilot agentic platform appears to require:

- **`engine: copilot`** — absent from the frontmatter; all sibling workflows (`ci-doctor.md`, `daily-malicious-code-scan.md`, `ai-moderator.md`) declare this, and without it the Copilot platform likely won't process the file as an agentic workflow at all.
- **`safe-outputs`** — the workflow holds `issues: write` permission but omits the `safe-outputs.create-issue` block that the Copilot engine uses as a capability gate for write operations; issue creation will likely be silently blocked at runtime.
- **`tools`** — no `tools` block means the agent has no explicit access to GitHub API toolsets (security alerts, CI runs, PR listings), which are central to the workflow's stated purpose. This may be supplied by the imported config, but that dependency hasn't landed yet.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge in current form — the workflow is almost certainly non-functional due to missing required frontmatter fields.
- The single changed file is missing `engine: copilot`, `safe-outputs`, and a `tools` block that are present in every other agentic workflow in this repo. The workflow's primary stated goal (creating GitHub Issues) is gated behind `safe-outputs` which is absent. Additionally, the workflow has a hard dependency on a not-yet-merged PR in a separate repository (`JacobPEvans/.github#83`), meaning the import will fail until that lands. Low confidence reflects that the workflow would likely be silently ignored or fail at runtime as written.
- `.github/workflows/repo-health-audit.md` — all issues are concentrated in this single file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/repo-health-audit.md | New Copilot agentic workflow for daily repo health auditing — missing `engine: copilot`, `safe-outputs` for issue creation, and a `tools` block, all of which are present in every peer workflow in this repo and are likely required for the workflow to function correctly. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Scheduler as GitHub Scheduler (05:00 UTC)
    participant WD as workflow_dispatch
    participant Runner as Copilot Agent Runner
    participant SharedConfig as JacobPEvans/.github shared config
    participant SharedPrompt as JacobPEvans/.github shared prompt
    participant GH as GitHub API (CI / Security / PRs)
    participant Issues as GitHub Issues

    Scheduler->>Runner: Trigger on cron '0 5 * * *'
    WD->>Runner: Manual trigger

    Runner->>SharedConfig: imports repo-health-audit-config.md@main
    Runner->>SharedPrompt: {{#import}} repo-health-audit-prompt.md@main

    Runner->>GH: Read CI run results (actions: read)
    Runner->>GH: Read security alerts (security-events: read)
    Runner->>GH: Read open PRs (pull-requests: read)
    Runner->>GH: Read repo contents (contents: read)

    alt Issues found
        Runner->>Issues: create-issue (issues: write) ⚠️ blocked without safe-outputs
    else Clean
        Runner->>Runner: noop / log clean
    end
```

<sub>Last reviewed commit: e0dd167</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->