### PR TITLE
fix: set cleanupPeriodDays to 30 (upstream default)

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -135,7 +135,9 @@ in
     # Extended thinking enabled with token budget controlled via env vars
     alwaysThinkingEnabled = true;
 
-    # Session cleanup - 30 days is the upstream default
+    # Session cleanup: explicitly set to 30 days (upstream Claude default).
+    # Keeping this explicit to document the intentional choice and prevent
+    # accidental drift if the module option default ever changes.
     cleanupPeriodDays = 30;
 
     # Environment variables for model config and token optimization

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -311,10 +311,10 @@ in
       # Session management
       cleanupPeriodDays = mkOption {
         type = types.int;
-        default = 14;
+        default = 30;
         description = ''
           Sessions inactive longer than this period are deleted.
-          Default upstream is 30, we use 14 to reduce storage.
+          Upstream Claude default is 30 days.
         '';
       };
 


### PR DESCRIPTION
## Summary

- Explicitly sets `cleanupPeriodDays` to `30` with a comment noting it is the upstream default
- Replaces the previous non-default value of `14`

## Test plan

- [ ] Verify `nix flake check` passes
- [ ] Confirm `cleanupPeriodDays: 30` appears in the generated `settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a minor configuration inconsistency in `modules/claude-config.nix`: the previous code set `cleanupPeriodDays = 14` while its own comment noted the upstream default is `30`. This change brings the value in line with upstream, removes any surprise divergence, and updates the comment to be self-explanatory.

- `cleanupPeriodDays` changed from `14` → `30` to match the Claude Code upstream default
- Comment reworded from `"(upstream default is 30)"` to `"30 days is the upstream default"` for clarity
- No other logic or behaviour is affected — a clean, surgical correctness fix 🔬

<h3>Confidence Score: 5/5</h3>

- Safe to merge — single numeric value corrected to match documented upstream default with no behavioural side-effects.
- The change is one integer and one comment update in a declarative Nix config file. The old value (14) was already functional; bumping to 30 simply stops sessions from being cleaned up slightly sooner than upstream intends. Zero risk of breakage.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/claude-config.nix | Single-line config fix: bumps `cleanupPeriodDays` from 14 → 30 (the upstream default) and tightens the inline comment to remove the now-redundant parenthetical. No logic, no side-effects — purely a value alignment. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["home-manager activation"] --> B["claude-config.nix evaluated"]
    B --> C["settings.cleanupPeriodDays = 30"]
    C --> D["Serialised into settings.json"]
    D --> E{"Claude Code reads settings.json\non startup"}
    E --> F["Session files older than 30 days\nare eligible for cleanup"]
    F --> G["Cleanup job runs\n(Claude Code internals)"]
    G --> H["Stale session data pruned 🗑️"]
```

<sub>Last reviewed commit: 9eabbdf</sub>

<!-- /greptile_comment -->