### PR TITLE
feat: add splunk-mcp-connect wrapper script

### DIFF
--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -247,12 +247,18 @@
     # Wraps the Splunk MCP Server App connection via mcp-remote stdio proxy.
     # Reads SPLUNK_MCP_ENDPOINT and SPLUNK_MCP_TOKEN from env (injected by
     # doppler-mcp from Doppler ai-ci-automation/prd project).
+    # MCP server entry: nix-darwin hosts/macbook-m4/home.nix (infrastructure, not AI-specific)
     # Usage: splunk-mcp-connect (no args — called by Claude Code MCP server config)
     (writeShellScriptBin "splunk-mcp-connect" ''
       set -euo pipefail
       : "''${SPLUNK_MCP_ENDPOINT:?SPLUNK_MCP_ENDPOINT not set in Doppler}"
       : "''${SPLUNK_MCP_TOKEN:?SPLUNK_MCP_TOKEN not set in Doppler}"
-      exec ${pkgs.nodejs}/bin/npx -y mcp-remote \
+      # SECURITY NOTE: Bearer token is visible in process list via --header arg.
+      # This is a known mcp-remote limitation — no stdin/env-based header injection
+      # exists yet. Mitigated by: (1) macOS single-user system, (2) token is
+      # Splunk-scoped with limited capabilities, (3) rotatable via Doppler.
+      export NODE_TLS_REJECT_UNAUTHORIZED=0  # Self-signed cert on Splunk; scoped to mcp-remote only
+      exec ${bun}/bin/bunx --bun mcp-remote@0.1.38 \
         "$SPLUNK_MCP_ENDPOINT" \
         --header "Authorization: Bearer $SPLUNK_MCP_TOKEN"
     '')


### PR DESCRIPTION
## Summary

- Add `splunk-mcp-connect` wrapper script to `ai-tools.nix`
- Reads `SPLUNK_MCP_ENDPOINT` and `SPLUNK_MCP_TOKEN` from env (injected by `doppler-mcp`)
- Execs `npx mcp-remote` as stdio-to-HTTP proxy to the Splunk MCP Server App

## Dependencies

- **Doppler secrets**: `SPLUNK_MCP_ENDPOINT` and `SPLUNK_MCP_TOKEN` must be set in `ai-ci-automation/prd`

## Test plan

- [ ] `darwin-rebuild switch` succeeds
- [ ] `splunk-mcp-connect` binary available on PATH
- [ ] With Doppler secrets set, `splunk-mcp-connect` successfully proxies to Splunk MCP App

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `splunk-mcp-connect` `writeShellScriptBin` wrapper to `modules/ai-tools.nix` that acts as a stdio-to-HTTP proxy for the Splunk MCP Server App via `mcp-remote`, relying on `doppler-mcp` to inject `SPLUNK_MCP_ENDPOINT` and `SPLUNK_MCP_TOKEN` at runtime. The concept fits cleanly into the existing pattern of secrets-injected MCP wrappers (à la `pal`/`doppler-mcp`), but the implementation has a few rough edges before it's production-ready:

- **`npx` instead of `bunx` (no version pin)**: The file's own package hierarchy documentation (lines 24–29) and `mcp/default.nix` both mandate `bunx` over `npx` for npm packages, and require a pinned version (`package@x.y.z`). Every other npm wrapper in this file follows that pattern. Using an unpinned `npx -y mcp-remote` is a reproducibility risk and a direct convention violation.
- **Bearer token in process args**: Passing `$SPLUNK_MCP_TOKEN` via `--header` makes the token readable in `ps aux` while `mcp-remote` runs. This is a known `mcp-remote` limitation worth documenting for future maintainers.
- **Missing `mcp/default.nix` entry**: The wrapper exists as a binary, but no `splunk` entry is wired up in `modules/mcp/default.nix` to register it as a Claude Code MCP server (compare the `pal` entry). The tool currently can't fulfill its stated purpose without that config.

<h3>Confidence Score: 3/5</h3>

- Safe to merge functionally, but needs the `npx`→`bunx` + version pin fix before it can be considered idiomatic and reproducible for this codebase.
- The core logic (env var validation, exec pattern, `doppler-mcp` integration design) is sound and consistent with existing patterns. The two blockers are the convention violation (`npx` + no version pin) and the incomplete integration (no `mcp/default.nix` entry). The token exposure is a known `mcp-remote` limitation, not introduced incorrectly. Score reflects: good concept, two actionable fixes needed before the implementation is complete.
- `modules/ai-tools.nix` (lines 255–257: `npx` usage + missing version pin) and `modules/mcp/default.nix` (no `splunk` entry added to complete the integration)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/ai-tools.nix | Adds `splunk-mcp-connect` wrapper script; uses `npx` (against codebase convention of `bunx`) with no version pin, exposes bearer token in process args, and lacks a matching `mcp/default.nix` entry to complete the integration. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CC as Claude Code
    participant DM as doppler-mcp
    participant SM as splunk-mcp-connect
    participant MR as npx mcp-remote
    participant SE as Splunk MCP Server App

    CC->>DM: exec doppler-mcp splunk-mcp-connect
    DM->>DM: preflight Doppler auth check
    DM->>SM: exec with SPLUNK_MCP_ENDPOINT & SPLUNK_MCP_TOKEN injected
    SM->>SM: validate env vars (:? guard)
    SM->>MR: exec npx -y mcp-remote $SPLUNK_MCP_ENDPOINT --header "Bearer $TOKEN"
    Note over MR,SE: stdio ↔ HTTP proxy
    MR-->>SE: HTTP/SSE requests with Authorization header
    SE-->>MR: MCP JSON-RPC responses
    MR-->>CC: stdio MCP messages
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: modules/ai-tools.nix
Line: 255-257

Comment:
**`npx` violates codebase conventions + no version pin**

The file's own package hierarchy (lines 24–29) explicitly mandates `bunx` for all npm packages: *"Standard solution for npm/bun packages — Always pin to specific version: `package@x.y.z`"*. Every other npm wrapper in this file (`cclint`, `gh-copilot`, `chatgpt`, `claude-flow`) uses `${bun}/bin/bunx --bun` with a pinned version. The `mcp/default.nix` header also reinforces this: *"Uses bunx for npm packages (faster than npx, auto-installs)"*.

Using `${pkgs.nodejs}/bin/npx -y mcp-remote` (unpinned) breaks both rules:
1. `npx` is slower than `bunx` and less consistent across runs
2. Without a version pin, `mcp-remote` will silently upgrade and could break the MCP connection contract

```suggestion
      exec ${bun}/bin/bunx --bun mcp-remote@0.1.17 \
        "$SPLUNK_MCP_ENDPOINT" \
        --header "Authorization: Bearer $SPLUNK_MCP_TOKEN"
```
*(Pin to your desired version — check npmjs.com/package/mcp-remote for the latest stable release.)*

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: modules/ai-tools.nix
Line: 257

Comment:
**Bearer token visible in process list**

Passing `$SPLUNK_MCP_TOKEN` as part of a CLI argument (`--header "Authorization: Bearer $SPLUNK_MCP_TOKEN"`) makes the full token visible in process listings (`ps aux`, `/proc/<pid>/cmdline`). Any process running under the same user can read it while `npx`/`mcp-remote` is alive.

This is a known limitation of `mcp-remote`'s `--header` flag — there's no stdin-based or env-only injection path for headers in `mcp-remote` today. It's worth adding a comment here so future maintainers are aware of the tradeoff and can evaluate alternatives (e.g., passing the token via a temp header file if `mcp-remote` ever adds such support, or rotating the Splunk token frequently via Doppler).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: modules/ai-tools.nix
Line: 251-258

Comment:
**No corresponding `mcp/default.nix` entry**

The comment on line 250 says *"called by Claude Code MCP server config"*, and the PR description notes that `SPLUNK_MCP_ENDPOINT`/`SPLUNK_MCP_TOKEN` are injected by `doppler-mcp`. But there's no matching `splunk` entry in `modules/mcp/default.nix` to wire it up (compare how `pal` is configured there using `doppler-mcp` as the command).

Without that entry, the binary is available on `PATH` but won't be registered as an MCP server in `~/.claude.json`. If this is intentionally deferred to a follow-up PR, a `# TODO: add mcp/default.nix splunk entry` comment here would make that intent clear.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: f05a270</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->