### PR TITLE
feat: enable 1M context window models in model picker

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -162,10 +162,6 @@ in
       # See: https://code.claude.com/docs/en/agent-teams
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
 
-      # Enable 1M token context window models in model picker
-      # Set to "1" to hide 1M variants from picker; "0" or unset keeps them visible
-      CLAUDE_CODE_DISABLE_1M_CONTEXT = "0";
-
       # Adaptive thinking for Opus 4.6/Sonnet 4.6 (explicitly enabled)
       CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0";
 


### PR DESCRIPTION
## Summary

- Sets `CLAUDE_CODE_DISABLE_1M_CONTEXT` from `"1"` to `"0"` in `modules/claude-config.nix`
- Updates the comment to reflect the new intent (enabled, not disabled)

## Test plan

- [ ] Run `darwin-rebuild switch` after merge and confirm 1M model variants appear in `/model` picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR flips `CLAUDE_CODE_DISABLE_1M_CONTEXT` from `"1"` to `"0"` in `modules/claude-config.nix` to expose 1M token context-window model variants (e.g. `sonnet[1m]`) in Claude Code's `/model` picker. It's a one-liner config change with a matching comment update.

**Key changes & observations:**
- The single changed line inverts the `CLAUDE_CODE_DISABLE_*` flag from enabled (`"1"`) to effectively disabled (`"0"`), following the same convention already used by `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0"` in this file.
- The correctness of `"0"` as a disable-the-disable value depends entirely on Claude Code's internal implementation — if it performs a strict `=== "1"` check the intent is achieved; if it does a JavaScript truthy check on the string, `"0"` is still truthy and 1M variants remain hidden.
- The second comment line ("env var **removes** only 1M variants") is now slightly misleading after the intent was inverted; it still describes the disabling behavior rather than the current enabling intent.
- The test plan is manual and post-merge, which is the only practical option for this type of env-var-gated UI change — but verifying the check semantics in Claude Code's source (or a pre-merge local test) would add confidence before deployment.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with low blast radius, but the intended effect is unverified — if Claude Code uses a truthy check the 1M models will still be hidden.
- The change is minimal (one env var value flip) and limited to Claude Code's model picker UI — no data, security, or system integrity is at risk. Score is kept at 3 rather than higher because the behavior of setting a DISABLE-prefixed env var to "0" (vs. simply unsetting it) is not externally documented for this specific variable, and the test plan is post-merge manual verification only.
- modules/claude-config.nix — specifically lines 165-167 where the env var value and comment need verification against Claude Code's actual parsing logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/claude-config.nix | Flips CLAUDE_CODE_DISABLE_1M_CONTEXT from "1" to "0" to enable 1M token context models; semantics of "0" vs. unset for DISABLE-prefix env vars in Claude Code need verification. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["darwin-rebuild switch\n(deploys env var)"] --> B["Claude Code session starts"]
    B --> C{"CLAUDE_CODE_DISABLE_1M_CONTEXT\ncheck in Claude Code"}
    C -->|"strict === '1' check\n(value is '0' → falsy)"| D["✅ 1M model variants\nappear in /model picker"]
    C -->|"truthy check\n('0' is non-empty string → truthy)"| E["❌ 1M model variants\nstill hidden from /model picker"]
    D --> F["User selects sonnet[1m]\nor opus[1m]"]
    E --> G["User sees same picker\nas before the PR"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: modules/claude-config.nix
Line: 165-167

Comment:
**`"0"` vs. unset: truthy-check risk**

`CLAUDE_CODE_DISABLE_1M_CONTEXT` is an undocumented, unofficial env var. In Node.js, `process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT` returns a **string**, so if Claude Code's internals do a truthy check (`if (process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT)`), then `"0"` is a non-empty string and will still evaluate as truthy — meaning the DISABLE flag remains active and 1M variants will **not** appear.

The existing sibling var `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0"` follows the same pattern, which suggests Claude Code may be doing a strict `=== "1"` check here. But if it doesn't, the 1M models will stay hidden even after this change.

The safest alternative — if the intent is truly to rely on Claude Code's default (enabled) behavior — is to simply remove the line entirely, rather than explicitly setting the DISABLE flag to `"0"`:

```suggestion
      # Enable 1M token context window models in model picker (default behavior)
      # CLAUDE_CODE_DISABLE_1M_CONTEXT = "1"; # Uncomment to hide 1M variants
```

This removes ambiguity entirely. If you need to keep it explicit for documentation, verifying the strict-equality check in Claude Code's source before merging is strongly recommended.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: modules/claude-config.nix
Line: 166

Comment:
**Stale comment phrasing**

After the intent flip, the second comment line now reads "env var **removes** only 1M variants" — which still describes the old, disabling behavior. A reader seeing `"0"` paired with "removes" has to do a double-take to figure out what's happening.

```suggestion
      # Enable 1M token context window models in model picker
      # No native settings.json key exists; set to "1" to remove 1M variants from picker
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 03f92b2</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->