### PR TITLE
chore: remove model override to use account-tier default (1M context)

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -66,10 +66,9 @@ in
   # Agent teams display mode (direct settings.json property)
   teammateMode = "auto";
 
-  # Model: commented out to use account-tier default (Opus 4.6 with 1M context)
-  # opusplan uses Opus for planning, Sonnet for execution, but lacks [1m] variant
+  # Model: use account-tier default. The 'opusplan' model is no longer
+  # specified as it lacks a 1M context variant.
   # See: https://code.claude.com/docs/en/model-config
-  # model = "opusplan";
 
   # Release channel: "stable" delays ~1 week to avoid regressions
   autoUpdatesChannel = "stable";


### PR DESCRIPTION
## Summary

- Comments out `model = "opusplan"` in `claude-config.nix` to let the account-tier default (Opus 4.6 with 1M context) take effect
- Updates related env var comments to reflect no model override is set
- With `CLAUDE_CODE_DISABLE_1M_CONTEXT` removed in #155, `opusplan` was forcing the 200K variant which lacks a `[1m]` model

## Test plan

- [ ] `nix build` passes
- [ ] After `darwin-rebuild switch`, verify `~/.claude/settings.json` has no `"model"` key
- [ ] `/model` in Claude Code shows "Default (Opus 4.6 with 1M context)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is the second half of a two-part fix to unlock the 1M-context Opus 4.6 model. PR #155 removed the `CLAUDE_CODE_DISABLE_1M_CONTEXT` env var (correctly noting that `"0"` is still truthy in Node.js), and this PR removes the `opusplan` model override that was silently routing Claude Code to the 200K-context variant because `opusplan` has no `[1m]` counterpart in the model picker.

**Key changes:**
- `model = "opusplan"` is commented out in `modules/claude-config.nix`, reverting `programs.claude.model` to its `null` default
- `settings.nix` correctly handles `null` via `lib.optionalAttrs (cfg.model != null)`, so no `"model"` key will appear in `~/.claude/settings.json` after `darwin-rebuild switch`
- The comment in the `env` block is updated to accurately reflect that no model override is active

The implementation is clean and correct — the `options.nix` / `settings.nix` module machinery already anticipated this "no override" path, and the change fits naturally into the existing configuration pattern.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — single-line config change with no logic risk.
- The change is minimal and correct: commenting out the `model` assignment causes the option to fall back to its `null` default, and the downstream `lib.optionalAttrs` guard in `settings.nix` already handles `null` cleanly by omitting the key entirely. No other files are touched, no new logic is introduced, and the module's own type system (`types.nullOr types.str`) validates the resulting state at evaluation time.
- No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/claude-config.nix | Comments out `model = "opusplan"` so the `model` option reverts to the module's `null` default; `settings.nix` correctly omits the key via `lib.optionalAttrs (cfg.model != null)`, producing a `settings.json` with no model override and enabling the account-tier 1M-context default. Comment in the `env` block updated accordingly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["claude-config.nix\n# model = opusplan  ← commented out\n(no value set)"] --> B["programs.claude.model\ndefault = null\n(from options.nix)"]
    B --> C{cfg.model != null?}
    C -- "No (null)" --> D["lib.optionalAttrs → omits 'model' key\nfrom settings object"]
    C -- "Yes (old: 'opusplan')" --> E["model: 'opusplan' written\nto settings.json\n→ forces 200K context variant"]
    D --> F["~/.claude/settings.json\nno 'model' key present"]
    F --> G["Claude Code reads settings.json\n→ falls back to account-tier default"]
    G --> H["✅ Opus 4.6 with 1M context window"]
    E --> I["❌ opusplan (200K context)\nlacks [1m] model variant"]
```

<sub>Last reviewed commit: d9a606d</sub>

<!-- /greptile_comment -->