### PR TITLE
fix(ci): migrate copilot-setup-steps to determinate-nix-action@v3

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,5 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v21
-      - uses: DeterminateSystems/flake-checker-action@v12
+      - uses: DeterminateSystems/determinate-nix-action@v3


### PR DESCRIPTION
## Summary

- Replaces `DeterminateSystems/nix-installer-action@v21` and `DeterminateSystems/flake-checker-action@v12` with `DeterminateSystems/determinate-nix-action@v3` in `copilot-setup-steps.yml`
- Both old actions run on Node.js 20, deprecated on GitHub Actions June 2, 2026
- `determinate-nix-action@v3` is the consolidated replacement bundling both Nix installation and flake checking

## Test plan

- [ ] Copilot setup steps complete successfully
- [ ] No Node.js 20 deprecation warnings in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)