### PR TITLE
fix(ci): add pull-requests: write for release-please auto-approval

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ jobs:
   release-please:
     permissions:
       contents: read
+      pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}


### PR DESCRIPTION
# Release-Please Permissions Update

## Summary

Adds `pull-requests: write` to the caller job permissions so the reusable
`_release-please` workflow in `JacobPEvans/.github` can auto-approve release PRs
using `GITHUB_TOKEN`, unblocking auto-merge.

**Depends on**: JacobPEvans/.github#99

## Changes

- `.github/workflows/release-please.yml`: add `pull-requests: write` to job permissions

## Test Plan

- [ ] JacobPEvans/.github#99 merged first
- [ ] Push a `feat:` commit to trigger release-please
- [ ] Verify the release PR is auto-approved by `github-actions[bot]`
- [ ] Verify auto-merge completes after CI passes
