### PR TITLE
refactor(ci): use reusable copilot-setup-steps workflow from .github

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,12 +1,10 @@
 name: Copilot Setup Steps
 
-on:
-  workflow_call:
+on: push
+
+permissions:
+  contents: read
 
 jobs:
   copilot-setup-steps:
-    name: Copilot Setup Steps
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/determinate-nix-action@v3
+    uses: JacobPEvans/.github/.github/workflows/_copilot-setup-steps.yml@main


### PR DESCRIPTION
# refactor(ci): use reusable copilot-setup-steps workflow from .github

## Summary

- Replace inline `copilot-setup-steps.yml` with a call to the centralized reusable workflow `_copilot-setup-steps.yml` from JacobPEvans/.github
- Consolidates action version management (actions/checkout@v6, determinate-nix-action@v3) to a single source of truth
- Reduces duplication across nix repos and simplifies future maintenance

## Changes

- **`.github/workflows/copilot-setup-steps.yml`** — Replaced inline checkout + nix setup actions with a single `uses:` call to the reusable workflow from JacobPEvans/.github

## Test plan

- [ ] Verify the reusable workflow runs successfully on push
- [ ] Confirm Copilot coding agents can discover and execute the setup steps
- [ ] Check that both `actions/checkout@v6` and `determinate-nix-action@v3` are correctly invoked by the centralized workflow

Related: JacobPEvans/.github#97 (reusable workflow, already merged)
