### PR TITLE
fix(devenv): use python package attr instead of version string

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -279,7 +279,7 @@
                   devenv.root = if pwdIsFlakeRoot then pwd else toString ./.;
                   languages.python = {
                     enable = true;
-                    version = "3.14";
+                    package = pkgs.python314;
                     venv.enable = true;
                     venv.requirements = ''
                       langchain
@@ -308,7 +308,7 @@
                   devenv.root = if pwdIsMlxRoot then pwd else toString ./mlx-server;
                   languages.python = {
                     enable = true;
-                    version = "3.14";
+                    package = pkgs.python314;
                     uv = {
                       enable = true;
                       sync.enable = true;


### PR DESCRIPTION
## Summary

- Replace `languages.python.version = "3.14"` with `languages.python.package = pkgs.python314` in both `ai-dev` and `mlx-server` devShells
- The `version` option requires the `nixpkgs-python` flake input, which was removed in `4954bd1` as dead weight. The `package` option resolves directly from nixpkgs — no extra input needed
- Aligns with how `auto-claude.nix` and `auto-claude-reporting.nix` already reference `pkgs.python314`

## Changes

- `flake.nix`: 2 lines changed — `languages.python.version` → `languages.python.package` in `ai-dev` and `mlx-server` devShells

## Test Plan

- [x] `nix eval .#devShells.aarch64-darwin.ai-dev --apply 'x: "ok"' --impure` — passes
- [x] `nix eval .#devShells.aarch64-darwin.mlx-server --apply 'x: "ok"' --impure` — passes
- [x] `nix develop .#ai-dev --impure --command python3 --version` — Python 3.14.3
- [x] `nix develop .#mlx-server --impure --command python3 --version` — Python 3.14.3 (prints "MLX environment ready")
- [x] `nix fmt -- --fail-on-change .` — 0 changed
- [x] `nix flake check --no-build` — all checks pass (pre-existing `module-eval` failure unrelated to this change)
- [x] CI passes — all checks green
- [ ] `direnv allow` in `mlx-server/` works end-to-end
