### PR TITLE
fix(tests): use MagicMock instance for SimpleDocumentStore in pipeline tests

### DIFF
--- a/orchestrator/tests/test_pipeline.py
+++ b/orchestrator/tests/test_pipeline.py
@@ -32,7 +32,7 @@ def _make_mock_modules() -> dict[str, MagicMock]:
 
     # SimpleDocumentStore
     mock_docstore_mod = MagicMock()
-    mock_docstore_mod.SimpleDocumentStore = MagicMock
+    mock_docstore_mod.SimpleDocumentStore = MagicMock()
 
     # OpenAIEmbedding
     mock_embed_mod = MagicMock()


### PR DESCRIPTION
Assigning the MagicMock class (not an instance) prevented auto-creation
of class-method attributes like from_persist_dir, causing AttributeError
in save/load tests since the llama-index migration (#210).

(claude)
