### PR TITLE
fix(devshell): use python package attr in orchestrator shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -311,7 +311,7 @@
                   devenv.root = if pwdIsOrchestratorRoot then pwd else toString ./orchestrator;
                   languages.python = {
                     enable = true;
-                    version = "3.14";
+                    package = pkgs.python314;
                     uv = {
                       enable = true;
                       sync.enable = true;


### PR DESCRIPTION
## Summary

  - Fix broken orchestrator dev shell by replacing `languages.python.version = "3.14"` with `package = pkgs.python314`
  - The `version` attribute requires a `nixpkgs-python` flake input that doesn't exist in this flake, preventing shell entry
  - Now consistent with the working `ai-dev` and `mlx-server` shell patterns

  ## Validation

  - `nix flake check` passes (all checks green)
  - Orchestrator shell enters successfully (Python 3.14.3)
  - `pytest -v`: 173 passed, 1 skipped, 90.48% coverage (threshold: 80%)

  ## Test plan

  - [x] `nix flake check` passes
  - [x] `nix develop .#orchestrator --impure` enters without error
  - [x] `uv sync --extra dev && uv run pytest -v` — all tests pass
  - [x] Coverage ≥ 80%