### PR TITLE
fix(plugins): update stale plugin count comment in development.nix

### DIFF
--- a/modules/claude/plugins/development.nix
+++ b/modules/claude/plugins/development.nix
@@ -15,15 +15,11 @@ let
   # automatically enabled after `nix flake update jacobpevans-cc-plugins`.
   #
   # Known plugins (for reference, not used for enablement):
-  #   After consolidation (v2.0.0): 8 plugins
-  #   - git-guards (hooks: git permissions + main branch protection)
-  #   - content-guards (hooks: token/markdown/webfetch validation + issue limits)
-  #   - git-workflows (7 skills: worktree, sync, refresh, rebase, troubleshooting)
-  #   - github-workflows (4 skills: PR management, issue shaping)
-  #   - infra-orchestration (3 skills: terraform/ansible orchestration)
-  #   - ai-delegation (2 skills: multi-model delegation + autonomous maintenance)
-  #   - config-management (2 skills: permission sync)
-  #   - codeql-resolver (1 command + 3 agents + 2 skills: CodeQL security)
+  #   After consolidation: 15 plugins
+  #   - git-guards, content-guards, git-workflows, github-workflows
+  #   - infra-orchestration, ai-delegation, config-management, codeql-resolver
+  #   - process-cleanup, pr-lifecycle, git-standards, code-standards
+  #   - infra-standards, project-standards, session-analytics
   jacobpevansPlugins =
     let
       entries = builtins.readDir jacobpevans-cc-plugins;


### PR DESCRIPTION
# PR #222: Update stale plugin comments

## Summary

- Fix stale comment in `development.nix` that referenced nonexistent v2.0.0 and listed 8 plugins (actual count: 15)
- Flake lock update for `jacobpevans-cc-plugins` deferred until companion PRs merge

## Changes

- Updated plugin count comment in `modules/claude/plugins/development.nix` from 8 to 15
- Removed reference to v2.0.0 (no longer applicable)

## Related PRs

Flake lock update is blocked by:

- [JacobPEvans/.github#106](https://github.com/JacobPEvans/.github/pull/106) — Remove debug step and ignored inputs from release-please workflow
- [JacobPEvans/claude-code-plugins#145](https://github.com/JacobPEvans/claude-code-plugins/pull/145) — Move release-please settings into config

After these merge, the flake lock update will be pushed to this branch.

## Test Plan

- [x] `nix flake check` passes
- [ ] After companion PRs merge, push flake lock update to this branch
