### PR TITLE
chore(deps): update jacobpevans-cc-plugins to v1.8.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1773831466,
-        "narHash": "sha256-ZJN/TJ89O+Zl+1iDo8/xc7ZhoiUA7BiflU5sFPKQf6c=",
+        "lastModified": 1773856913,
+        "narHash": "sha256-5zsgRLj+6QxYJ3jQYs8W8rIbXTG7FHNbrCJivoBRdsw=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "2acd01f5b66a9c6917cb60c2f774f792a0636edc",
+        "rev": "cd12dfbf8cad597a5e4f9e1f807508ac1776531e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

This update advances the `jacobpevans-cc-plugins` flake input from `2acd01f` to `cd12dfb` (v1.8.2), picking up three key improvements from the upstream cc-plugins repository:

- **Release-please config migration** (#148, #150) — Improves CI/CD pipeline stability
- **Plugin releases** — v1.8.0, v1.8.1, v1.8.2 with bug fixes and enhancements
- **DevShell reference updates** (#146) — Ensures compatibility with dev environments

## Changes

| Input | Previous | Current | Version |
|-------|----------|---------|---------|
| `jacobpevans-cc-plugins` | `2acd01f` | `cd12dfb` | v1.8.2 |

**Flake lock update:** 3 insertions, 3 deletions (timestamp and narHash updated)

## Test Plan

- [x] `nix flake check` passes all checks
- [x] Verified locked revision matches cc-plugins HEAD (`cd12dfb`)
- [x] No breaking changes to module interface
- [x] Plugin cache migration verified with existing installations

## Related Issues & PRs

Upstream resolution in cc-plugins:
- [#146](https://github.com/JacobPEvans/claude-code-plugins/pull/146) — devShell reference updates
- [#148](https://github.com/JacobPEvans/claude-code-plugins/pull/148) — Release-please config (part 1)
- [#150](https://github.com/JacobPEvans/claude-code-plugins/pull/150) — Release-please config (part 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
