### PR TITLE
fix: move sync-ollama-models to pal-models.nix for MLX model append

### DIFF
--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -170,20 +170,8 @@
       exec ${pkgs.doppler}/bin/doppler run -p ai-ci-automation -c prd -- "$@"
     '')
 
-    # ==========================================================================
-    # Sync PAL Ollama Models
-    # ==========================================================================
-    # Refreshes ~/.config/pal-mcp/custom_models.json from `ollama list`.
-    # Run after `ollama pull <model>` to make new models available in PAL
-    # without a full darwin-rebuild switch.
-    (writeShellScriptBin "sync-ollama-models" ''
-      set -euo pipefail
-      mkdir -p "$HOME/.config/pal-mcp"
-      ${pkgs.curl}/bin/curl -sf http://localhost:11434/api/tags \
-        | ${pkgs.jq}/bin/jq --from-file ${./mcp/scripts/pal-models.jq} \
-        > "$HOME/.config/pal-mcp/custom_models.json"
-      echo "PAL custom models updated. Restart Claude Code to pick up changes."
-    '')
+    # sync-ollama-models moved to modules/claude/pal-models.nix
+    # (needs MLX config access to append static MLX model entry)
 
     # ==========================================================================
     # Check PAL MCP Health

--- a/modules/claude/pal-models.nix
+++ b/modules/claude/pal-models.nix
@@ -52,6 +52,24 @@ in
     # resolves via PATH. The package is built from the pinned flake input.
     home.packages = [
       (pkgs.callPackage ../mcp/pal-package.nix { inherit pal-mcp-server; })
+
+      # Refresh custom_models.json between darwin-rebuild switches.
+      # Run after `ollama pull <model>` to register new models in PAL.
+      (pkgs.writeShellScriptBin "sync-ollama-models" ''
+        set -euo pipefail
+        mkdir -p "${outputDir}"
+
+        # Try Ollama first; fall back to empty model list
+        ollama_json=$(${pkgs.curl}/bin/curl -sf http://localhost:11434/api/tags \
+          | ${pkgs.jq}/bin/jq --from-file ${../mcp/scripts/pal-models.jq} 2>/dev/null \
+          || echo '{"models": []}')
+
+        # Append static MLX model entry
+        echo "$ollama_json" \
+          | ${pkgs.jq}/bin/jq --argjson mlx '${mlxModelJson}' '.models += [$mlx]' \
+          > "${outputFile}"
+        echo "PAL custom models updated. Restart Claude Code to pick up changes."
+      '')
     ];
 
     # Inject CUSTOM_MODELS_CONFIG_PATH into PAL server env.


### PR DESCRIPTION
## Summary

- Move `sync-ollama-models` from `ai-tools.nix` to `pal-models.nix`
- The script now appends the static MLX model entry (same logic as the activation script)
- Previously, running `sync-ollama-models` after a rebuild would overwrite the MLX entry

## Test plan

- [ ] `sync-ollama-models` produces JSON with MLX model entry at the end
- [ ] `darwin-rebuild switch` still works (no duplicate package conflict)

(claude)