### PR TITLE
fix: add release-please config for manifest mode

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "version-file": "VERSION",
+      "include-v-in-tag": true,
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous", "hidden": true},
+        {"type": "refactor", "section": "Refactoring", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "ci", "section": "CI", "hidden": true}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add committed `release-please-config.json` for manifest mode
- `release-please-action@v4` reads config from the git tree at runtime, not the local filesystem — the runtime fallback that constructs config from action inputs does not reliably apply all settings (e.g., `changelog-sections`, `version-file`)
- A committed config file is the canonical way to ensure consistent behavior

## Test plan

- [ ] Verify `release-please-config.json` is valid JSON matching the schema
- [ ] Confirm release-please CI workflow picks up the config on next `fix:` or `feat:` merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)