### PR TITLE
feat: enable MLX inference server (vllm-mlx)

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -131,6 +131,9 @@ in
       claudeStatusline.enable = false; # Disabled (kept for easy re-enable)
       claudeStatuslineDaniel3303.enable = true; # Active: ClaudeCodeStatusLine (2-line)
 
+      # MLX inference server (vllm-mlx on port 11435)
+      mlx.enable = true;
+
       # GitHub CLI extension for AI workflows
       gh.extensions = [ ghExtensions.gh-aw ];
     };


### PR DESCRIPTION
## Summary

- Enable `programs.mlx` module which was defined but never turned on
- Starts vllm-mlx LaunchAgent serving `gpt-oss-120b-4bit` on port 11435
- Registers MLX model entry in PAL MCP `custom_models.json`
- Installs `mlx`, `mlx-switch`, `mlx-chat`, `mlx-status`, `mlx-default` CLI tools

## Test plan

- [ ] `darwin-rebuild switch` completes
- [ ] `launchctl list | grep vllm` shows the LaunchAgent
- [ ] `curl -sf http://localhost:11435/v1/models` returns model info
- [ ] `sync-ollama-models` includes MLX entry in output

(claude)