### PR TITLE
fix: change MLX port to 11436 (11435 already in use)

### DIFF
--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -94,8 +94,8 @@ in
       # 'pro' = latest Gemini Pro (requires GEMINI_API_KEY).
       # 'auto' = PAL picks best available model based on configured API keys.
       DEFAULT_MODEL = "pro";
-      # Custom API endpoint — MLX inference server (vllm-mlx on port 11435)
-      CUSTOM_API_URL = "http://127.0.0.1:11435/v1";
+      # Custom API endpoint — MLX inference server (vllm-mlx on port 11436)
+      CUSTOM_API_URL = "http://127.0.0.1:11436/v1";
       # Conversation limits
       CONVERSATION_TIMEOUT_HOURS = "6";
       MAX_CONVERSATION_TURNS = "50";

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -46,8 +46,8 @@ in
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = 11435;
-      description = "Port for the vllm-mlx API server (avoids Ollama 11434, Open WebUI 8080)";
+      default = 11436;
+      description = "Port for the vllm-mlx API server (avoids Ollama 11434, screenpipe 11435, Open WebUI 8080)";
     };
 
     host = lib.mkOption {


### PR DESCRIPTION
## Summary

- Change MLX default port from 11435 → 11436 (screenpipe AI pipe occupies 11435)
- Update CUSTOM_API_URL in PAL MCP env to match

## Test plan

- [ ] `darwin-rebuild switch` completes
- [ ] MLX serves on port 11436
- [ ] No port conflict with screenpipe

(claude)