### PR TITLE
fix: auto-sync Claude Code plugin cache after nix rebuild

### DIFF
--- a/modules/claude/plugins.nix
+++ b/modules/claude/plugins.nix
@@ -42,21 +42,23 @@ in
     # Only targets jacobpevans-cc-plugins — other marketplaces manage their own
     # update cadence. Fails open: if claude CLI is missing or updates fail, log
     # a warning and continue.
-    home.activation.updateClaudePlugins = lib.hm.dag.entryAfter [ "linkGeneration" "verifyCacheIntegrity" ] ''
-      if [ -n "$DRY_RUN_CMD" ]; then
-        echo "claude-plugins: dry-run — skipping plugin cache sync" >&2
-      elif command -v claude >/dev/null 2>&1; then
-        echo "claude-plugins: syncing jacobpevans-cc-plugins cache..." >&2
-        claude plugins marketplace update jacobpevans-cc-plugins \
-          || echo "claude-plugins: marketplace update failed (non-fatal)" >&2
-        claude plugins list | grep '@jacobpevans-cc-plugins' | sed 's/.*❯ //' \
-          | while IFS= read -r plugin; do
-              claude plugins update "$plugin" \
-                || echo "claude-plugins: failed to update $plugin (non-fatal)" >&2
-            done
-      else
-        echo "claude-plugins: claude CLI not found — skipping plugin cache sync" >&2
-      fi
-    '';
+    home.activation.updateClaudePlugins =
+      lib.hm.dag.entryAfter [ "linkGeneration" "verifyCacheIntegrity" ]
+        ''
+          if [ -n "$DRY_RUN_CMD" ]; then
+            echo "claude-plugins: dry-run — skipping plugin cache sync" >&2
+          elif command -v claude >/dev/null 2>&1; then
+            echo "claude-plugins: syncing jacobpevans-cc-plugins cache..." >&2
+            claude plugins marketplace update jacobpevans-cc-plugins \
+              || echo "claude-plugins: marketplace update failed (non-fatal)" >&2
+            claude plugins list | grep '@jacobpevans-cc-plugins' | sed 's/.*❯ //' \
+              | while IFS= read -r plugin; do
+                  claude plugins update "$plugin" \
+                    || echo "claude-plugins: failed to update $plugin (non-fatal)" >&2
+                done
+          else
+            echo "claude-plugins: claude CLI not found — skipping plugin cache sync" >&2
+          fi
+        '';
   };
 }


### PR DESCRIPTION
## Summary

- Adds `home.activation.updateClaudePlugins` to `modules/claude/plugins.nix` that runs after `linkGeneration` to refresh Claude Code's runtime plugin cache
- Without this, `claude plugins list` shows stale versions (v1.0.0-1.2.0) even after the flake input updates and symlinks point to the new nix store path
- Targets only `jacobpevans-cc-plugins` marketplace; fails open if `claude` CLI is unavailable

## Test plan

- [ ] Run `darwin-rebuild switch` and check activation output for "syncing jacobpevans-cc-plugins cache..."
- [ ] Verify `claude plugins list | grep jacobpevans-cc-plugins` shows current versions after rebuild
- [ ] Verify dry-run mode skips the sync: `darwin-rebuild switch --dry-run` should log "dry-run — skipping"
- [ ] Verify graceful failure when `claude` CLI is not in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)