### PR TITLE
fix: add MLX perf tuning flags and remove Ollama from stack

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -113,7 +113,7 @@ in
     # Revisit: if vllm-mlx adds paged KV cache with true continuous batching,
     # or if switching to a smaller model where bandwidth is not the bottleneck.
     # decodeConcurrency = lib.mkOption {
-    #   type = lib.types.int;
+    #   type = lib.types.ints.positive;
     #   default = 32;
     #   description = "Max concurrent decode requests. No benefit for 122B MoE on M4 Max (bandwidth-bound).";
     # };
@@ -123,7 +123,7 @@ in
     # does not help when one request already saturates memory bandwidth.
     # Revisit: same conditions as decodeConcurrency.
     # promptConcurrency = lib.mkOption {
-    #   type = lib.types.int;
+    #   type = lib.types.ints.positive;
     #   default = 8;
     #   description = "Max concurrent prefill requests. No benefit for 122B MoE (bandwidth-bound).";
     # };
@@ -157,7 +157,7 @@ in
     # acceptance overhead but can improve throughput if draft quality is high.
     # Revisit: tune after enabling draftModel — start at 3, try 5 if acceptance > 80%.
     # numDraftTokens = lib.mkOption {
-    #   type = lib.types.int;
+    #   type = lib.types.ints.positive;
     #   default = 3;
     #   description = "Tokens drafted per speculative step. Only used with draftModel.";
     # };
@@ -178,7 +178,7 @@ in
     # Setting this would only affect raw curl calls without max_tokens.
     # Revisit: no need unless adding a consumer that omits max_tokens.
     # maxTokens = lib.mkOption {
-    #   type = lib.types.int;
+    #   type = lib.types.ints.positive;
     #   default = 512;
     #   description = "Default max tokens when client omits max_tokens. All current consumers set it explicitly.";
     # };


### PR DESCRIPTION
## Summary

- Add MLX performance tuning options and LaunchAgent flags for vllm-mlx server stability and throughput
- Remove Ollama module from active stack (module file kept for rollback reference)
- Use `lib.types.ints.positive` for performance option types (consistent with codebase pattern)

## MLX Performance Tuning

Three new active options in `modules/mlx/default.nix`, passed to the LaunchAgent `ProgramArguments`:

- **`maxKvSize`** (default 8192) — Caps rotating KV cache per session to prevent kernel panic (`IOGPUMemory completeMemory() prepare count underflow`) on long agentic sessions with 122B models
- **`prefillStepSize`** (default 8192) — Increases prompt prefill chunk size from default 2048, yielding ~1.5x TTFT improvement on long prompts
- **`promptCacheSize`** (default 5) — Enables LRU prefix KV caching for up to 5.8x TTFT speedup when multiple consumers share system prompts

Eight inactive options documented as comments with benchmark rationale and revisit conditions (decode/prompt concurrency, speculative decoding, pipelining, cache bytes, max tokens).

All benchmarked 2026-03-19 on M4 Max 128GB with Qwen3.5-122B-A10B-4bit.

## Ollama Removal

- Removed `./ollama.nix` import from `modules/default.nix` (file itself retained for rollback)
- Removed `ollamaCfg` binding, `OLLAMA_JQ_FILE` and `OLLAMA_URL` exports from `modules/claude/pal-models.nix`
- Simplified `modules/mcp/scripts/sync-pal-models.sh` to output MLX models directly instead of merging MLX+Ollama
- Updated `README.md` to remove Ollama from features list and repo structure

## Test Plan

- [ ] `nix flake check` passes (formatting, statix, deadnix, shellcheck, module-eval)
- [ ] `darwin-rebuild switch` succeeds — LaunchAgent plist includes new flags
- [ ] `launchctl print gui/$(id -u)/dev.vllm-mlx.server` shows `--max-kv-size`, `--prefill-step-size`, `--prompt-cache-size`
- [ ] `sync-mlx-models` works without Ollama references
- [ ] No runtime errors from removed Ollama config references
