### PR TITLE
fix: disable greptile plugin (cost)

### DIFF
--- a/modules/claude/plugins/external.nix
+++ b/modules/claude/plugins/external.nix
@@ -39,9 +39,8 @@ _:
     # Requires: GitLab API token
     "gitlab@claude-plugins-official" = false;
 
-    # Greptile - AI-powered codebase search
-    # Requires: GREPTILE_API_KEY env var
-    "greptile@claude-plugins-official" = true;
+    # Greptile - removed (2026-03-20): great product, not worth the cost for our use case
+    "greptile@claude-plugins-official" = false;
 
     # =========================================================================
     # Documentation & Context


### PR DESCRIPTION
## Summary

- Disable Greptile plugin (`true` → `false`) due to cost — great product, not worth the price for our use case
- Preserves marketplace entry pattern for easy re-enablement if pricing changes

## Changes

- `modules/claude/plugins/external.nix`: Set `greptile@claude-plugins-official` to `false`, updated comment with removal date and reason

## Test Plan

- [x] `nix flake check` passes
- [x] Grep confirms only removal comment references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
