### PR TITLE
fix: defer cache purge when Claude Code sessions are active

### DIFF
--- a/modules/claude/scripts/verify-cache-integrity.sh
+++ b/modules/claude/scripts/verify-cache-integrity.sh
@@ -46,9 +46,10 @@ if [[ -f "$HASH_FILE" ]]; then
   done < "$HASH_FILE"
 fi
 
-# Build new hashes, purge stale caches
+# Build new hashes and detect staleness
 # Marketplaces are directory symlinks to /nix/store/ (plugins.nix without recursive)
 declare -A new_hashes
+stale_detected=false
 while IFS= read -r -d '' entry; do
   name=$(basename "$entry")
 
@@ -61,13 +62,29 @@ while IFS= read -r -d '' entry; do
   new_hashes["$name"]="$hash"
 
   if [[ "${old_hashes[$name]:-}" != "$hash" ]]; then
+    stale_detected=true
+  fi
+done < <(find "$MARKETPLACES_DIR" -mindepth 1 -maxdepth 1 -type l -print0)
+
+# Session-aware guard: if caches are stale but Claude Code is running, defer the
+# purge to avoid breaking active sessions. Hook scripts inside cache directories are
+# resolved at session start — deleting them mid-session causes an unbreakable error
+# loop (every hook fails, including Stop). By also skipping the hash file update,
+# the next rebuild will re-detect staleness and purge when no sessions are active.
+if [[ "$stale_detected" == true ]] && pgrep -qx "claude"; then
+  log_info "Stale caches detected but Claude Code session is active — deferring purge"
+  exit 0
+fi
+
+# Purge stale caches (safe — no active sessions)
+for name in "${!new_hashes[@]}"; do
+  if [[ "${old_hashes[$name]:-}" != "${new_hashes[$name]}" ]]; then
     if [[ -d "$CACHE_DIR/$name" ]]; then
       rm -rf "${CACHE_DIR:?}/$name"
       log_info "Purged stale cache: $name"
-      log_info "  Store path changed to: $target"
     fi
   fi
-done < <(find "$MARKETPLACES_DIR" -mindepth 1 -maxdepth 1 -type l -print0)
+done
 
 # Write updated hashes atomically to avoid leaving a partially written file
 mkdir -p "$CACHE_DIR"


### PR DESCRIPTION
## Summary
- Adds session-aware guard to `verify-cache-integrity.sh` — checks `pgrep -qx claude` before purging stale plugin caches
- When active sessions detected: defers purge and skips hash file update so next rebuild re-detects staleness
- Prevents the unbreakable hook error loop where deleting cache dirs mid-session breaks all registered hooks (including Stop)

Closes the known issue documented in memory: "Plugin cache purge breaks active sessions"

## Test plan
- [ ] Rebuild with active Claude Code session → verify log shows "deferring purge"
- [ ] Rebuild with no Claude Code sessions → verify stale caches are purged normally
- [ ] After deferred purge, rebuild again with no sessions → verify purge runs on second rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)