### PR TITLE
feat: add Google Workspace MCP server and gws CLI

### DIFF
--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -50,6 +50,7 @@
 #   gh-copilot: @githubnext/github-copilot-cli@latest (unversioned - upstream)
 #   chatgpt: chatgpt-cli@3.3.0
 #   claude-flow: claude-flow@2.0.0
+#   gws: @googleworkspace/cli@latest (pre-v1.0, rapid development - same as gh-copilot)
 #
 # UVX WRAPPER PACKAGES (Python packages not in nixpkgs/homebrew):
 #   hf: huggingface-hub==1.6.0 CLI (model downloads, used with HuggingFace MCP)

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -154,7 +154,16 @@ in
   # Selective tool loading: --tools limits which Google services are exposed
   google-workspace = {
     command = "doppler-mcp";
-    args = [ "uvx" "workspace-mcp" "--tools" "gmail" "drive" "calendar" ];
+    args = [
+      "uvx"
+      "--from"
+      "google-workspace-mcp==0.1.2"
+      "workspace-mcp"
+      "--tools"
+      "gmail"
+      "drive"
+      "calendar"
+    ];
   };
   google-maps = official "google-maps" // {
     disabled = true;


### PR DESCRIPTION
## Summary
- Replace disabled `gdrive` MCP stub with active `google-workspace` MCP server
  ([taylorwilsdon/google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp))
  via `doppler-mcp` + `uvx`, with selective tool loading (gmail, drive, calendar)
- Add `gws` CLI wrapper ([googleworkspace/cli](https://github.com/googleworkspace/cli))
  for structured Gmail triage, watch, and Drive operations
- Pin `workspace-mcp` to `google-workspace-mcp==0.1.2` (matches huggingface-mcp-server pattern)

## Context
Enables AI-powered email triage through Claude Code — Claude can directly read inbox,
classify messages, label/archive, and draft responses via the MCP server. The `gws` CLI
provides structured output (`+triage`, `+watch` NDJSON stream) for AI consumption.

### Design decisions
- `doppler-mcp` wrapping required — Google OAuth secrets must not be in any file Claude can read
- `@latest` for gws CLI is intentional — pre-v1.0, rapid development (same pattern as gh-copilot)
- MCP server version is pinned (`==0.1.2`) for reproducibility (same pattern as huggingface-mcp-server)
- google-workspace MCP is NOT disabled (unlike most entries in "Additional" section) — actively used

## Changes
- `modules/mcp/default.nix` — Replace `gdrive` stub with `google-workspace` MCP entry
- `modules/ai-tools.nix` — Add `gws` bunx wrapper and update CURRENT STATUS header

## Test plan
- [ ] `nix flake check` passes
- [ ] `darwin-rebuild switch` succeeds
- [ ] `which gws` resolves
- [ ] Google Workspace MCP server appears in Claude Code session
- [ ] `gws gmail +triage` returns structured inbox summary (after OAuth setup)
