### PR TITLE
fix(mlx): cap KV cache at 16GB to prevent OOM

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -62,7 +62,7 @@ in
         {
           name = "mlx.cacheMemoryMb";
           actual = mlxCfg.cacheMemoryMb;
-          expected = null;
+          expected = 16384;
         }
         {
           name = "mlx.prefillBatchSize";

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -40,20 +40,22 @@
     #
     # vllm-mlx 0.2.6 replaced the old token-count KV cache (--max-kv-size) with a
     # memory-aware cache that auto-sizes based on available RAM and evicts via LRU.
-    # The default allocates ~20% of RAM (~25.6GB on 128GB), which combined with
-    # ~70GB model weights leaves comfortable headroom for macOS + apps.
+    # The server default allocates ~20% of RAM (~25.6GB on 128GB), which combined
+    # with ~65GB model weights consumes ~90GB — leaving only ~38GB for macOS + apps.
+    # With 10+ Claude Code sessions this caused V8 OOM crashes and swap exhaustion.
 
     # cacheMemoryMb — Override the memory-aware cache size (--cache-memory-mb).
-    # Default: null = auto-detect (~20% RAM = ~25.6GB on 128GB systems).
+    # Default: 16384 (16GB). Balances prefix cache reuse with OOM prevention.
+    # With a 65GB model, 16GB cache uses ~81GB total, leaving ~47GB on 128GB systems
+    # for macOS + 3 Claude Code sessions. If MLX ever causes another OOM, lower to 8192.
+    # Set to null to restore server auto-detect (~20% RAM = ~25.6GB — too aggressive).
     # Prevents kernel panic: IOGPUMemory completeMemory() prepare count underflow
-    # on long agentic sessions (58k+ tokens). The memory-aware LRU eviction handles
-    # this automatically, but an explicit cap can be set if needed.
+    # on long agentic sessions (58k+ tokens).
     # Ref: https://github.com/ml-explore/mlx-lm/issues/883
-    # Revisit: increase on M4 Ultra 256GB, or decrease if running a larger model.
     cacheMemoryMb = lib.mkOption {
       type = lib.types.nullOr lib.types.ints.positive;
-      default = null;
-      description = "Cache memory limit in MB. Null = auto-detect (~20% RAM). Overrides memory-aware cache sizing.";
+      default = 16384;
+      description = "Cache memory limit in MB. Null = auto-detect (~20% RAM). Default 16GB prevents OOM with large models. Lower to 8192 if OOM recurs.";
     };
 
     # prefillBatchSize — Batch size for prompt prefill processing (--prefill-batch-size).


### PR DESCRIPTION
# PR #271: Cap MLX KV Cache at 16GB

## Summary

The vllm-mlx server's default KV cache behavior causes OOM crashes under concurrent Claude Code
usage. The default was to allocate ~20% of available RAM (~25.6GB on 128GB M4 Max systems), which
combined with ~65GB Llama model weights and ~10GB macOS overhead consumed ~90GB total, leaving
only ~38GB headroom. With 10+ concurrent Claude Code sessions, this triggered Node.js V8 OOM
crashes and 99.1% swap exhaustion.

This PR caps the KV cache at 16GB, reducing total memory consumption to ~81GB (cache + model +
overhead), which leaves ~47GB of breathing room on 128GB systems.

## Changes

- **modules/mlx/options.nix**: Updated `cacheMemoryMb` default from `null` (auto ~25.6GB) to
  `16384` (16GB)
  - Updated comment to explain the OOM issue and memory calculation
  - Clarified that 16GB cache with 65GB model = ~81GB total, leaving ~47GB on 128GB systems
  - Added note that operators should lower to 8192 if OOM recurs in edge cases

- **lib/checks/mlx.nix**: Updated regression test expected value from `null` to `16384` to match
  the new default

## Test plan

- [x] Config builds cleanly with new 16GB cache default
- [x] Regression test validates the new 16GB default value
- [ ] Monitor Claude Code sessions under load to confirm OOM crashes are resolved
- [ ] If swap usage still exceeds 50%, consider further tuning `mlx.prefillBatchSize` or
  lowering `cacheMemoryMb` to 8192

## Related

Closes: (if applicable - ref. #196 for context on multi-model orchestration)
