### PR TITLE
feat: add visual-explainer marketplace plugin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -331,6 +331,7 @@
         "obsidian-skills": "obsidian-skills",
         "pal-mcp-server": "pal-mcp-server",
         "superpowers-marketplace": "superpowers-marketplace",
+        "visual-explainer-marketplace": "visual-explainer-marketplace",
         "wakatime": "wakatime"
       }
     },
@@ -347,6 +348,22 @@
       "original": {
         "owner": "obra",
         "repo": "superpowers-marketplace",
+        "type": "github"
+      }
+    },
+    "visual-explainer-marketplace": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773079619,
+        "narHash": "sha256-fDMUkcxYuM1jJkdlWgNUz74ndj3qRikSgAiZLYdbeFY=",
+        "owner": "nicobailon",
+        "repo": "visual-explainer",
+        "rev": "61f06e818e8fd49a86351d5981dcc6eeeae2f890",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nicobailon",
+        "repo": "visual-explainer",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,10 @@
       url = "github:obra/superpowers-marketplace";
       flake = false;
     };
+    visual-explainer-marketplace = {
+      url = "github:nicobailon/visual-explainer";
+      flake = false;
+    };
     wakatime = {
       url = "github:wakatime/claude-code-wakatime";
       flake = false;
@@ -117,6 +121,7 @@
       obsidian-skills,
       axton-obsidian-visual-skills,
       superpowers-marketplace,
+      visual-explainer-marketplace,
       wakatime,
       pal-mcp-server,
       ...
@@ -144,6 +149,7 @@
           obsidian-skills
           axton-obsidian-visual-skills
           superpowers-marketplace
+          visual-explainer-marketplace
           wakatime
           ;
       };

--- a/modules/claude/plugins/community.nix
+++ b/modules/claude/plugins/community.nix
@@ -3,6 +3,7 @@
 # Plugins from community-maintained marketplaces:
 # - cc-marketplace: Official source for claudecodecommands.directory plugins
 # - superpowers-marketplace: Enhanced Claude capabilities (obra/Jesse Vincent)
+# - visual-explainer-marketplace: Rich HTML diagrams, diff reviews, slides (nicobailon)
 # - bitwarden-marketplace: Enterprise-grade session analysis and config validation
 
 _:
@@ -28,6 +29,10 @@ _:
     # Obsidian Visual Skills - Diagrams (axtonliu/axton-obsidian-visual-skills)
     # Marketplace declares single plugin "obsidian-visual-skills" bundling 3 skills
     "obsidian-visual-skills@axton-obsidian-visual-skills" = true;
+
+    # Visual Explainer - HTML diagrams, diff reviews, plan audits, slides, data tables
+    # Marketplace declares single plugin "visual-explainer" with 1 skill + 8 commands
+    "visual-explainer@visual-explainer-marketplace" = true;
 
     # Bitwarden Marketplace - Enterprise-grade session analysis and config validation
     # claude-retrospective: 3 skills (retrospecting, extracting-session-data, analyzing-git-sessions)

--- a/modules/claude/plugins/marketplaces.nix
+++ b/modules/claude/plugins/marketplaces.nix
@@ -192,6 +192,15 @@ let
       };
     };
 
+    # --- Visualization ---
+    # Rich HTML pages for diagrams, diff reviews, slides, data tables (nicobailon)
+    "visual-explainer-marketplace" = {
+      source = {
+        type = "github";
+        url = "nicobailon/visual-explainer";
+      };
+    };
+
     # --- Enterprise / Well-Known ---
     # Bitwarden AI plugins: session retrospective, config validation, code review
     "bitwarden-marketplace" = {


### PR DESCRIPTION
## Summary
- Adds [visual-explainer](https://github.com/nicobailon/visual-explainer) marketplace plugin
- Registers marketplace in `marketplaces.nix`, enables the plugin in `community.nix`
- Provides 1 skill + 8 commands for generating rich HTML pages: diagrams, diff reviews, plan audits, slides, data tables, and project recaps

## Test plan
- [x] `nix flake check` passes (all checks green)
- [ ] `darwin-rebuild switch` with the new plugin
- [ ] Verify `visual-explainer` commands appear in Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)