### PR TITLE
fix: add .file-size.yml for centralized file size checking

### DIFF
--- a/.file-size.yml
+++ b/.file-size.yml
@@ -1,0 +1,13 @@
+# File size check configuration
+# Consumed by JacobPEvans/.github/_file-size.yml reusable workflow
+# Schema: defaults (warn/error bytes), scan (extensions), extended (higher limit), exempt (no limit)
+defaults:
+  warn: 6144
+  error: 12288
+
+scan:
+  - .md
+  - .nix
+
+exempt:
+  - CHANGELOG


### PR DESCRIPTION
## Summary
- Adds `.file-size.yml` per-repo configuration for the shared `JacobPEvans/.github/_file-size.yml` reusable workflow
- Scans `.md` and `.nix` files with 6 KB warn / 12 KB error thresholds
- Exempts `CHANGELOG` which grows naturally with each release-please version bump

## Test plan
- [ ] CI File Size job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)