### PR TITLE
fix: quote flake URL in orchestrator .envrc

### DIFF
--- a/orchestrator/.envrc
+++ b/orchestrator/.envrc
@@ -1,1 +1,1 @@
-use flake github:JacobPEvans/nix-devenv?dir=shells/orchestrator --impure
+use flake "github:JacobPEvans/nix-devenv?dir=shells/orchestrator" --impure


### PR DESCRIPTION
## Summary
- Quotes the flake URL in `orchestrator/.envrc` to prevent shell parsing issues with the `?dir=` query parameter
- Companion fix to #273 — same quoting pattern applied to the other affected `.envrc`

## Changes
- `orchestrator/.envrc`: Wrap the flake URL in double quotes so the `?` in `?dir=` is not interpreted as a shell glob character

## Test plan
- [ ] `cd orchestrator && direnv allow` activates successfully
- [ ] Shell enters the orchestrator devenv without errors

Related: #273
