### PR TITLE
docs(mlx): add benchmark results tracking

### DIFF
--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -8,6 +8,7 @@ Performance tracking for the vllm-mlx inference server across configuration chan
 - **Hardware**: Apple M4 Max, 128 GB unified memory
 - **OS**: macOS 26.3.1 (Tahoe)
 - **Server**: vllm-mlx 0.2.6 (OpenAI-compatible API on port 11434)
+- **Client**: `curl` for API latency tests, custom bash script with `footprint`/`vm_stat` for memory-tracked sweeps
 - **Model**: mlx-community/Qwen3.5-122B-A10B-4bit (~65 GB on disk)
 
 ## How to Run


### PR DESCRIPTION
# PR #279: MLX Benchmark Tracking

## Summary

- Adds `docs/mlx-benchmarks.md` for persistent MLX inference benchmark tracking
- Records post-OOM guardrails (PR #271) results confirming zero performance cost
- Includes baseline comparison and methodology observations

## Changes

- New file: `docs/mlx-benchmarks.md` — timestamped benchmark results with system info, results tables, and analysis

## Test Plan

- [x] Benchmarks executed on live M4 Max 128GB system
- [x] Results verified against previous baseline (Issue #257)

Related: #257, #271, #273
