### PR TITLE
fix: remove stale manual plugin list from development.nix comment

### DIFF
--- a/modules/claude/plugins/development.nix
+++ b/modules/claude/plugins/development.nix
@@ -10,16 +10,8 @@ let
   # ============================================================================
   # JacobPEvans Personal Plugins - Auto-discovered from flake input
   # ============================================================================
-  # Dynamically discovers all plugin directories from the jacobpevans-cc-plugins
-  # flake input using builtins.readDir. New plugins added to the repo are
-  # automatically enabled after `nix flake update jacobpevans-cc-plugins`.
-  #
-  # Known plugins (for reference, not used for enablement):
-  #   After consolidation: 16 plugins
-  #   - git-guards, content-guards, git-workflows, github-workflows
-  #   - infra-orchestration, ai-delegation, config-management, codeql-resolver
-  #   - process-cleanup, pr-lifecycle, git-standards, code-standards
-  #   - infra-standards, project-standards, session-analytics, pal-health
+  # Plugins from `jacobpevans-cc-plugins` are discovered and enabled automatically.
+  # The list of plugins is determined by the repository contents at flake update time.
   jacobpevansPlugins =
     let
       entries = builtins.readDir jacobpevans-cc-plugins;


### PR DESCRIPTION
## Summary

- Removes the stale manual plugin list from the `development.nix` comment — the list was redundant with auto-discovery via `builtins.readDir` and prone to drift
- Replaces with a two-line comment describing the auto-discovery behavior (per Gemini code review feedback)
- Comment-only change; no functional code modified

## Changes

- `modules/claude/plugins/development.nix`: removed 10-line manual plugin list, replaced with 2-line auto-discovery description

## Depends on

Merge after [JacobPEvans/claude-code-plugins#171](https://github.com/JacobPEvans/claude-code-plugins/pull/171) so that `nix flake update jacobpevans-cc-plugins` picks up the marketplace.json fix.

Note: `flake.lock` is intentionally not updated in this PR — that will be a follow-up commit after cc-plugins PR #171 merges.

## Test plan

- [x] `nix flake check --no-build` passes locally
- [ ] After cc-plugins #171 merges: run `nix flake update jacobpevans-cc-plugins` and commit updated `flake.lock`
- [ ] `darwin-rebuild switch` — session-start error no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
