### PR TITLE
fix(deps): close Renovate automation gaps for version-pinned packages

### DIFF
--- a/modules/gh-extensions/gh-aw.nix
+++ b/modules/gh-extensions/gh-aw.nix
@@ -6,7 +6,8 @@
 
 pkgs.buildGoModule rec {
   pname = "gh-aw";
-  version = "0.62.5"; # Update from https://github.com/github/gh-aw/releases
+  # renovate: datasource=github-releases depName=github/gh-aw
+  version = "0.62.5";
 
   src = fetchFromGitHub {
     owner = "github";

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -27,6 +27,7 @@ let
 
   # Pinned version — single source of truth. Shared via mlxShared so
   # benchmark wrappers in packages.nix use the same version.
+  # renovate: datasource=pypi depName=vllm-mlx
   vllmMlxVersion = "0.2.6";
 
   # Central vllm-mlx wrapper — single source of truth for the pinned version.

--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,15 @@
   "nix": {
     "enabled": true
   },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 7am on Monday"]
+  },
   "customManagers": [
     {
       "description": "bunx wrapper npm packages pinned in Nix modules",
       "customType": "regex",
-      "fileMatch": ["modules/ai-tools\\.nix"],
+      "fileMatch": ["\\.nix$"],
       "matchStrings": [
         "bunx\\s+--bun\\s+(?<depName>(?:@[^@/]+\\/)?[^@\\s]+)@(?<currentValue>[\\d][^\\s]*)"
       ],
@@ -20,10 +24,11 @@
     {
       "description": "uv/uvx wrapper PyPI packages pinned in Nix modules",
       "customType": "regex",
-      "fileMatch": ["modules/ai-tools\\.nix", "modules/mlx/default\\.nix"],
+      "fileMatch": ["\\.nix$"],
       "matchStrings": [
-        "uvx\\s+--from\\s+\"(?<depName>[a-zA-Z0-9_-]+)==(?<currentValue>[\\d][^\\s\"]*)\""
-        , "uv\\s+run\\s+--with\\s+\"(?<depName>[a-zA-Z0-9_-]+)==(?<currentValue>[\\d][^\\s\"]*)\""
+        "uvx\\s+--from\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "uv\\s+run[^\"]*--with\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\"",
+        "\"--from\"\\n\\s+\"(?<depName>[a-zA-Z0-9][a-zA-Z0-9._-]*)(?:\\[[^\\]]+\\])?==(?<currentValue>[\\d][^\\s\"]*)\""
       ],
       "datasourceTemplate": "pypi"
     }
@@ -32,7 +37,7 @@
     {
       "description": "Bunx wrapper npm packages - weekly updates",
       "matchDatasources": ["npm"],
-      "matchFileNames": ["modules/ai-tools.nix"],
+      "matchManagers": ["custom.regex"],
       "groupName": "npm-wrappers",
       "schedule": ["after 7am on Monday"],
       "minimumReleaseAge": "3 days"
@@ -40,23 +45,23 @@
     {
       "description": "uv/uvx wrapper PyPI packages - weekly updates",
       "matchDatasources": ["pypi"],
-      "matchFileNames": ["modules/ai-tools.nix", "modules/mlx/default.nix"],
+      "matchManagers": ["custom.regex"],
       "groupName": "pypi-wrappers",
       "schedule": ["after 7am on Monday"],
       "minimumReleaseAge": "3 days"
     },
     {
       "description": "MLX Python packages - weekly updates (upstream changes daily, short soak time)",
-      "matchManagers": ["uv"],
-      "matchFileNames": ["mlx-server/uv.lock"],
+      "matchManagers": ["pep621"],
+      "matchFileNames": ["mlx-server/**"],
       "groupName": "mlx-packages",
       "schedule": ["after 7am on Monday"],
       "minimumReleaseAge": "2 days"
     },
     {
       "description": "Orchestrator Python packages - weekly updates",
-      "matchManagers": ["uv"],
-      "matchFileNames": ["orchestrator/uv.lock"],
+      "matchManagers": ["pep621"],
+      "matchFileNames": ["orchestrator/**"],
       "groupName": "orchestrator-packages",
       "schedule": ["after 7am on Monday"],
       "minimumReleaseAge": "3 days"


### PR DESCRIPTION
## Summary
- Widen uvx/bunx customManager `fileMatch` to all `.nix` files (was limited to 2 specific files, missing MCP servers and MLX packages)
- Add third matchString for MCP args pattern where `--from` is on the preceding line
- Enable `lockFileMaintenance` to auto-refresh `mlx-server/uv.lock` and `orchestrator/uv.lock` weekly
- Fix `matchManagers` from deprecated `"uv"` to `"pep621"`
- Add `# renovate:` annotations to `vllm-mlx` version pin and `gh-aw` package

## Context
`huggingface_hub` was stuck at 1.6.0 in `mlx-server/uv.lock` despite 1.7.2 being available because Renovate never refreshed lock files. Additionally, `huggingface-mcp-server`, `google-workspace-mcp`, and `openai` version pins in MCP/MLX modules were invisible to Renovate due to narrow `fileMatch` scope.

## Packages now covered

| Package | Detection Method |
|---------|-----------------|
| huggingface-mcp-server | uvx `--from` args pattern |
| google-workspace-mcp | uvx `--from` args pattern |
| openai | `uv run --with` pattern |
| vllm-mlx | `# renovate:` annotation |
| gh-aw | `# renovate:` annotation |
| All mlx-server/orchestrator transitive deps | lockFileMaintenance |

## Related PRs
- JacobPEvans/.github — annotation-based customManager + HuggingFace trust rule
- JacobPEvans/nix-home — annotations for grip + git-flow-next
- JacobPEvans/nix-darwin — annotation for ClaudeBar

## Test plan
- [x] `nix flake check` passes
- [x] JSON validates
- [ ] Verify Renovate dashboard detects new packages after merge
- [ ] Confirm lockFileMaintenance PR appears on next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)