### PR TITLE
fix(mlx): switch default model to Qwen3.5-27B to prevent memory freezes

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -115,6 +115,11 @@ in
         }
         # Environment variables
         {
+          name = "mlx.env.MLX_DEFAULT_MODEL";
+          actual = hmConfig.config.home.sessionVariables.MLX_DEFAULT_MODEL;
+          expected = mlxCfg.defaultModel;
+        }
+        {
           name = "mlx.env.MLX_API_URL";
           actual = hmConfig.config.home.sessionVariables.MLX_API_URL;
           expected = "http://127.0.0.1:11434/v1";

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -35,7 +35,8 @@
     };
 
     # ---- vllm-mlx 0.2.6 PERFORMANCE TUNING ----
-    # Benchmarked 2026-03-19 on M4 Max 128GB with Qwen3.5-122B-A10B-4bit.
+    # Benchmarked 2026-03-19 on M4 Max 128GB with Qwen3.5-122B-A10B-4bit (~65 GB).
+    # Memory budgets below reference the 122B model; the default is now 27B (~15 GB).
     # Baseline: 55-74 tok/s generation, no parallel request benefit (bandwidth-bound).
     #
     # vllm-mlx 0.2.6 replaced the old token-count KV cache (--max-kv-size) with a


### PR DESCRIPTION
## Summary

- Switch default vllm-mlx model from Qwen3.5-122B-A10B-4bit (65 GB) to Qwen3.5-27B-4bit (15 GB)
- Eliminates full-system freezes caused by memory compressor thrashing on 128 GB M4 Max
- Add `MLX_DEFAULT_MODEL` env var regression guard to prevent option/env drift
- Clarify performance tuning comments reference the 122B model, not the new default

## Root Cause

The 65 GB model causes macOS memory compressor thrashing: 64.4 GB dirty anonymous memory with only 457 MB free, 1.25x compression ratio on ML weights. Jetsam event reports confirm 3m37s+ system-wide log gaps (kernel too frozen to write). Freezes of 5-40+ seconds occurred approximately once per hour.

## Why Qwen3.5-27B

Scores **identically** on SWE-bench Verified (72.4%) at 1/4 the memory. The larger model remains available on-demand via `mlx-switch` for heavy tasks.

## Changes

| File | Change |
| ---- | ------ |
| `modules/mlx/options.nix` | Default model 122B -> 27B; clarify tuning comment header |
| `lib/checks/mlx.nix` | Update regression expected value; add `MLX_DEFAULT_MODEL` env var sync check |

## Test plan

- [x] `nix flake check` passes (all 15 checks including `mlx-defaults-regression`)
- [ ] `darwin-rebuild switch` deploys new LaunchAgent with 27B model
- [ ] `mlx-status` shows ~15 GB memory usage
- [ ] `memory_pressure` reports Normal (was WARNING/CRITICAL)
- [ ] No system freezes after 1+ hour of use
