### PR TITLE
fix(ci): replace stub benchmark PR comments with benchmark-action

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -137,7 +137,7 @@ jobs:
         id: prepare
         if: steps.filter.outputs.run == 'true'
         run: |
-          result_file=$(ls -t data/benchmarks/*.json 2>/dev/null | head -1)
+          result_file=$(ls -t data/benchmarks/*-*.json 2>/dev/null | head -1)
           if [ -z "$result_file" ]; then
             echo "[]" > /tmp/benchmark-output.json
             exit 0


### PR DESCRIPTION
## Summary

- Replace stub benchmark PR comments ("See artifact...") with native `benchmark-action/github-action-benchmark`
- Benchmark results now show inline tables with metric names, values, and units
- Regression detection at 130% threshold with automatic PR comment alerts
- Skipped suites handled gracefully (empty array, no errors)

## Changes

- `jq` one-liner reshapes existing `collect-results.py` JSON into benchmark-action custom format
- `marocchino/sticky-pull-request-comment` replaced with `benchmark-action/github-action-benchmark@v1`
- No custom scripts added

## Test plan

- [ ] PR triggers benchmark CI (touches `scripts/benchmarks/` path filter)
- [ ] Verify benchmark-action posts comparison table on this PR
- [ ] Verify skipped suites don't error

Related: #294
