### PR TITLE
fix(security): add Python security scanning and OSV scanner to CI

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -131,7 +131,6 @@ jobs:
     needs: changes
     if: always()
     uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@main
-    secrets: inherit
 
   # ==========================================================================
   # MERGE GATE - The ONLY required check in branch protection
@@ -145,5 +144,5 @@ jobs:
       - name: Check all results
         uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: nix-validate, markdown-lint, file-size, benchmark-validate, python-security, osv-scan
+          allowed-skips: nix-validate, markdown-lint, file-size, benchmark-validate, python-security
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

Wire `_python-security.yml` and `_osv-scan.yml` reusable workflows into the nix-ai CI gate, adding Python-specific path filtering for targeted security scanning.

## Changes

- Add `python` path filter detecting changes in `mlx-server/**` and `orchestrator/**`
- Wire `_python-security.yml` for pip-audit, conditional on Python file changes
- Wire `_osv-scan.yml` for lockfile vulnerability scanning (runs unconditionally on all PRs)
- Add both jobs to Merge Gate `needs`; `python-security` in `allowed-skips` (conditional), `osv-scan` excluded from `allowed-skips` (must always pass)
- Fix pre-existing shellcheck SC2086: quote `$GITHUB_OUTPUT` references
- Normalize job syntax: `needs: changes` (not `needs: [changes]`), `needs` before `if`
- Remove unnecessary `secrets: inherit` from `osv-scan` (operates on local lockfiles)

## Dependencies

- **Blocked on**: `_python-security.yml` and `_osv-scan.yml` must be created in [JacobPEvans/.github](https://github.com/JacobPEvans/.github) first (see JacobPEvans/.github#4)
- CI Gate workflow will fail at file parsing until those reusable workflows exist

## Test plan

- [ ] CI Gate parses successfully after reusable workflows are created in `.github`
- [ ] pip-audit runs only on Python file changes (`mlx-server/**`, `orchestrator/**`)
- [ ] OSV scan runs on all PRs regardless of file changes
- [ ] Merge Gate fails if OSV scan does not complete (not in `allowed-skips`)
