### PR TITLE
chore(deps): enable Renovate automerge for Python packages (minor/patch)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,7 +65,10 @@
       "matchFileNames": ["mlx-server/**"],
       "groupName": "mlx-packages",
       "schedule": ["after 7am on Monday"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "3 days",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
     },
     {
       "description": "Orchestrator Python packages - weekly updates",
@@ -73,7 +76,10 @@
       "matchFileNames": ["orchestrator/**"],
       "groupName": "orchestrator-packages",
       "schedule": ["after 7am on Monday"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "3 days",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,7 @@
       "groupName": "mlx-packages",
       "schedule": ["after 7am on Monday"],
       "minimumReleaseAge": "3 days",
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
@@ -77,6 +78,7 @@
       "groupName": "orchestrator-packages",
       "schedule": ["after 7am on Monday"],
       "minimumReleaseAge": "3 days",
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"


### PR DESCRIPTION
# PR #370 Update

## Summary

- Enable Renovate automerge (squash strategy) for `mlx-packages` and `orchestrator-packages` groups
- Restrict to minor/patch updates only — major versions still require human review
- Combined with existing 3-day `minimumReleaseAge` soak period for supply chain security

## Changes

- `renovate.json`: Add `automerge`, `automergeType`, `automergeStrategy`, and `matchUpdateTypes` to both pep621 package rules

## Test plan

- [ ] Verify Renovate creates PRs with automerge enabled on next scheduled run
- [ ] Confirm major version updates are NOT auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
