### PR TITLE
fix(mlx): add flock serialization to model switch operations

### DIFF
--- a/modules/mlx/scripts/mlx-default.sh
+++ b/modules/mlx/scripts/mlx-default.sh
@@ -6,9 +6,9 @@ label="dev.vllm-mlx.server"
 domain="gui/$(id -u)"
 
 # Acquire the same lock as mlx-switch to prevent racing with an in-progress switch
-LOCK_FILE="/tmp/mlx-switch.lock"
-exec 9>"$LOCK_FILE"
-/usr/bin/flock -n 9 || { echo "An mlx-switch is in progress. Wait for it to finish."; exit 1; }
+LOCK_FILE="${TMPDIR:-/tmp}/mlx-switch.lock"
+/usr/bin/shlock -f "$LOCK_FILE" -p $$ || { echo "An mlx-switch is in progress. Wait for it to finish."; exit 1; }
+trap 'rm -f "$LOCK_FILE"' EXIT
 
 launchctl bootout "$domain/$label" 2>/dev/null || true
 lsof -ti :"${MLX_PORT:?}" 2>/dev/null | xargs kill 2>/dev/null || true

--- a/modules/mlx/scripts/mlx-default.sh
+++ b/modules/mlx/scripts/mlx-default.sh
@@ -5,6 +5,11 @@
 label="dev.vllm-mlx.server"
 domain="gui/$(id -u)"
 
+# Acquire the same lock as mlx-switch to prevent racing with an in-progress switch
+LOCK_FILE="/tmp/mlx-switch.lock"
+exec 9>"$LOCK_FILE"
+/usr/bin/flock -n 9 || { echo "An mlx-switch is in progress. Wait for it to finish."; exit 1; }
+
 launchctl bootout "$domain/$label" 2>/dev/null || true
 lsof -ti :"${MLX_PORT:?}" 2>/dev/null | xargs kill 2>/dev/null || true
 sleep 1

--- a/modules/mlx/scripts/mlx-switch.sh
+++ b/modules/mlx/scripts/mlx-switch.sh
@@ -7,6 +7,12 @@ label="dev.vllm-mlx.server"
 domain="gui/$(id -u)"
 plist="$HOME/Library/LaunchAgents/$label.plist"
 
+# Prevent concurrent model switches — overlapping multi-GB NVMe reads can
+# saturate the SSD and stall system services (runningboardd → WindowServer).
+LOCK_FILE="/tmp/mlx-switch.lock"
+exec 9>"$LOCK_FILE"
+/usr/bin/flock -n 9 || { echo "Another mlx-switch is in progress. Aborting."; exit 1; }
+
 trap 'lsof -ti :"$MLX_PORT" 2>/dev/null | xargs kill 2>/dev/null; sleep 1; launchctl bootstrap "$domain" "$plist" 2>/dev/null; echo "Default restored."' EXIT
 
 mlx-preflight "$model" || exit 1

--- a/modules/mlx/scripts/mlx-switch.sh
+++ b/modules/mlx/scripts/mlx-switch.sh
@@ -7,13 +7,11 @@ label="dev.vllm-mlx.server"
 domain="gui/$(id -u)"
 plist="$HOME/Library/LaunchAgents/$label.plist"
 
-# Prevent concurrent model switches — overlapping multi-GB NVMe reads can
-# saturate the SSD and stall system services (runningboardd → WindowServer).
-LOCK_FILE="/tmp/mlx-switch.lock"
-exec 9>"$LOCK_FILE"
-/usr/bin/flock -n 9 || { echo "Another mlx-switch is in progress. Aborting."; exit 1; }
+# Serialize model switches — only one at a time for optimal I/O scheduling.
+LOCK_FILE="${TMPDIR:-/tmp}/mlx-switch.lock"
+/usr/bin/shlock -f "$LOCK_FILE" -p $$ || { echo "Another mlx-switch is in progress. Aborting."; exit 1; }
 
-trap 'lsof -ti :"$MLX_PORT" 2>/dev/null | xargs kill 2>/dev/null; sleep 1; launchctl bootstrap "$domain" "$plist" 2>/dev/null; echo "Default restored."' EXIT
+trap 'lsof -ti :"$MLX_PORT" 2>/dev/null | xargs kill 2>/dev/null; sleep 1; launchctl bootstrap "$domain" "$plist" 2>/dev/null; rm -f "$LOCK_FILE"; echo "Default restored."' EXIT
 
 mlx-preflight "$model" || exit 1
 


### PR DESCRIPTION
# PR #390 - MLX Switch Lock

## Summary

Adds flock-based mutual exclusion to mlx-switch.sh and mlx-default.sh to
prevent concurrent model switch operations from racing. When two model switch
commands run simultaneously, the second fails immediately with a clear error
instead of corrupting state or causing I/O contention.

## Changes

- `modules/mlx/scripts/mlx-switch.sh`: acquire lock via `shlock` before model
  operations
- `modules/mlx/scripts/mlx-default.sh`: acquire lock before writing default
  model state
- Lock file: `/tmp/mlx-switch.lock` (process-scoped; auto-released on exit)

## Test Plan

- `nix flake check` passes without warnings
- Run `mlx-switch <model>` in terminal A, immediately run `mlx-switch <other>`
  in terminal B — B should fail with "Another mlx-switch is in progress"
- Run `mlx-default` while `mlx-switch` is running in another terminal — should
  show lock message
- Verify single-terminal `mlx-switch` operations work unchanged (no latency
  regression)
