### PR TITLE
chore(benchmarks): Qwen3.5 vs Gemma4 comparison + summary fixes

### DIFF
--- a/data/benchmarks/2026-04-10T004511Z-3b5d3ea-gemma-4-e4b-it-4bit-throughput.json
+++ b/data/benchmarks/2026-04-10T004511Z-3b5d3ea-gemma-4-e4b-it-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T00:45:11Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/gemma-4-e4b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 2.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "20.18"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 2.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "101.09"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 3.3,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "156.47"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 3.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "297.27"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T005446Z-3b5d3ea-gemma-4-e4b-it-4bit-ttft.json
+++ b/data/benchmarks/2026-04-10T005446Z-3b5d3ea-gemma-4-e4b-it-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T00:54:46Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/gemma-4-e4b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 1.5655,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 1.4231,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.1,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "1.5655",
+        "warm_avg": "1.4231"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T005557Z-3b5d3ea-gemma-4-e4b-it-4bit-code-accuracy.json
+++ b/data/benchmarks/2026-04-10T005557Z-3b5d3ea-gemma-4-e4b-it-4bit-code-accuracy.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T00:55:57Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "code-accuracy",
+  "model": "mlx-community/gemma-4-e4b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "bug-detection",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "ratio",
+      "tags": {
+        "bugs_planted": "3",
+        "bugs_found": "3"
+      }
+    },
+    {
+      "name": "code-planning",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "ratio",
+      "tags": {
+        "correct": "0",
+        "total": "3"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T010043Z-3b5d3ea-gemma-4-e4b-it-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-10T010043Z-3b5d3ea-gemma-4-e4b-it-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T01:00:43Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/gemma-4-e4b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "33.02"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "41.70"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "24.83"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "89.67"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T014859Z-3b5d3ea-Qwen3.5-27B-4bit-throughput.json
+++ b/data/benchmarks/2026-04-10T014859Z-3b5d3ea-Qwen3.5-27B-4bit-throughput.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T01:48:59Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3.5-27B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 2.2,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "22.31"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 2.3,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "113.46"
+      }
+    }
+  ],
+  "errors": [
+    "throughput/long-512: curl failed (exit 28)",
+    "throughput/long-1024: curl failed (exit 22)"
+  ]
+}

--- a/data/benchmarks/2026-04-10T015730Z-3b5d3ea-Qwen3.5-27B-4bit-ttft.json
+++ b/data/benchmarks/2026-04-10T015730Z-3b5d3ea-Qwen3.5-27B-4bit-ttft.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T01:57:30Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3.5-27B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [],
+  "errors": [
+    "ttft/cold: failed for prompt 'What is the capital of France?...'",
+    "ttft/cold: failed for prompt 'Explain quantum entanglement b...'",
+    "ttft/cold: failed for prompt 'List three benefits of exercis...'",
+    "ttft/warm: failed",
+    "ttft/warm: failed",
+    "ttft/warm: failed"
+  ]
+}

--- a/data/benchmarks/2026-04-10T021308Z-3b5d3ea-Qwen3.5-27B-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-10T021308Z-3b5d3ea-Qwen3.5-27B-4bit-tool-calling.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T02:13:08Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Qwen3.5-27B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "41.59"
+      }
+    }
+  ],
+  "errors": [
+    "tool-calling/should-call-tool: request failed",
+    "tool-calling/both-args: request failed",
+    "tool-calling/no-tool-needed: request failed"
+  ]
+}

--- a/data/benchmarks/2026-04-10T024446Z-3b5d3ea-Qwen3.5-27B-4bit-code-accuracy.json
+++ b/data/benchmarks/2026-04-10T024446Z-3b5d3ea-Qwen3.5-27B-4bit-code-accuracy.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T02:44:46Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "code-accuracy",
+  "model": "mlx-community/Qwen3.5-27B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "bug-detection",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "ratio",
+      "tags": {
+        "bugs_planted": "3",
+        "bugs_found": "3"
+      }
+    },
+    {
+      "name": "code-planning",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "ratio",
+      "tags": {
+        "correct": "0",
+        "total": "3"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T025019Z-3b5d3ea-gemma-4-31b-it-4bit-throughput.json
+++ b/data/benchmarks/2026-04-10T025019Z-3b5d3ea-gemma-4-31b-it-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T02:50:19Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/gemma-4-31b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 6.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "7.75"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 5.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "47.68"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 4.1,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "124.02"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 5.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "190.17"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T025629Z-3b5d3ea-gemma-4-31b-it-4bit-ttft.json
+++ b/data/benchmarks/2026-04-10T025629Z-3b5d3ea-gemma-4-31b-it-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T02:56:29Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/gemma-4-31b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 1.4384,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 1.5755,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 0.91,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "1.4384",
+        "warm_avg": "1.5755"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T025638Z-3b5d3ea-gemma-4-31b-it-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-10T025638Z-3b5d3ea-gemma-4-31b-it-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T02:56:38Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/gemma-4-31b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "18.99"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "24.59"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "11.28"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "47.34"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T025820Z-3b5d3ea-gemma-4-31b-it-4bit-code-accuracy.json
+++ b/data/benchmarks/2026-04-10T025820Z-3b5d3ea-gemma-4-31b-it-4bit-code-accuracy.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T02:58:20Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "code-accuracy",
+  "model": "mlx-community/gemma-4-31b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "bug-detection",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "ratio",
+      "tags": {
+        "bugs_planted": "3",
+        "bugs_found": "3"
+      }
+    },
+    {
+      "name": "code-planning",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "ratio",
+      "tags": {
+        "correct": "0",
+        "total": "3"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T030547Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-throughput.json
+++ b/data/benchmarks/2026-04-10T030547Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T03:05:47Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 19.2,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "2.60"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 23.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "10.90"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 23.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "21.74"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 24.3,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "42.12"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T030704Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-ttft.json
+++ b/data/benchmarks/2026-04-10T030704Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T03:07:04Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.7421,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.7384,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.0,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.7421",
+        "warm_avg": "0.7384"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T030709Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-10T030709Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T03:07:09Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "5.51"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "4.62"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "4.27"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "11.24"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-10T030735Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-code-accuracy.json
+++ b/data/benchmarks/2026-04-10T030735Z-3b5d3ea-Qwen3.5-35B-A3B-4bit-code-accuracy.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-10T03:07:35Z",
+  "git_sha": "3b5d3ea",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "code-accuracy",
+  "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "bug-detection",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "ratio",
+      "tags": {
+        "bugs_planted": "3",
+        "bugs_found": "3"
+      }
+    },
+    {
+      "name": "code-planning",
+      "metric": "accuracy",
+      "value": 0.33,
+      "unit": "ratio",
+      "tags": {
+        "correct": "1",
+        "total": "3"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/docs/mlx-benchmarks-history.md
+++ b/docs/mlx-benchmarks-history.md
@@ -1,0 +1,204 @@
+<!-- cspell:words TTFT hellaswag parameterize keyerror -->
+# MLX Benchmark History
+
+Archived narratives for prior benchmark sessions. The current summary lives in
+[`mlx-benchmarks.md`](mlx-benchmarks.md); auto-generated tables there always show
+the latest 5 runs per suite. Entries here are kept as human-readable context for
+configuration decisions and multi-model baselines.
+
+## 2026-03-22 — Full Suite with Tool Calling & Code Accuracy
+
+Config: KV cache 16 GB, ProcessType=Background, HardResourceLimits 100 GB,
+`--enable-auto-tool-choice --tool-call-parser qwen` (PR #280).
+System: macOS 26.3.1, vllm-mlx 0.2.6, PID 1438.
+
+### Throughput Sweep (5 lengths)
+
+| Test | Output | Elapsed | tok/s |
+|------|--------|---------|-------|
+| Short gen (50 tok) | 50 | 7.78s | 6.4 |
+| Short gen (100 tok) | 100 | 5.22s | 19.2 |
+| Medium gen (256 tok) | 256 | 9.88s | 25.9 |
+| Long gen (512 tok) | 512 | 19.04s | 26.9 |
+| Long gen (1024 tok) | 1024 | 39.47s | 25.9 |
+
+Note: Lower tok/s than previous run (25-27 vs 44-49) because tool-calling mode
+enables Qwen3's `<think>` reasoning tokens which count toward completion_tokens.
+The model generates internal reasoning before responding, trading throughput for
+quality. This is the expected behavior when `--tool-call-parser qwen` is active.
+
+### TTFT (Cold vs Warm, 3 runs each)
+
+| Test | Latency |
+|------|---------|
+| Cold avg (3 unique prompts) | 0.566s |
+| Warm avg (3 cached prompts) | 0.652s |
+| Cache speedup | 0.9x (no benefit) |
+
+Prefix cache shows no benefit with tool-calling mode enabled. The `<think>` tokens
+likely invalidate cache entries since the model's internal reasoning varies per request.
+
+### Tool Calling (OpenAI-compatible function calling)
+
+| Test | Latency | Tokens | Called Tool? | Details |
+|------|---------|--------|-------------|---------|
+| Weather query (should call) | 7.89s | 104 | YES | `get_weather({"location": "San Francisco"})` |
+| Weather + unit (both args) | 6.32s | 131 | YES | `get_weather({"location": "Tokyo", "unit": "celsius"})` |
+| No tool needed (math) | 4.95s | 84 | NO | Correctly answered without tool |
+| Ambiguous (climate) | 9.03s | 200 | NO | Correctly reasoned climate != weather tool |
+
+Tool calling accuracy: **4/4 correct decisions** (2 correct calls, 2 correct abstentions).
+
+### Concurrent Requests (3 parallel)
+
+| Requests | Total Tokens | Elapsed | Aggregate tok/s |
+|----------|-------------|---------|-----------------|
+| 3 | 600 | 23.71s | 25.3 |
+
+No throughput scaling with concurrency — model is memory-bandwidth-bound. 25.3 aggregate
+tok/s across 3 requests ≈ same as single-request throughput (25.9 tok/s).
+
+### Code Accuracy with Tool Calling
+
+#### Test 1: Code Planning (tool selection accuracy)
+
+| Task | First Tool | Expected | Correct? |
+|------|-----------|----------|----------|
+| Add validation to auth.py | file_read | file_read | YES |
+| Find functions without error handling | bash_exec | grep_search | NO (reasonable alt) |
+| Create config.yaml | file_write | file_write | YES |
+| Run test suite | bash_exec | bash_exec | YES |
+
+Score: **3/4** (75%). The model chose `bash_exec find` instead of `grep_search` for
+one case — a reasonable alternative approach.
+
+#### Test 2: Code Implementation (bug fix via tool call)
+
+| Bug | Tool Called | Correct Tool? | Valid Fix? |
+|-----|-----------|---------------|-----------|
+| Off-by-one error | file_read | NO | MAYBE |
+| SQL injection | file_read | NO | MAYBE |
+
+Score: **0/2** for direct `file_edit`. The model chose to `file_read` first before
+editing — actually the safer approach (read-before-edit), but scored as incorrect
+since the test expected direct `file_edit`. In a real agentic loop, step 2 would
+be the edit. This matches Claude Code's own pattern of reading files before editing.
+
+#### Test 3: Code Review (bug detection)
+
+| Bugs Planted | Bugs Found | Accuracy |
+|-------------|-----------|----------|
+| 3 (off-by-one, null check, SQL injection) | 3 | **100%** |
+
+All three planted bugs detected in 18.7s. No false positives.
+
+#### Test 4: Multi-step Tool Chain
+
+| Step | Tool | Expected | Correct? |
+|------|------|----------|----------|
+| 1 | grep_search | grep_search | YES |
+| 2 | (summarized directly) | file_read | OK |
+
+The model correctly searched with grep first, then summarized the results directly
+instead of reading each file — an efficient optimization.
+
+### Memory Timeline
+
+| Time | Phase | vllm RSS (GB) | vllm Peak (GB) | Free (GB) | Active (GB) | Wired (GB) | Compressed (GB) | Swap |
+|------|-------|---------------|----------------|-----------|-------------|------------|-----------------|------|
+| 00:57:28 | idle (pre-test) | 65 | 65 | 2.1 | 40.6 | 5.6 | 37.3 | 0.00M |
+| 00:58:50 | after throughput | 65 | 65 | 0.1 | 24.8 | 70.1 | 7.2 | 0.00M |
+| 00:58:54 | after TTFT | 65 | 65 | 0.1 | 24.1 | 71.6 | 7.2 | 0.00M |
+| 00:59:23 | after tool calling | 65 | 65 | 0.9 | 24.5 | 69.9 | 7.3 | 0.00M |
+| 00:59:47 | after concurrent | 65 | 65 | 0.4 | 24.6 | 70.1 | 7.3 | 0.00M |
+| 01:00:04 | idle (post-test) | 65 | 68 | 1.7 | 83.7 | 7.2 | 8.1 | 0.00M |
+
+vllm-mlx peak RSS reached 68 GB briefly (3 GB above baseline) — first time peak
+exceeded baseline. Likely caused by concurrent request KV cache allocation. Still
+well within the 100 GB hard limit with zero swap.
+
+### Key Takeaways
+
+- **Tool calling works reliably**: 4/4 correct tool decisions, proper argument extraction
+- **Code review is strong**: 3/3 bugs found with zero false positives
+- **Read-before-edit pattern**: Model prefers to read files before editing — same as
+  Claude Code's approach, and the right instinct for safety
+- **Throughput trades for quality**: `<think>` reasoning tokens reduce raw tok/s from
+  ~45 to ~26 but improve decision quality
+- **Memory stable**: 65 GB baseline, 68 GB peak, zero swap throughout
+
+## 2026-03-22 — Post-OOM Guardrails (PR #273 merged)
+
+Config: KV cache 16 GB, ProcessType=Background, HardResourceLimits 100 GB.
+System: macOS 26.3.1, vllm-mlx 0.2.6.
+
+| Test | Metric | Value | Notes |
+|------|--------|-------|-------|
+| Short gen (50 tok) | tok/s | 23.6 | Single request, warm server |
+| Long gen (512 tok) | tok/s | 44.5 | Single request |
+| TTFT cold | latency | 1.13s | Unique prompt, no prefix cache |
+| TTFT warm | latency | 0.29s | Repeated prompt, prefix cache hit |
+| Cache speedup | ratio | 3.9x | warm vs cold TTFT |
+
+## 2026-03-22 — Memory-Tracked Throughput Sweep
+
+Config: KV cache 16 GB, ProcessType=Background, HardResourceLimits 100 GB.
+System: macOS 26.3.1, vllm-mlx 0.2.6, PID 1438.
+
+Sequential generation tests with memory snapshots via `footprint` (process)
+and `vm_stat` (system). All values in GB unless noted.
+
+### Throughput
+
+| Test | Tokens | Time | tok/s |
+|------|--------|------|-------|
+| Short gen | 50 | 1.95s | 25.6 |
+| Medium gen | 256 | 5.39s | 47.5 |
+| Long gen | 512 | 10.43s | 49.1 |
+| Rapid fire 1/3 | 50 | 1.32s | 37.9 |
+| Rapid fire 2/3 | 50 | 1.27s | 39.4 |
+| Rapid fire 3/3 | 50 | 1.22s | 41.0 |
+
+### Memory Timeline
+
+| Time | Phase | vllm RSS (GB) | vllm Peak (GB) | Free (GB) | Active (GB) | Wired (GB) | Compressed (GB) | Swap |
+|------|-------|---------------|----------------|-----------|-------------|------------|-----------------|------|
+| 23:24:05 | idle (pre-test) | 65 | 65 | 0.9 | 58.9 | 5.7 | 2.7 | 0.00M |
+| 23:24:07 | after short gen (50 tok) | 65 | 65 | 0.7 | 22.1 | 69.8 | 2.7 | 0.00M |
+| 23:24:13 | after medium gen (256 tok) | 65 | 65 | 1.4 | 21.7 | 70.7 | 2.6 | 0.00M |
+| 23:24:23 | after long gen (512 tok) | 65 | 65 | 1.7 | 22.5 | 70.6 | 2.6 | 0.00M |
+| 23:24:28 | after 3x rapid short gen | 65 | 65 | 1.5 | 22.3 | 71.3 | 2.6 | 0.00M |
+| 23:24:33 | idle (post-test, +5s) | 65 | 65 | 2.2 | 86.3 | 5.0 | 2.6 | 0.00M |
+
+### Memory Observations
+
+- **vllm-mlx RSS is constant at 65 GB** throughout all tests — no memory leaks, no
+  growth from KV cache accumulation. Peak never exceeds baseline.
+- **Wired memory spikes during generation** (5.7 → 71.3 GB) as MLX allocates Metal
+  GPU buffers for KV cache and compute. These return to active memory after generation
+  completes (visible in the post-test idle row: wired drops back to 5.0 GB).
+- **Zero swap throughout** — the 16 GB KV cache cap keeps total memory well within
+  the 128 GB physical limit.
+- **Throughput increases with token count**: 25.6 tok/s (50 tok) → 49.1 tok/s (512 tok).
+  Short generations are TTFT-dominated; longer generations amortize prefill cost and
+  approach the memory-bandwidth ceiling (~50 tok/s for this model).
+
+## 2026-03-20 — Initial Baseline (Issue #257)
+
+Config: KV cache uncapped (~25.6 GB auto-detect), no ProcessType, no resource limits.
+System: macOS 26.3.0, vllm-mlx 0.2.6.
+
+| Test | Metric | Value | Notes |
+|------|--------|-------|-------|
+| Short gen (50 tok) | tok/s | 5.5 | Likely includes cold TTFT in measurement |
+| Long gen (512 tok) | tok/s | 43.3 | Single request |
+| TTFT cold | latency | 2.0s | First request |
+| TTFT warm | latency | 0.76s | Cached |
+| Cache speedup | ratio | 2.6x | warm vs cold TTFT |
+
+### Observations
+
+- **Throughput stable** at ~44 tok/s — 16 GB KV cap has no impact (bandwidth-bound)
+- **Short gen improved** 5.5 → 23.6 tok/s (warm server vs cold TTFT in baseline)
+- **TTFT improved** cold 2.0s → 1.13s, warm 0.76s → 0.29s
+- **OOM guardrails zero cost** — ProcessType=Background is metadata-only

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -72,7 +72,7 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-10 00:45 | 3b5d3ea | gemma-4-e4b-it-4bit | medium-256 | 2.5 | 256 | 101.09 |
 | 2026-04-10 00:45 | 3b5d3ea | gemma-4-e4b-it-4bit | long-512 | 3.3 | 512 | 156.47 |
 | 2026-04-10 00:45 | 3b5d3ea | gemma-4-e4b-it-4bit | long-1024 | 3.4 | 1024 | 297.27 |
-| 2026-04-06 04:56 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — | — |
+| 2026-04-06 04:56 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — |
 
 ### TTFT
 
@@ -87,7 +87,7 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-10 00:54 | 3b5d3ea | gemma-4-e4b-it-4bit | cold-avg | 1.565 | cold |
 | 2026-04-10 00:54 | 3b5d3ea | gemma-4-e4b-it-4bit | warm-avg | 1.423 | warm |
 | 2026-04-10 00:54 | 3b5d3ea | gemma-4-e4b-it-4bit | cache-speedup | 1.100 | — |
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
 
 ### Tool Calling
 
@@ -106,7 +106,7 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-10 01:00 | 3b5d3ea | gemma-4-e4b-it-4bit | both-args | 100.0% | accuracy | — |
 | 2026-04-10 01:00 | 3b5d3ea | gemma-4-e4b-it-4bit | no-tool-needed | 100.0% | accuracy | — |
 | 2026-04-10 01:00 | 3b5d3ea | gemma-4-e4b-it-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — |
 
 ### Code Accuracy
 
@@ -120,7 +120,7 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-10 02:44 | 3b5d3ea | Qwen3.5-27B-4bit | code-planning | 0.0% | accuracy | — |
 | 2026-04-10 00:55 | 3b5d3ea | gemma-4-e4b-it-4bit | bug-detection | 100.0% | accuracy | — |
 | 2026-04-10 00:55 | 3b5d3ea | gemma-4-e4b-it-4bit | code-planning | 0.0% | accuracy | — |
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — |
 
 ### Framework Benchmark
 
@@ -131,213 +131,22 @@ mlx-eval --tasks hellaswag --limit 100
 
 | Date | SHA | Category | Score | Claude Baseline | Gap |
 |------|-----|----------|-------|-----------------|-----|
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
 
 ### Model Comparison Matrix
 
 | Model | Code Accuracy | Tool Calling | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
 |-------|---------------|--------------|------|------------|--------------------------------------------|---------------------|
 | Qwen3.5-122B-A10B-4bit | — | — | — | — | — | — |
-| Qwen3.5-27B-4bit | 50.0% | 100.0% | — | 2.2 | — | — |
-| Qwen3.5-35B-A3B-4bit | 66.5% | 100.0% | 82.7% | 22.6 | — | — |
-| gemma-4-31b-it-4bit | 50.0% | 50.0% | 1.31 | 5.3 | — | — |
-| gemma-4-e4b-it-4bit | 50.0% | 100.0% | 1.36 | 2.9 | — | — |
+| Qwen3.5-27B-4bit | 50% | 25% (1/4) | — | 2.3 tok/s | — | — |
+| Qwen3.5-35B-A3B-4bit | 66% | 100% | 0.74s | 24.3 tok/s | — | — |
+| gemma-4-31b-it-4bit | 50% | 50% | 1.44s | 6.4 tok/s | — | — |
+| gemma-4-e4b-it-4bit | 50% | 100% | 1.57s | 3.4 tok/s | — | — |
 
 <!-- BENCHMARK-TABLE-END -->
 
-### 2026-03-22 — Full Suite with Tool Calling & Code Accuracy
+## History
 
-Config: KV cache 16 GB, ProcessType=Background, HardResourceLimits 100 GB,
-`--enable-auto-tool-choice --tool-call-parser qwen` (PR #280).
-System: macOS 26.3.1, vllm-mlx 0.2.6, PID 1438.
-
-#### Throughput Sweep (5 lengths)
-
-| Test | Output | Elapsed | tok/s |
-|------|--------|---------|-------|
-| Short gen (50 tok) | 50 | 7.78s | 6.4 |
-| Short gen (100 tok) | 100 | 5.22s | 19.2 |
-| Medium gen (256 tok) | 256 | 9.88s | 25.9 |
-| Long gen (512 tok) | 512 | 19.04s | 26.9 |
-| Long gen (1024 tok) | 1024 | 39.47s | 25.9 |
-
-Note: Lower tok/s than previous run (25-27 vs 44-49) because tool-calling mode
-enables Qwen3's `<think>` reasoning tokens which count toward completion_tokens.
-The model generates internal reasoning before responding, trading throughput for
-quality. This is the expected behavior when `--tool-call-parser qwen` is active.
-
-#### TTFT (Cold vs Warm, 3 runs each)
-
-| Test | Latency |
-|------|---------|
-| Cold avg (3 unique prompts) | 0.566s |
-| Warm avg (3 cached prompts) | 0.652s |
-| Cache speedup | 0.9x (no benefit) |
-
-Prefix cache shows no benefit with tool-calling mode enabled. The `<think>` tokens
-likely invalidate cache entries since the model's internal reasoning varies per request.
-
-#### Tool Calling (OpenAI-compatible function calling)
-
-| Test | Latency | Tokens | Called Tool? | Details |
-|------|---------|--------|-------------|---------|
-| Weather query (should call) | 7.89s | 104 | YES | `get_weather({"location": "San Francisco"})` |
-| Weather + unit (both args) | 6.32s | 131 | YES | `get_weather({"location": "Tokyo", "unit": "celsius"})` |
-| No tool needed (math) | 4.95s | 84 | NO | Correctly answered without tool |
-| Ambiguous (climate) | 9.03s | 200 | NO | Correctly reasoned climate != weather tool |
-
-Tool calling accuracy: **4/4 correct decisions** (2 correct calls, 2 correct abstentions).
-
-#### Concurrent Requests (3 parallel)
-
-| Requests | Total Tokens | Elapsed | Aggregate tok/s |
-|----------|-------------|---------|-----------------|
-| 3 | 600 | 23.71s | 25.3 |
-
-No throughput scaling with concurrency — model is memory-bandwidth-bound. 25.3 aggregate
-tok/s across 3 requests ≈ same as single-request throughput (25.9 tok/s).
-
-#### Code Accuracy with Tool Calling
-
-##### Test 1: Code Planning (tool selection accuracy)
-
-| Task | First Tool | Expected | Correct? |
-|------|-----------|----------|----------|
-| Add validation to auth.py | file_read | file_read | YES |
-| Find functions without error handling | bash_exec | grep_search | NO (reasonable alt) |
-| Create config.yaml | file_write | file_write | YES |
-| Run test suite | bash_exec | bash_exec | YES |
-
-Score: **3/4** (75%). The model chose `bash_exec find` instead of `grep_search` for
-one case — a reasonable alternative approach.
-
-##### Test 2: Code Implementation (bug fix via tool call)
-
-| Bug | Tool Called | Correct Tool? | Valid Fix? |
-|-----|-----------|---------------|-----------|
-| Off-by-one error | file_read | NO | MAYBE |
-| SQL injection | file_read | NO | MAYBE |
-
-Score: **0/2** for direct `file_edit`. The model chose to `file_read` first before
-editing — actually the safer approach (read-before-edit), but scored as incorrect
-since the test expected direct `file_edit`. In a real agentic loop, step 2 would
-be the edit. This matches Claude Code's own pattern of reading files before editing.
-
-##### Test 3: Code Review (bug detection)
-
-| Bugs Planted | Bugs Found | Accuracy |
-|-------------|-----------|----------|
-| 3 (off-by-one, null check, SQL injection) | 3 | **100%** |
-
-All three planted bugs detected in 18.7s. No false positives.
-
-##### Test 4: Multi-step Tool Chain
-
-| Step | Tool | Expected | Correct? |
-|------|------|----------|----------|
-| 1 | grep_search | grep_search | YES |
-| 2 | (summarized directly) | file_read | OK |
-
-The model correctly searched with grep first, then summarized the results directly
-instead of reading each file — an efficient optimization.
-
-#### Memory Timeline
-
-| Time | Phase | vllm RSS (GB) | vllm Peak (GB) | Free (GB) | Active (GB) | Wired (GB) | Compressed (GB) | Swap |
-|------|-------|---------------|----------------|-----------|-------------|------------|-----------------|------|
-| 00:57:28 | idle (pre-test) | 65 | 65 | 2.1 | 40.6 | 5.6 | 37.3 | 0.00M |
-| 00:58:50 | after throughput | 65 | 65 | 0.1 | 24.8 | 70.1 | 7.2 | 0.00M |
-| 00:58:54 | after TTFT | 65 | 65 | 0.1 | 24.1 | 71.6 | 7.2 | 0.00M |
-| 00:59:23 | after tool calling | 65 | 65 | 0.9 | 24.5 | 69.9 | 7.3 | 0.00M |
-| 00:59:47 | after concurrent | 65 | 65 | 0.4 | 24.6 | 70.1 | 7.3 | 0.00M |
-| 01:00:04 | idle (post-test) | 65 | 68 | 1.7 | 83.7 | 7.2 | 8.1 | 0.00M |
-
-vllm-mlx peak RSS reached 68 GB briefly (3 GB above baseline) — first time peak
-exceeded baseline. Likely caused by concurrent request KV cache allocation. Still
-well within the 100 GB hard limit with zero swap.
-
-#### Key Takeaways
-
-- **Tool calling works reliably**: 4/4 correct tool decisions, proper argument extraction
-- **Code review is strong**: 3/3 bugs found with zero false positives
-- **Read-before-edit pattern**: Model prefers to read files before editing — same as
-  Claude Code's approach, and the right instinct for safety
-- **Throughput trades for quality**: `<think>` reasoning tokens reduce raw tok/s from
-  ~45 to ~26 but improve decision quality
-- **Memory stable**: 65 GB baseline, 68 GB peak, zero swap throughout
-
-### 2026-03-22 — Post-OOM Guardrails (PR #273 merged)
-
-Config: KV cache 16 GB, ProcessType=Background, HardResourceLimits 100 GB.
-System: macOS 26.3.1, vllm-mlx 0.2.6.
-
-| Test | Metric | Value | Notes |
-|------|--------|-------|-------|
-| Short gen (50 tok) | tok/s | 23.6 | Single request, warm server |
-| Long gen (512 tok) | tok/s | 44.5 | Single request |
-| TTFT cold | latency | 1.13s | Unique prompt, no prefix cache |
-| TTFT warm | latency | 0.29s | Repeated prompt, prefix cache hit |
-| Cache speedup | ratio | 3.9x | warm vs cold TTFT |
-
-### 2026-03-22 — Memory-Tracked Throughput Sweep
-
-Config: KV cache 16 GB, ProcessType=Background, HardResourceLimits 100 GB.
-System: macOS 26.3.1, vllm-mlx 0.2.6, PID 1438.
-
-Sequential generation tests with memory snapshots via `footprint` (process)
-and `vm_stat` (system). All values in GB unless noted.
-
-#### Throughput
-
-| Test | Tokens | Time | tok/s |
-|------|--------|------|-------|
-| Short gen | 50 | 1.95s | 25.6 |
-| Medium gen | 256 | 5.39s | 47.5 |
-| Long gen | 512 | 10.43s | 49.1 |
-| Rapid fire 1/3 | 50 | 1.32s | 37.9 |
-| Rapid fire 2/3 | 50 | 1.27s | 39.4 |
-| Rapid fire 3/3 | 50 | 1.22s | 41.0 |
-
-#### Memory Timeline
-
-| Time | Phase | vllm RSS (GB) | vllm Peak (GB) | Free (GB) | Active (GB) | Wired (GB) | Compressed (GB) | Swap |
-|------|-------|---------------|----------------|-----------|-------------|------------|-----------------|------|
-| 23:24:05 | idle (pre-test) | 65 | 65 | 0.9 | 58.9 | 5.7 | 2.7 | 0.00M |
-| 23:24:07 | after short gen (50 tok) | 65 | 65 | 0.7 | 22.1 | 69.8 | 2.7 | 0.00M |
-| 23:24:13 | after medium gen (256 tok) | 65 | 65 | 1.4 | 21.7 | 70.7 | 2.6 | 0.00M |
-| 23:24:23 | after long gen (512 tok) | 65 | 65 | 1.7 | 22.5 | 70.6 | 2.6 | 0.00M |
-| 23:24:28 | after 3x rapid short gen | 65 | 65 | 1.5 | 22.3 | 71.3 | 2.6 | 0.00M |
-| 23:24:33 | idle (post-test, +5s) | 65 | 65 | 2.2 | 86.3 | 5.0 | 2.6 | 0.00M |
-
-#### Memory Observations
-
-- **vllm-mlx RSS is constant at 65 GB** throughout all tests — no memory leaks, no
-  growth from KV cache accumulation. Peak never exceeds baseline.
-- **Wired memory spikes during generation** (5.7 → 71.3 GB) as MLX allocates Metal
-  GPU buffers for KV cache and compute. These return to active memory after generation
-  completes (visible in the post-test idle row: wired drops back to 5.0 GB).
-- **Zero swap throughout** — the 16 GB KV cache cap keeps total memory well within
-  the 128 GB physical limit.
-- **Throughput increases with token count**: 25.6 tok/s (50 tok) → 49.1 tok/s (512 tok).
-  Short generations are TTFT-dominated; longer generations amortize prefill cost and
-  approach the memory-bandwidth ceiling (~50 tok/s for this model).
-
-### 2026-03-20 — Initial Baseline (Issue #257)
-
-Config: KV cache uncapped (~25.6 GB auto-detect), no ProcessType, no resource limits.
-System: macOS 26.3.0, vllm-mlx 0.2.6.
-
-| Test | Metric | Value | Notes |
-|------|--------|-------|-------|
-| Short gen (50 tok) | tok/s | 5.5 | Likely includes cold TTFT in measurement |
-| Long gen (512 tok) | tok/s | 43.3 | Single request |
-| TTFT cold | latency | 2.0s | First request |
-| TTFT warm | latency | 0.76s | Cached |
-| Cache speedup | ratio | 2.6x | warm vs cold TTFT |
-
-### Observations
-
-- **Throughput stable** at ~44 tok/s — 16 GB KV cap has no impact (bandwidth-bound)
-- **Short gen improved** 5.5 → 23.6 tok/s (warm server vs cold TTFT in baseline)
-- **TTFT improved** cold 2.0s → 1.13s, warm 0.76s → 0.29s
-- **OOM guardrails zero cost** — ProcessType=Background is metadata-only
+Detailed narratives for earlier benchmark sessions (2026-03-20 through 2026-03-22,
+including memory timelines, OOM guardrail tuning, and the initial `--tool-call-parser
+qwen` baseline) live in [`mlx-benchmarks-history.md`](mlx-benchmarks-history.md).

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -56,27 +56,71 @@ mlx-eval --tasks hellaswag --limit 100
 
 ### Throughput
 
-| Date | SHA | Test | Metric | Value | Unit |
-|------|-----|------|--------|-------|------|
-| 2026-04-06 04:56 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
+| Date | SHA | Model | Test | tok/s | Tokens | Elapsed |
+|------|-----|-------|------|-------|--------|---------|
+| 2026-04-10 03:05 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | short-50 | 19.2 | 50 | 2.60 |
+| 2026-04-10 03:05 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | medium-256 | 23.5 | 256 | 10.90 |
+| 2026-04-10 03:05 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | long-512 | 23.6 | 512 | 21.74 |
+| 2026-04-10 03:05 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | long-1024 | 24.3 | 1024 | 42.12 |
+| 2026-04-10 02:50 | 3b5d3ea | gemma-4-31b-it-4bit | short-50 | 6.4 | 50 | 7.75 |
+| 2026-04-10 02:50 | 3b5d3ea | gemma-4-31b-it-4bit | medium-256 | 5.4 | 256 | 47.68 |
+| 2026-04-10 02:50 | 3b5d3ea | gemma-4-31b-it-4bit | long-512 | 4.1 | 512 | 124.02 |
+| 2026-04-10 02:50 | 3b5d3ea | gemma-4-31b-it-4bit | long-1024 | 5.4 | 1024 | 190.17 |
+| 2026-04-10 01:48 | 3b5d3ea | Qwen3.5-27B-4bit | short-50 | 2.2 | 50 | 22.31 |
+| 2026-04-10 01:48 | 3b5d3ea | Qwen3.5-27B-4bit | medium-256 | 2.3 | 256 | 113.46 |
+| 2026-04-10 00:45 | 3b5d3ea | gemma-4-e4b-it-4bit | short-50 | 2.5 | 50 | 20.18 |
+| 2026-04-10 00:45 | 3b5d3ea | gemma-4-e4b-it-4bit | medium-256 | 2.5 | 256 | 101.09 |
+| 2026-04-10 00:45 | 3b5d3ea | gemma-4-e4b-it-4bit | long-512 | 3.3 | 512 | 156.47 |
+| 2026-04-10 00:45 | 3b5d3ea | gemma-4-e4b-it-4bit | long-1024 | 3.4 | 1024 | 297.27 |
+| 2026-04-06 04:56 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — | — |
 
 ### TTFT
 
-| Date | SHA | Test | Metric | Value | Unit |
-|------|-----|------|--------|-------|------|
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
+| Date | SHA | Model | Test | Latency (s) | Type |
+|------|-----|-------|------|-------------|------|
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | cold-avg | 0.742 | cold |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | warm-avg | 0.738 | warm |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | cache-speedup | 1.000 | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | cold-avg | 1.438 | cold |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | warm-avg | 1.575 | warm |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | cache-speedup | 0.910 | — |
+| 2026-04-10 00:54 | 3b5d3ea | gemma-4-e4b-it-4bit | cold-avg | 1.565 | cold |
+| 2026-04-10 00:54 | 3b5d3ea | gemma-4-e4b-it-4bit | warm-avg | 1.423 | warm |
+| 2026-04-10 00:54 | 3b5d3ea | gemma-4-e4b-it-4bit | cache-speedup | 1.100 | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — |
 
 ### Tool Calling
 
-| Date | SHA | Test | Metric | Value | Unit |
-|------|-----|------|--------|-------|------|
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
+| Date | SHA | Model | Task | Score | Metric | Samples |
+|------|-----|-------|------|-------|--------|---------|
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | both-args | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | both-args | 0.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 02:13 | 3b5d3ea | Qwen3.5-27B-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 01:00 | 3b5d3ea | gemma-4-e4b-it-4bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-10 01:00 | 3b5d3ea | gemma-4-e4b-it-4bit | both-args | 100.0% | accuracy | — |
+| 2026-04-10 01:00 | 3b5d3ea | gemma-4-e4b-it-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 01:00 | 3b5d3ea | gemma-4-e4b-it-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — | — |
 
 ### Code Accuracy
 
-| Date | SHA | Test | Metric | Value | Unit |
-|------|-----|------|--------|-------|------|
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
+| Date | SHA | Model | Task | Score | Metric | Samples |
+|------|-----|-------|------|-------|--------|---------|
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | code-planning | 33.0% | accuracy | — |
+| 2026-04-10 02:58 | 3b5d3ea | gemma-4-31b-it-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 02:58 | 3b5d3ea | gemma-4-31b-it-4bit | code-planning | 0.0% | accuracy | — |
+| 2026-04-10 02:44 | 3b5d3ea | Qwen3.5-27B-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 02:44 | 3b5d3ea | Qwen3.5-27B-4bit | code-planning | 0.0% | accuracy | — |
+| 2026-04-10 00:55 | 3b5d3ea | gemma-4-e4b-it-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 00:55 | 3b5d3ea | gemma-4-e4b-it-4bit | code-planning | 0.0% | accuracy | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — | — |
 
 ### Framework Benchmark
 
@@ -87,7 +131,17 @@ mlx-eval --tasks hellaswag --limit 100
 
 | Date | SHA | Category | Score | Claude Baseline | Gap |
 |------|-----|----------|-------|-----------------|-----|
-| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
+| 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — | — |
+
+### Model Comparison Matrix
+
+| Model | Code Accuracy | Tool Calling | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
+|-------|---------------|--------------|------|------------|--------------------------------------------|---------------------|
+| Qwen3.5-122B-A10B-4bit | — | — | — | — | — | — |
+| Qwen3.5-27B-4bit | 50.0% | 100.0% | — | 2.2 | — | — |
+| Qwen3.5-35B-A3B-4bit | 66.5% | 100.0% | 82.7% | 22.6 | — | — |
+| gemma-4-31b-it-4bit | 50.0% | 50.0% | 1.31 | 5.3 | — | — |
+| gemma-4-e4b-it-4bit | 50.0% | 100.0% | 1.36 | 2.9 | — | — |
 
 <!-- BENCHMARK-TABLE-END -->
 

--- a/scripts/benchmarks/collect-results.py
+++ b/scripts/benchmarks/collect-results.py
@@ -401,7 +401,7 @@ def run_tool_calling_suite(model: str) -> tuple[list[dict], list[str]]:
             continue
 
         message = choices[0].get("message", {})
-        tool_calls = message.get("tool_calls", [])
+        tool_calls = message.get("tool_calls") or []
         called_tool = len(tool_calls) > 0
 
         correct = called_tool == tc["expect_tool"]

--- a/scripts/benchmarks/collect-results.py
+++ b/scripts/benchmarks/collect-results.py
@@ -400,7 +400,9 @@ def run_tool_calling_suite(model: str) -> tuple[list[dict], list[str]]:
             errors.append(f"tool-calling/{tc['name']}: no choices in response")
             continue
 
-        message = choices[0].get("message", {})
+        # OpenAI-compatible servers may return explicit null for both message and
+        # message.tool_calls, so use `or {}` / `or []` rather than dict .get defaults.
+        message = choices[0].get("message") or {}
         tool_calls = message.get("tool_calls") or []
         called_tool = len(tool_calls) > 0
 

--- a/scripts/benchmarks/generate-summary.py
+++ b/scripts/benchmarks/generate-summary.py
@@ -70,7 +70,8 @@ def fmt_timestamp(ts: str) -> str:
 
 
 def _skipped_row(date: str, sha: str, ncols: int) -> str:
-    cells = ["—"] * (ncols - 2)
+    # Row already contains 3 cells: date, sha, the "(skipped ...)" label.
+    cells = ["—"] * (ncols - 3)
     return f"| {date} | {sha} | _(skipped — no MLX hardware)_ | " + " | ".join(cells) + " |"
 
 
@@ -261,9 +262,59 @@ def render_suite(suite: str, runs: list[dict]) -> str:
     return heading + body
 
 
+def _summarize_run(suite: str, run: dict) -> str:
+    """Produce a single cell for the model-comparison matrix from one run."""
+    if run.get("skipped"):
+        return "—"
+    results = run.get("results", [])
+    errors = run.get("errors", [])
+    if not results and not errors:
+        return "—"
+
+    if suite == "throughput":
+        # Peak sustained tok/s across the sweep is the headline number.
+        tok_s = [r.get("value", 0) for r in results if r.get("unit") == "tok/s"]
+        return f"{max(tok_s):.1f} tok/s" if tok_s else "—"
+
+    if suite == "ttft":
+        # Cold latency is the user-facing metric; warm/cache-speedup are diagnostics.
+        for r in results:
+            if r.get("name") == "cold-avg" or r.get("tags", {}).get("type") == "cold":
+                return f"{r.get('value', 0):.2f}s"
+        return "—"
+
+    if suite in {"tool-calling", "code-accuracy", "coding", "reasoning", "knowledge"}:
+        # Accuracy suites: average success, but flag partial runs caused by errors.
+        # Accept any accuracy-style unit (bool, ratio, percent, or unspecified).
+        acc_results = [
+            r for r in results if r.get("unit") in ("bool", "ratio", "percent", "")
+        ]
+        if not acc_results:
+            return "—"
+        values = [r.get("value", 0) for r in acc_results]
+        avg = sum(values) / len(values)
+        total_attempts = len(values) + len(errors)
+        if errors and total_attempts > len(values):
+            # Re-base on attempts so partial runs are never flattered by errors.
+            avg = sum(values) / total_attempts
+            return f"{avg:.0%} ({len(values)}/{total_attempts})"
+        return f"{avg:.0%}"
+
+    if suite == "capability-comparison":
+        values = [r.get("value", 0) for r in results]
+        if not values:
+            return "—"
+        return f"{sum(values) / len(values):.2f}"
+
+    # Framework / generic fallback.
+    values = [r.get("value", 0) for r in results]
+    if not values:
+        return "—"
+    return f"{sum(values) / len(values):.2f}"
+
+
 def render_model_comparison(grouped: dict[str, list[dict]]) -> str:
     """Build a cross-model comparison matrix from the most recent run of each suite per model."""
-    # Collect latest score per (model, suite) pair
     matrix: dict[str, dict[str, str]] = {}  # model -> {suite: score_str}
     suites_seen: list[str] = []
 
@@ -276,23 +327,7 @@ def render_model_comparison(grouped: dict[str, list[dict]]) -> str:
                 matrix[model] = {}
             if suite in matrix[model]:
                 continue  # already have the latest for this model+suite
-            if run.get("skipped"):
-                matrix[model][suite] = "—"
-                continue
-            results = run.get("results", [])
-            if not results:
-                matrix[model][suite] = "—"
-                continue
-            # Summarize: for single-result suites use the value; for multi-result, average
-            values = [r.get("value", 0) for r in results]
-            avg = sum(values) / len(values) if values else 0
-            unit = results[0].get("unit", "")
-            if unit == "tok/s":
-                matrix[model][suite] = f"{avg:.1f}"
-            elif unit in ("ratio", "bool") or avg <= 1.0:
-                matrix[model][suite] = f"{avg:.1%}"
-            else:
-                matrix[model][suite] = f"{avg:.2f}"
+            matrix[model][suite] = _summarize_run(suite, run)
 
     models = sorted(matrix.keys())
     if len(models) < 2:


### PR DESCRIPTION
## Summary

Fast-suite benchmark comparison (throughput, ttft, tool-calling, code-accuracy)
across 4 MLX models, plus fixes to `generate-summary.py` and `collect-results.py`
found during review, and a history split on `docs/mlx-benchmarks.md` to fit under
the 12 KB file-size check.

Models compared (all via PR #418's infrastructure):

- `mlx-community/Qwen3.5-27B-4bit` — dense, 15 GB
- `mlx-community/gemma-4-31b-it-4bit` — dense, 17 GB
- `mlx-community/Qwen3.5-35B-A3B-4bit` — MoE, 19 GB, 3B active
- `mlx-community/gemma-4-e4b-it-4bit` — MoE, 4.9 GB

## Key Findings

| Metric | Qwen3.5-27B | gemma-4-31b | Qwen3.5-35B-A3B | gemma-4-e4b |
|--------|-------------|-------------|-----------------|-------------|
| Throughput (peak tok/s) | 2.3 | 6.4 | **24.3** | 3.4 |
| TTFT cold-avg (s) | — | 1.44 | **0.74** | 1.57 |
| Tool Calling | 25% (1/4) | 50% | **100%** | **100%** |
| Code Accuracy | 50% | 50% | **66%** | 50% |

- **Qwen3.5-35B-A3B (MoE)** is the clear winner — dominates throughput at roughly
  4–10× the dense models and leads every other metric.
- **Qwen3.5-27B** shows `25% (1/4)` for tool calling because 3/4 tasks hit curl
  timeouts from Qwen3 `<think>` reasoning chains (separate issue, not fixed here).
- **gemma-4-31b** fails `should-call-tool` and `both-args` — likely a parser-config
  mismatch with `--tool-call-parser hermes`.

## Changes

### Data & results

- 16 new result files in `data/benchmarks/` (4 models × 4 suites)
- Regenerated `docs/mlx-benchmarks.md` with the fixed summary generator
- New `docs/mlx-benchmarks-history.md` containing the 2026-03-xx narratives that
  previously lived in the main benchmarks doc (memory timelines, OOM guardrail
  tuning, initial `--tool-call-parser qwen` baseline)

### Bug fixes (surfaced by gemini-code-assist / copilot-pull-request-reviewer)

- `collect-results.py`: `message = choices[0].get("message") or {}` so explicit
  `null` values from OpenAI-compatible servers don't crash the tool-calling suite.
  Same pattern as the `tool_calls` fix — `.get(key, default)` only supplies
  `default` when the key is missing, not when it's `None`.
- `generate-summary.py`: `_skipped_row` was off-by-one (`ncols - 2` trailing cells
  instead of `ncols - 3`), producing rows with one extra column that broke
  `MD056/table-column-count`. All 5 skipped-row rendering sites now match their
  header column counts.
- `generate-summary.py`: `render_model_comparison` averaged heterogeneous units —
  TTFT `cold-avg`/`warm-avg`/`cache-speedup` results were mixed into a bogus
  `82.7%`. New `_summarize_run` helper is suite-aware: TTFT reports cold-avg
  latency in seconds, throughput reports peak tok/s, and accuracy suites include
  `errors` in the denominator so partial runs render as `25% (1/4)` instead of a
  flattering `100%`.
- `generate-summary.py`: accuracy-suite filter accepts `ratio`/`percent`/`""` in
  addition to `bool`, so `code-accuracy` results (which use `unit: "ratio"`)
  populate the matrix correctly.

### File-size fix

- Historical narratives moved to `docs/mlx-benchmarks-history.md` to bring the
  main file from 16 KB back under the 12 KB hard limit enforced by
  `_file-size.yml`.

## Test Plan

- [x] `markdownlint-cli2 'docs/**/*.md'` → 0 errors
- [x] `ruff check scripts/benchmarks/*.py` → 0 errors
- [x] `nix fmt` → 0 files changed
- [x] `uv run scripts/benchmarks/dry-run-check.py` → schema OK, imports healthy
- [x] `uv run scripts/benchmarks/generate-summary.py` → matrix values look
      correct (Qwen3.5-35B-A3B `0.74s` TTFT, Qwen3.5-27B `25% (1/4)` tool-calling)
- [x] All 16 JSON result files validate against `data/benchmarks/schema.json`
- [x] All GitHub Actions checks green (File Size, Markdown Lint, CodeQL, Merge
      Gate, all Benchmark / *)
- [x] All 15 review threads resolved

## Related

- Depends on PR #418 (merged) — benchmark infrastructure
