### PR TITLE
feat(mcp): route PAL through Bifrost AI gateway

### DIFF
--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -96,7 +96,10 @@ in
       # Run PAL's `listmodels` tool for current aliases and providers.
       DEFAULT_MODEL = "auto";
       # Custom API endpoint — MLX inference server (vllm-mlx on port 11434)
-      CUSTOM_API_URL = "http://127.0.0.1:11434/v1";
+      # Route PAL through Bifrost AI gateway (localhost:30080) instead of
+      # vllm-mlx directly. Bifrost fans out to OpenAI/Gemini/OpenRouter/MLX
+      # based on model name. Tracked: JacobPEvans/nix-ai#450
+      CUSTOM_API_URL = "http://localhost:30080/v1";
       # MLX timeout tuning (PAL reads from providers/openai_compatible.py)
       CUSTOM_CONNECT_TIMEOUT = "30"; # 30s for localhost MLX (catches stalled server)
       CUSTOM_READ_TIMEOUT = "300"; # 5min for large model inference

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -91,18 +91,19 @@ in
     env = {
       # Enable ALL PAL tools (default disables: analyze,refactor,testgen,secaudit,docgen,tracer)
       DISABLED_TOOLS = "";
-      # 'auto' = PAL picks best available model per-task based on configured API keys.
-      # Falls back across providers: OpenAI -> Gemini -> OpenRouter -> MLX.
-      # Run PAL's `listmodels` tool for current aliases and providers.
+      # 'auto' = PAL picks a model alias per-task; Bifrost then routes the
+      # resulting request to the right provider based on the model name.
+      # Run PAL's `listmodels` (or curl http://localhost:30080/v1/models)
+      # for current aliases and providers.
       DEFAULT_MODEL = "auto";
-      # Custom API endpoint — MLX inference server (vllm-mlx on port 11434)
       # Route PAL through Bifrost AI gateway (localhost:30080) instead of
       # vllm-mlx directly. Bifrost fans out to OpenAI/Gemini/OpenRouter/MLX
       # based on model name. Tracked: JacobPEvans/nix-ai#450
       CUSTOM_API_URL = "http://localhost:30080/v1";
-      # MLX timeout tuning (PAL reads from providers/openai_compatible.py)
-      CUSTOM_CONNECT_TIMEOUT = "30"; # 30s for localhost MLX (catches stalled server)
-      CUSTOM_READ_TIMEOUT = "300"; # 5min for large model inference
+      # OpenAI-compatible client timeouts — applies to whichever backend
+      # CUSTOM_API_URL points at (Bifrost in this config).
+      CUSTOM_CONNECT_TIMEOUT = "30"; # 30s connect — catches stalled upstream
+      CUSTOM_READ_TIMEOUT = "300"; # 5min read — accommodates large model inference
       # Conversation limits
       CONVERSATION_TIMEOUT_HOURS = "6";
       MAX_CONVERSATION_TURNS = "50";


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450

## Summary
Completes Phase 2b of the PAL MCP to Bifrost migration. PAL's `CUSTOM_API_URL` now points at the Bifrost gateway at `http://localhost:30080/v1` instead of talking to vllm-mlx directly on `:11434`. Bifrost then fans out to OpenAI/Gemini/OpenRouter and local MLX based on model name.

## Why
Bifrost (deployed in JacobPEvans/orbstack-kubernetes#138) is a multi-provider AI gateway that replaces PAL's custom routing with an OpenAI-compatible HTTP API. With the Doppler K8s Operator bootstrapped today and `/v1/models` returning 509 live models, we can start migrating PAL's single-model tools (`chat`, `listmodels`, etc.) onto the gateway without losing local MLX access.

`ANTHROPIC_API_KEY` is intentionally omitted from the Doppler config — Claude Code reaches Anthropic directly via its own subscription, so there is no value in round-tripping through Bifrost for Claude models.

## Test plan
- [x] `nix flake check --no-build` passes locally
- [x] Pre-commit hooks pass locally
- [ ] After merge: `darwin-rebuild switch --flake ~/git/nix-darwin/main`
- [ ] `claude mcp list` shows both `pal` and `bifrost` Connected
- [ ] `mcp__pal__chat --model openai/gpt-4o --prompt "2+2"` succeeds
- [ ] `mcp__pal__chat --model mlx-community/Qwen3.5-27B-4bit --prompt "2+2"` succeeds