### PR TITLE
docs(pal): trim policy scope to clink/consensus after Bifrost activation

### DIFF
--- a/modules/claude/rules/pal-mcp-policy.md
+++ b/modules/claude/rules/pal-mcp-policy.md
@@ -1,21 +1,37 @@
 ---
-description: PAL MCP availability protocol — mandatory investigation before declaring unavailable
+description: PAL MCP availability protocol — scoped to clink and consensus after Bifrost migration
 ---
 
 # PAL MCP Policy
 
-PAL MCP routes prompts to external and local models (OpenAI, Gemini, OpenRouter, MLX).
-It is the token offloading backbone. **Never declare it unavailable without investigation.**
+PAL MCP hosts two tools with no native Claude Code or Bifrost equivalent:
+**`clink`** (parallel multi-model prompting) and **`consensus`** (multi-model
+voting/agreement). Every other PAL tool has a native replacement — single-model
+prompts go through the Bifrost AI gateway at `http://localhost:30080/v1`,
+architecture/planning work goes through Plan mode or the `Plan` subagent, etc.
+See the Phase 3 audit matrix on `JacobPEvans/nix-ai#450` for the full mapping.
+
+This policy **only applies to `clink` and `consensus`**. Never declare either
+unavailable without completing the investigation protocol below. Silently
+skipping a multi-model step because `ToolSearch` came back empty is the
+failure mode this rule exists to prevent.
 
 ## Configuration
 
-- **DEFAULT_MODEL=auto**: PAL picks best model per-task based on available API keys
-- **Providers**: OpenAI → Gemini → OpenRouter → MLX (local). Run `mcp__pal__listmodels` for available models.
-- **Secrets**: Injected via Doppler with encrypted fallback cache (no network dependency on start)
+- **DEFAULT_MODEL=auto**: PAL picks a model alias per-task; for single-model
+  work this flows through `CUSTOM_API_URL` → Bifrost → the right provider.
+  `clink`/`consensus` use their own multi-provider fan-out, not Bifrost.
+- **Secrets**: Local PAL subprocess secrets (API keys, config) are injected by
+  the `doppler-mcp` wrapper at launch time. This is separate from the Doppler
+  **K8s Operator** that syncs Bifrost's in-cluster provider keys — different
+  layer, don't conflate.
+- **Bifrost is not a replacement** for `clink`/`consensus` — Bifrost is a
+  single-request router, not a parallel orchestrator.
 
-## Availability Check Protocol (MANDATORY)
+## Availability Check Protocol (MANDATORY for clink/consensus)
 
-Three-step escalation. All three steps MUST be followed before declaring unavailable.
+Three-step escalation. All three steps MUST be followed before declaring
+`clink` or `consensus` unavailable.
 
 ### Step 1: ToolSearch
 
@@ -23,7 +39,7 @@ Three-step escalation. All three steps MUST be followed before declaring unavail
 ToolSearch("mcp__pal", max_results=5)
 ```
 
-If tools found → PAL is loaded. Proceed.
+If `mcp__pal__clink` or `mcp__pal__consensus` appears → proceed.
 If empty → **DO NOT STOP. Go to Step 2.** (deferred tools may not be populated yet)
 
 ### Step 2: Check server status
@@ -34,7 +50,7 @@ claude mcp list 2>/dev/null | grep "^pal:"
 
 | Status | Action |
 | ------ | ------ |
-| `✓ Connected` | ToolSearch again: `select:mcp__pal__chat` |
+| `✓ Connected` | ToolSearch again: `select:mcp__pal__clink` |
 | `✗ Failed` | Go to Step 3 |
 | Not listed | Tell user: "PAL not registered. Run `check-pal-mcp` to diagnose." |
 
@@ -50,10 +66,13 @@ Tell user: "PAL reconnected but requires session restart to load tools."
 
 ## NEVER-Do List
 
-- NEVER skip PAL based on ToolSearch alone
-- NEVER declare "PAL unavailable" without completing all 3 steps
-- NEVER silently omit PAL-dependent phases
-- NEVER suggest manual workarounds without first attempting the protocol above
+- NEVER skip `clink`/`consensus` based on ToolSearch alone
+- NEVER declare either unavailable without completing all 3 steps
+- NEVER silently omit a multi-model phase because PAL looked absent
+- NEVER substitute Bifrost for `clink`/`consensus` — Bifrost cannot fan out
+  to multiple models in one request
+- NEVER suggest manual workarounds (e.g., sequential `chat` calls imitating
+  `consensus`) without first attempting the protocol above
 
 ## Diagnostics
 
@@ -62,3 +81,11 @@ If PAL fails after the protocol:
 1. `check-pal-mcp` — full health check (Doppler auth, secrets, MCP status)
 2. `cat ~/.local/state/doppler-mcp.log` — recent invocation log
 3. `doppler me` — verify Doppler authentication
+
+## See also
+
+- **Bifrost health**: `curl http://localhost:30080/health`
+- **Bifrost model catalog**: `curl http://localhost:30080/v1/models`
+- **Bifrost MCP registration**: `bifrost` block in `modules/mcp/default.nix`
+- **Phase 3 audit matrix** (full PAL → native mapping):
+  [JacobPEvans/nix-ai#450](https://github.com/JacobPEvans/nix-ai/issues/450)

--- a/modules/claude/rules/pal-mcp-policy.md
+++ b/modules/claude/rules/pal-mcp-policy.md
@@ -33,14 +33,19 @@ failure mode this rule exists to prevent.
 Three-step escalation. All three steps MUST be followed before declaring
 `clink` or `consensus` unavailable.
 
-### Step 1: ToolSearch
+### Step 1: ToolSearch (target the specific tool you need)
+
+Search directly for the tool you're about to use rather than relying on a
+generic `mcp__pal` prefix — PAL exposes ~18 tools and a low `max_results`
+will truncate the list before `consensus`/`clink` appear.
 
 ```text
-ToolSearch("mcp__pal", max_results=5)
+ToolSearch("select:mcp__pal__clink", max_results=5)
+ToolSearch("select:mcp__pal__consensus", max_results=5)
 ```
 
-If `mcp__pal__clink` or `mcp__pal__consensus` appears → proceed.
-If empty → **DO NOT STOP. Go to Step 2.** (deferred tools may not be populated yet)
+If the target tool appears → proceed directly to using it.
+If not found → **DO NOT STOP. Go to Step 2.** (deferred tools may not be populated yet)
 
 ### Step 2: Check server status
 
@@ -50,7 +55,7 @@ claude mcp list 2>/dev/null | grep "^pal:"
 
 | Status | Action |
 | ------ | ------ |
-| `✓ Connected` | ToolSearch again: `select:mcp__pal__clink` |
+| `✓ Connected` | ToolSearch again for whichever tool is missing: `select:mcp__pal__clink` or `select:mcp__pal__consensus` |
 | `✗ Failed` | Go to Step 3 |
 | Not listed | Tell user: "PAL not registered. Run `check-pal-mcp` to diagnose." |
 


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450

## Summary

With Bifrost now the primary single-model router (JacobPEvans/nix-ai#466 merged in 1.35.0), the PAL MCP availability-check protocol only needs to cover the two tools that have no Bifrost equivalent: \`clink\` (parallel multi-model prompting) and \`consensus\` (multi-model voting).

Every other PAL tool has a native Claude Code replacement or routes through Bifrost directly — see the Phase 3 audit matrix comment on issue #450 for the full 15 REPLACE / 2 KEEP / 1 DROP mapping.

## Changes

- **Retitled description** from \"mandatory investigation before declaring unavailable\" to \"scoped to clink and consensus after Bifrost migration\" so grep/search tooling reflects the new scope immediately.
- **Rewrote the opening section** to explain that this policy narrows to \`clink\`/\`consensus\` only, with a link to the audit matrix for the full rationale.
- **Configuration section** now clarifies the two-Doppler-layer distinction that came up repeatedly on PR #466 review — local \`doppler-mcp\` wrapper vs. the in-cluster Doppler K8s Operator are separate things, don't conflate.
- **NEVER-Do list** rewritten to focus on clink/consensus failure modes, including an explicit \"never substitute Bifrost for clink/consensus\" since Bifrost is single-request-only.
- **Preserved the three-step reconnection escalation** — still load-bearing when clink or consensus disappear mid-session.
- **Added See-also section** with direct Bifrost health/catalog endpoints and the issue #450 link.

## Why

The old policy applied blanket \"never declare PAL unavailable\" rules to all 18 PAL tools. With 16 of those migrated to native replacements, running the full protocol on every PAL lookup was wasted motion. The narrowed policy is enforceable and correctly scoped.

## Test plan

- [x] \`nix flake check --no-build\` passes all 14 checks
- [x] \`pre-commit run --files modules/claude/rules/pal-mcp-policy.md\` passes (markdownlint, trim-whitespace, etc.)
- [x] File compiles with no syntax issues
- [ ] After merge: verify the rule loads correctly in a fresh Claude Code session via \`claude rules\` or equivalent