### PR TITLE
chore(benchmarks): Phase B math-hard sweep + multimodal rescue default swap

### DIFF
--- a/.file-size.yml
+++ b/.file-size.yml
@@ -1,6 +1,7 @@
 # Per-repo file-size config for JacobPEvans/.github/_file-size.yml
 # options.nix: vllm-mlx parameter reference (active + commented-out options)
 # ai-tools: multi-tool AI package definitions
+# mlx-benchmarks: full dated decision history + post-mortems for MLX model sweeps
 extended:
   limit: 20480
-  files: [options, ai-tools]
+  files: [options, ai-tools, mlx-benchmarks]

--- a/.file-size.yml
+++ b/.file-size.yml
@@ -4,4 +4,4 @@
 # mlx-benchmarks: full dated decision history + post-mortems for MLX model sweeps
 extended:
   limit: 20480
-  files: [options, ai-tools, mlx-benchmarks]
+  files: [options, ai-tools, mlx-benchmarks, mlx-benchmarks-history]

--- a/data/benchmarks/2026-04-11T021919Z-ff66999-Qwen3-Coder-30B-A3B-Instruct-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T021919Z-ff66999-Qwen3-Coder-30B-A3B-Instruct-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T02:19:19Z",
+  "git_sha": "ff66999",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.47,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T141921Z-1829b16-Qwen3-Coder-30B-A3B-Instruct-8bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T141921Z-1829b16-Qwen3-Coder-30B-A3B-Instruct-8bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T14:19:21Z",
+  "git_sha": "1829b16",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.37,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T143407Z-2eeafad-Devstral-Small-2-24B-Instruct-2512-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T143407Z-2eeafad-Devstral-Small-2-24B-Instruct-2512-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T14:34:07Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.37,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T145241Z-2eeafad-Seed-OSS-36B-Instruct-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T145241Z-2eeafad-Seed-OSS-36B-Instruct-4bit-math-hard.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T14:52:41Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Seed-OSS-36B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [],
+  "errors": [
+    "lm-eval/minerva_math500: exited 1: 2026-04-11:10:52:42 WARNING  [config.evaluate_config:281] --limit SHOULD ONLY BE USED FOR TESTING. REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT.\n2026-04-11:10:52:42 INFO     [config.evaluate_config"
+  ]
+}

--- a/data/benchmarks/2026-04-11T151844Z-2eeafad-Qwen3-Next-80B-A3B-Instruct-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T151844Z-2eeafad-Qwen3-Next-80B-A3B-Instruct-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T15:18:44Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.34,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T155022Z-2eeafad-Qwen3-Next-80B-A3B-Thinking-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T155022Z-2eeafad-Qwen3-Next-80B-A3B-Thinking-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T15:50:22Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.08,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T161004Z-2eeafad-GLM-4.5-Air-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T161004Z-2eeafad-GLM-4.5-Air-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T16:10:04Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/GLM-4.5-Air-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.08,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T163039Z-2eeafad-Qwen3.5-122B-A10B-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T163039Z-2eeafad-Qwen3.5-122B-A10B-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T16:30:39Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Qwen3.5-122B-A10B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.08,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T165554Z-2eeafad-gpt-oss-120b-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T165554Z-2eeafad-gpt-oss-120b-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T16:55:54Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/gpt-oss-120b-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.42,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T171249Z-2eeafad-Devstral-2-123B-Instruct-2512-4bit-math-hard.json
+++ b/data/benchmarks/2026-04-11T171249Z-2eeafad-Devstral-2-123B-Instruct-2512-4bit-math-hard.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T17:12:49Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "math-hard",
+  "model": "mlx-community/Devstral-2-123B-Instruct-2512-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "minerva_math500",
+      "metric": "math_verify",
+      "value": 0.42,
+      "unit": "ratio",
+      "tags": {
+        "task": "minerva_math500",
+        "limit": "100"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T185225Z-2eeafad-Qwen3-Coder-30B-A3B-Instruct-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T185225Z-2eeafad-Qwen3-Coder-30B-A3B-Instruct-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T18:52:25Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "0.98"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "1.42"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "0.75"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "5.11"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T185534Z-2eeafad-Qwen3-Coder-30B-A3B-Instruct-8bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T185534Z-2eeafad-Qwen3-Coder-30B-A3B-Instruct-8bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T18:55:34Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "1.51"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "1.14"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "0.53"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "7.23"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T185905Z-2eeafad-Devstral-Small-2-24B-Instruct-2512-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T185905Z-2eeafad-Devstral-Small-2-24B-Instruct-2512-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T18:59:05Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "1.57"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "1.42"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "1.08"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "9.52"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T190240Z-2eeafad-Seed-OSS-36B-Instruct-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T190240Z-2eeafad-Seed-OSS-36B-Instruct-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T19:02:40Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Seed-OSS-36B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "14.44"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "14.31"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "6.42"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "15.50"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T190628Z-2eeafad-Qwen3-Next-80B-A3B-Instruct-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T190628Z-2eeafad-Qwen3-Next-80B-A3B-Instruct-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T19:06:28Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "1.32"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "1.82"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "1.02"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "7.01"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T191038Z-2eeafad-Qwen3-Next-80B-A3B-Thinking-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T191038Z-2eeafad-Qwen3-Next-80B-A3B-Thinking-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T19:10:38Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "9.47"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "6.14"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "6.47"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "10.03"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T191340Z-2eeafad-GLM-4.5-Air-4bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T191340Z-2eeafad-GLM-4.5-Air-4bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T19:13:40Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/GLM-4.5-Air-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "4.67"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 0.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "False",
+        "elapsed_s": "4.65"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "3.33"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "8.54"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T191612Z-2eeafad-Qwen3-Next-80B-A3B-Instruct-8bit-tool-calling.json
+++ b/data/benchmarks/2026-04-11T191612Z-2eeafad-Qwen3-Next-80B-A3B-Instruct-8bit-tool-calling.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T19:16:12Z",
+  "git_sha": "2eeafad",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "tool-calling",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "should-call-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "1.71"
+      }
+    },
+    {
+      "name": "both-args",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "True",
+        "called_tool": "True",
+        "elapsed_s": "1.72"
+      }
+    },
+    {
+      "name": "no-tool-needed",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "0.88"
+      }
+    },
+    {
+      "name": "ambiguous-no-tool",
+      "metric": "accuracy",
+      "value": 1.0,
+      "unit": "bool",
+      "tags": {
+        "expect_tool": "False",
+        "called_tool": "False",
+        "elapsed_s": "9.17"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/docs/mlx-benchmarks-history.md
+++ b/docs/mlx-benchmarks-history.md
@@ -1,10 +1,122 @@
-<!-- cspell:words TTFT hellaswag parameterize keyerror -->
+<!-- cspell:words TTFT hellaswag parameterize keyerror multimodal Hendrycks -->
+<!-- cspell:words evalplus humaneval mbpp sympy minerva bigcode codegen toks -->
+<!-- cspell:words setrlimit RLIMIT antlr unloadable vllm mlx -->
 # MLX Benchmark History
 
 Archived narratives for prior benchmark sessions. The current summary lives in
 [`mlx-benchmarks.md`](mlx-benchmarks.md); auto-generated tables there always show
 the latest 5 runs per suite. Entries here are kept as human-readable context for
 configuration decisions and multi-model baselines.
+
+## 2026-04-11 — Phase B sweep, multimodal incident, benchmark pivot
+
+### The multimodal incident
+
+On 2026-02-24, HuggingFace upstream silently republished
+`mlx-community/Qwen3.5-35B-A3B-4bit` as a multimodal variant
+(`Qwen3_5MoeForConditionalGeneration`, `pipeline_tag: image-text-to-text`,
+sha `1e20fd8d42056f870933bf98ca6211024744f7ec`). The prior PR 465 default
+pointed at this model. Any fresh Claude Code session on main after that date
+raised a `TypeError: cannot unpack non-iterable NoneType object` from
+`vllm-mlx` `load_model_with_fallback`. Swapping the default was mandatory
+regardless of benchmark outcomes.
+
+Detection happened during Phase B smoke testing when a fresh Claude Code
+session could not load the default. HF API inspection via
+`curl .../api/models/<id>` showed the drift. Follow-up issue 3
+(HF pipeline_tag drift guard in `nix flake check`) was filed so this class
+of bug is caught automatically on future darwin-rebuilds.
+
+### Benchmark infrastructure: four blockers, one pivot
+
+The Phase A infrastructure commits (61cda7f, 939535e, 2c59f0d from the
+post-PR-465 work) wired up two new suites: `evalplus` (rigorous code gen via
+HumanEval+ / MBPP+) and `math-hard` (structured reasoning via
+Hendrycks MATH500 + leaderboard hard). Exercising them surfaced four
+independent bugs:
+
+1. **`max_length=2048` default** in lm-eval's `local-chat-completions`
+   backend. Combined with `max_gen_toks=1024`, only ~1023 tokens remain for
+   the prompt. Chat-wrapped HumanEval prompts blow through it and responses
+   get truncated mid-word (observed: `"Tru"` instead of `"True"`, `"goa"`
+   instead of `"goal"`). Fix: `max_length=32768` in the `mlx-eval` wrapper
+   `model_args`.
+
+2. **Completion-style tasks fail on chat models.** `humaneval_plus`,
+   `mbpp_plus`, and `humaneval` are raw-continuation tasks that expect a base
+   model to pick up from a function signature. Chat models wrap code in
+   markdown blocks with narrative prose and score 0% — the extractors only
+   prepend the signature to the prose prefix and lose the actual code. The
+   `_instruct` variants (`humaneval_instruct`, `mbpp_plus_instruct`) have
+   different extractors but the same fundamental issue with markdown code
+   blocks.
+
+3. **Standalone evalplus package RLIMIT on macOS.** `evalplus.codegen` works
+   cleanly via the OpenAI backend against vllm-mlx (generations are perfect),
+   but `evalplus.evaluate`'s `reliability_guard` calls
+   `resource.setrlimit(RLIMIT_AS, ...)` which raises
+   `ValueError: current limit exceeds maximum limit` on Darwin. Every sample
+   errors during sandbox setup, every score is 0. `--i_just_wanna_run` does
+   not bypass this.
+
+4. **`lm-eval[math]` extras required** for `minerva_math*` tasks (sympy,
+   math_verify, antlr4-python3-runtime).
+
+### The pivot
+
+Dropped the `evalplus` coding suite from this PR. The suite is stubbed with
+an informative skip record (`collect-results.py::run_evalplus_suite`) so
+`generate-summary.py` and schema validation keep working and the suite name
+stays registered. Follow-up issues track proper coding benchmark paths:
+
+- Issue 1: Docker-based EvalPlus scorer (bypass macOS RLIMIT_AS)
+- Issue 6: Vendor `humaneval_plus_instruct` task YAML for lm-eval
+- Issue 8: bigcode-evaluation-harness evaluation spike
+
+`math-hard` simplified to `minerva_math500 @ 100` only. `leaderboard_math_hard`
+was removed because it's a task group that multiplies `--limit` across 7
+subtasks (560 samples total) and blows past the 30-min per-task timeout.
+`minerva_math500` alone is a sufficient discriminator: Qwen3-Coder-30B scored
+47% math_verify, not saturated.
+
+### Sweep results (Phase B, 2026-04-11)
+
+Hardware: M4 Max 128 GB. Configuration: `lm-eval[api,math]==0.4.11`,
+`max_length=32768`, `num_concurrent=4`, `minerva_math500` @ 100 samples.
+vllm-mlx 0.2.6.
+
+Results table will be populated by `analyze-and-draft-decision.sh` once the
+full 11-model sweep completes.
+
+### Default swap rationale
+
+Swapping from the broken multimodal variant to
+`mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`:
+
+- Loads on vllm-mlx 0.2.6 (confirmed via smoke test)
+- 21 GB RAM, well within the 108 GB budget
+- Qwen3 MoE architecture family — same family as the prior default
+- 47% math_verify on minerva_math500 baseline measurement
+- Dedicated coder tuning — the Coder variant of Qwen3-30B-A3B Instruct,
+  designed for software engineering tasks
+
+If any candidate in the sweep beat this score by ≥ 3 pp, the default would
+swap to the winner. Otherwise this is the rescue baseline.
+
+### Takeaway
+
+The `evalplus` + HumanEval family was designed in 2021 for GPT-3-style base
+models. The 2023-2025 chat-instruct tuning revolution broke their implicit
+output-format assumptions. For coding benchmarks on chat models, reach for
+purpose-built harnesses (evalplus standalone, bigcode-evaluation-harness) —
+not the decade-old lm-eval task definitions. Math benchmarks are more
+forgiving because CoT prompting is the natural output format.
+
+mlx-community is "best-effort community quants", not a stable artifact
+repository. Capture `sha` in every benchmark result and verify `pipeline_tag`
+via the HF API before trusting a cached checkpoint.
+
+---
 
 ## 2026-03-22 — Full Suite with Tool Calling & Code Accuracy
 

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -104,17 +104,18 @@ mlx-eval --tasks hellaswag --limit 100
 
 | Date | SHA | Model | Task | Score | Metric | Samples |
 |------|-----|-------|------|-------|--------|---------|
-| 2026-04-10 11:19 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | should-call-tool | 0.0% | accuracy | — |
-| 2026-04-10 11:19 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | both-args | 0.0% | accuracy | — |
-| 2026-04-10 11:19 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | no-tool-needed | 100.0% | accuracy | — |
-| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | should-call-tool | 100.0% | accuracy | — |
-| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | both-args | 100.0% | accuracy | — |
-| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | no-tool-needed | 100.0% | accuracy | — |
-| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
-| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | should-call-tool | 0.0% | accuracy | — |
-| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | both-args | 0.0% | accuracy | — |
-| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | no-tool-needed | 100.0% | accuracy | — |
-| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 19:16 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-8bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-11 19:16 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-8bit | both-args | 100.0% | accuracy | — |
+| 2026-04-11 19:16 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-8bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 19:16 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-8bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 19:13 | 2eeafad | GLM-4.5-Air-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-11 19:13 | 2eeafad | GLM-4.5-Air-4bit | both-args | 0.0% | accuracy | — |
+| 2026-04-11 19:13 | 2eeafad | GLM-4.5-Air-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 19:13 | 2eeafad | GLM-4.5-Air-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 19:10 | 2eeafad | Qwen3-Next-80B-A3B-Thinking-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-11 19:10 | 2eeafad | Qwen3-Next-80B-A3B-Thinking-4bit | both-args | 100.0% | accuracy | — |
+| 2026-04-11 19:10 | 2eeafad | Qwen3-Next-80B-A3B-Thinking-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 19:10 | 2eeafad | Qwen3-Next-80B-A3B-Thinking-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
 
 ### Code Accuracy
 
@@ -141,16 +142,20 @@ mlx-eval --tasks hellaswag --limit 100
 
 | Date | SHA | Test | Metric | Value | Unit |
 |------|-----|------|--------|-------|------|
-| 2026-04-11 02:19 | ff66999 | minerva_math500 | math_verify | 0.47 | ratio |
+| 2026-04-11 17:12 | 2eeafad | minerva_math500 | math_verify | 0.42 | ratio |
+| 2026-04-11 16:55 | 2eeafad | minerva_math500 | math_verify | 0.42 | ratio |
+| 2026-04-11 16:30 | 2eeafad | minerva_math500 | math_verify | 0.08 | ratio |
 
 ### Model Comparison Matrix
 
-| Model | Math-Hard (minerva_math500) | Code Accuracy | Tool Calling | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
-|-------|-----------------------------|---------------|--------------|------|------------|--------------------------------------------|---------------------|
-| Devstral-2-123B-Instruct-2512-4bit | — | 0% (0/2) | 25% (1/4) | — | 2.5 tok/s | — | — |
-| Qwen3-Coder-30B-A3B-Instruct-4bit | 0.47 | — | — | — | — | — | — |
-| Qwen3.5-122B-A10B-4bit | — | 66% | 100% | 16.50s | 14.6 tok/s | — | — |
-| gpt-oss-120b-4bit | — | 34% | 50% | 1.24s | 18.9 tok/s | — | — |
+| Model | Tool Calling | Math-Hard (minerva_math500) | Code Accuracy | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
+|-------|--------------|-----------------------------|---------------|------|------------|--------------------------------------------|---------------------|
+| Devstral-2-123B-Instruct-2512-4bit | — | 0.42 | 0% (0/2) | — | 2.5 tok/s | — | — |
+| GLM-4.5-Air-4bit | 50% | — | — | — | — | — | — |
+| Qwen3-Next-80B-A3B-Instruct-8bit | 100% | — | — | — | — | — | — |
+| Qwen3-Next-80B-A3B-Thinking-4bit | 75% | — | — | — | — | — | — |
+| Qwen3.5-122B-A10B-4bit | — | 0.08 | 66% | 16.50s | 14.6 tok/s | — | — |
+| gpt-oss-120b-4bit | — | 0.42 | 34% | 1.24s | 18.9 tok/s | — | — |
 
 <!-- BENCHMARK-TABLE-END -->
 

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -137,7 +137,7 @@ mlx-eval --tasks hellaswag --limit 100
 |------|-----|----------|-------|-----------------|-----|
 | 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
 
-### math-hard
+### Math-Hard (minerva_math500)
 
 | Date | SHA | Test | Metric | Value | Unit |
 |------|-----|------|--------|-------|------|
@@ -145,8 +145,8 @@ mlx-eval --tasks hellaswag --limit 100
 
 ### Model Comparison Matrix
 
-| Model | math-hard | Code Accuracy | Tool Calling | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
-|-------|-----------|---------------|--------------|------|------------|--------------------------------------------|---------------------|
+| Model | Math-Hard (minerva_math500) | Code Accuracy | Tool Calling | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
+|-------|-----------------------------|---------------|--------------|------|------------|--------------------------------------------|---------------------|
 | Devstral-2-123B-Instruct-2512-4bit | — | 0% (0/2) | 25% (1/4) | — | 2.5 tok/s | — | — |
 | Qwen3-Coder-30B-A3B-Instruct-4bit | 0.47 | — | — | — | — | — | — |
 | Qwen3.5-122B-A10B-4bit | — | 66% | 100% | 16.50s | 14.6 tok/s | — | — |

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -1,4 +1,4 @@
-<!-- cspell:words TTFT hellaswag parameterize keyerror safetensor safetensors evalplus MBPP Hendrycks -->
+<!-- cspell:words TTFT hellaswag parameterize keyerror safetensor safetensors evalplus MBPP Hendrycks humaneval mbpp sympy minerva RLIMIT bigcode -->
 # MLX Benchmark Results
 
 Performance tracking for the vllm-mlx inference server across configuration changes.
@@ -59,8 +59,8 @@ mlx-eval --tasks hellaswag --limit 100
 | `coding` | HumanEval pass@1 (saturated; mostly historical) | lm-eval |
 | `reasoning` | GSM8K + HellaSwag + ARC-Challenge | lm-eval |
 | `knowledge` | MMLU + IFEval | lm-eval |
-| `evalplus` | **HumanEval+ + MBPP+** — EvalPlus extended test cases catch 5–15 pp more failures than HumanEval; not saturated by current frontier models | lm-eval |
-| `math-hard` | **Hendrycks MATH500 + leaderboard MATH hard** — competition math, structured multi-step reasoning proxy for code review; Opus-class models sit at 55–75% | lm-eval |
+| `evalplus` | **STUBBED on macOS** — both lm-eval's `*_instruct` tasks and the standalone `evalplus` Python package are broken for chat models on Darwin as of 2026-04-10. lm-eval can't parse markdown code blocks; `evalplus.evaluate`'s `reliability_guard` hits a macOS `RLIMIT_AS` bug. Tracked in follow-up issues (Docker sandbox, bigcode-eval-harness). | stubbed |
+| `math-hard` | **minerva_math500 + leaderboard_math_hard** — chain-of-thought competition math with sympy answer verification. Chat-template-aware. Structured-reasoning proxy for code review. Opus-class sits at 55–75%. | lm-eval |
 | `framework-eval` | Agent framework comparison (LangGraph, Qwen-Agent, smolagents, google-adk) | uv scripts |
 | `capability-comparison` | Full suite vs hardcoded Claude Opus baselines | run_all.sh |
 

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -11,7 +11,7 @@ Performance tracking for the vllm-mlx inference server across configuration chan
 - **OS**: macOS 26.4 (Tahoe)
 - **Server**: vllm-mlx 0.2.6 (OpenAI-compatible API on port 11434)
 - **Client**: `curl` for API latency tests, custom bash script with `footprint`/`vm_stat` for memory-tracked sweeps
-- **Model**: mlx-community/Qwen3.5-35B-A3B-4bit (~20 GB on disk; default as of 2026-04-10)
+- **Model**: mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit (~16 GB on disk; default as of 2026-04-11)
 
 ## How to Run
 
@@ -154,11 +154,18 @@ mlx-eval --tasks hellaswag --limit 100
 
 <!-- BENCHMARK-TABLE-END -->
 
-## Decision (2026-04-10) — Large-model sweep + default swap
+## Decision (2026-04-10) — Large-model sweep + default swap [SUPERSEDED]
+
+> ⚠️ **Superseded on 2026-04-11** — the winner below
+> (`mlx-community/Qwen3.5-35B-A3B-4bit`) was silently republished by HF upstream
+> as a multimodal variant (`Qwen3_5MoeForConditionalGeneration`,
+> `pipeline_tag: image-text-to-text`, sha `1e20fd8d42056f870933bf98ca6211024744f7ec`)
+> on 2026-02-24. vllm-mlx 0.2.6 cannot load it. See the 2026-04-11 decision
+> block below for the rescue swap.
 
 After benchmarking cached large models on M4 Max 128 GB, the winner on every
-dimension is **`mlx-community/Qwen3.5-35B-A3B-4bit`** — _smaller_ than the
-prior default. `programs.mlx.defaultModel` updated to match. Resolves #334.
+dimension was **`mlx-community/Qwen3.5-35B-A3B-4bit`** — _smaller_ than the
+prior default. `programs.mlx.defaultModel` was updated to match.
 
 ### Role winners
 

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -135,13 +135,20 @@ mlx-eval --tasks hellaswag --limit 100
 |------|-----|----------|-------|-----------------|-----|
 | 2026-04-06 04:55 | fd819b9 | _(skipped — no MLX hardware)_ | — | — | — |
 
+### math-hard
+
+| Date | SHA | Test | Metric | Value | Unit |
+|------|-----|------|--------|-------|------|
+| 2026-04-11 02:19 | ff66999 | minerva_math500 | math_verify | 0.47 | ratio |
+
 ### Model Comparison Matrix
 
-| Model | Code Accuracy | Tool Calling | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
-|-------|---------------|--------------|------|------------|--------------------------------------------|---------------------|
-| Devstral-2-123B-Instruct-2512-4bit | 0% (0/2) | 25% (1/4) | — | 2.5 tok/s | — | — |
-| Qwen3.5-122B-A10B-4bit | 66% | 100% | 16.50s | 14.6 tok/s | — | — |
-| gpt-oss-120b-4bit | 34% | 50% | 1.24s | 18.9 tok/s | — | — |
+| Model | math-hard | Code Accuracy | Tool Calling | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
+|-------|-----------|---------------|--------------|------|------------|--------------------------------------------|---------------------|
+| Devstral-2-123B-Instruct-2512-4bit | — | 0% (0/2) | 25% (1/4) | — | 2.5 tok/s | — | — |
+| Qwen3-Coder-30B-A3B-Instruct-4bit | 0.47 | — | — | — | — | — | — |
+| Qwen3.5-122B-A10B-4bit | — | 66% | 100% | 16.50s | 14.6 tok/s | — | — |
+| gpt-oss-120b-4bit | — | 34% | 50% | 1.24s | 18.9 tok/s | — | — |
 
 <!-- BENCHMARK-TABLE-END -->
 

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -62,7 +62,7 @@ mlx-eval --tasks hellaswag --limit 100
 | `reasoning` | GSM8K + HellaSwag + ARC-Challenge | lm-eval |
 | `knowledge` | MMLU + IFEval | lm-eval |
 | `evalplus` | **STUBBED on macOS** — both lm-eval's `*_instruct` tasks and the standalone `evalplus` Python package are broken for chat models on Darwin as of 2026-04-10. lm-eval can't parse markdown code blocks; `evalplus.evaluate`'s `reliability_guard` hits a macOS `RLIMIT_AS` bug. Tracked in follow-up issues (Docker sandbox, bigcode-eval-harness). | stubbed |
-| `math-hard` | **minerva_math500 + leaderboard_math_hard** — chain-of-thought competition math with sympy answer verification. Chat-template-aware. Structured-reasoning proxy for code review. Opus-class sits at 55–75%. | lm-eval |
+| `math-hard` | **minerva_math500 @ 100** — chain-of-thought competition math with sympy answer verification. Chat-template-aware. Structured-reasoning proxy for code review. Opus-class sits at 55–75%. | lm-eval |
 | `framework-eval` | Agent framework comparison (LangGraph, Qwen-Agent, smolagents, google-adk) | uv scripts |
 | `capability-comparison` | Full suite vs hardcoded Claude Opus baselines | run_all.sh |
 

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -1,4 +1,6 @@
-<!-- cspell:words TTFT hellaswag parameterize keyerror safetensor safetensors evalplus MBPP Hendrycks humaneval mbpp sympy minerva RLIMIT bigcode -->
+<!-- cspell:words TTFT hellaswag parameterize keyerror safetensor safetensors -->
+<!-- cspell:words evalplus MBPP Hendrycks humaneval mbpp sympy minerva RLIMIT -->
+<!-- cspell:words bigcode multimodal unloadable codegen setrlimit antlr -->
 # MLX Benchmark Results
 
 Performance tracking for the vllm-mlx inference server across configuration changes.
@@ -188,6 +190,57 @@ prior default. `programs.mlx.defaultModel` updated to match. Resolves #334.
 Parameter count is a poor proxy for capability on tightly-quantized MoE models
 when TTFT dominates UX. 35B-A3B (3B active) is the sweet spot of the
 mlx-community catalog on 128 GB Apple Silicon.
+
+## Decision (2026-04-11) — multimodal incident + math-hard sweep
+
+Two forcing events drove this decision:
+
+1. **The 2026-04-10 default is now broken.** On 2026-02-24 HF upstream silently
+   republished `mlx-community/Qwen3.5-35B-A3B-4bit` as a multimodal variant
+   (`Qwen3_5MoeForConditionalGeneration`, `pipeline_tag: image-text-to-text`,
+   sha `1e20fd8d42056f870933bf98ca6211024744f7ec`). vllm-mlx cannot load it.
+   Every fresh Claude Code session on main raised a TypeError from
+   `load_model_with_fallback`. A replacement default was mandatory regardless
+   of benchmark outcomes.
+2. **The prior `code-accuracy` suite didn't discriminate.** PR #465 benchmarked
+   six large candidates and found none beat the 35B-A3B baseline, but the
+   suite was a regex-scored toy with zero signal. Real benchmarks were needed.
+
+The Phase B sweep replaces `code-accuracy` with `math-hard` (minerva_math500
+@ 100 samples, chain-of-thought sympy-verified competition math) as the
+structured-reasoning proxy for code review, and stubs the `evalplus` coding
+suite because both lm-eval task variants AND the standalone evalplus Python
+package are broken for chat models on macOS (see follow-up issues for details).
+
+### Role winners (2026-04-11)
+
+<!-- Results row will be finalized after full sweep completes. -->
+
+| Role | Model | Rationale |
+|------|-------|-----------|
+| **Default (rescue)** | `Qwen3-Coder-30B-A3B-Instruct-4bit` | Confirmed loading on vllm-mlx 0.2.6, same Qwen3 MoE family as prior default, 47% math_verify on minerva_math500 @ 100 samples, 21 GB RAM. Replaces the unloadable multimodal variant. |
+| **Best math-hard** | _(TBD — top Phase B finisher)_ | Final ranking depends on sweep completion. |
+
+### Benchmark infrastructure fixes (2026-04-11)
+
+Four blockers discovered while exercising the new suites:
+
+1. `lm-eval`'s `local-chat-completions` backend defaults `max_length=2048`,
+   truncating chat-wrapped prompts mid-word. Fixed: `max_length=32768` in
+   wrapper `model_args`.
+2. `humaneval_plus` / `mbpp_plus` / `humaneval_instruct` / `mbpp_plus_instruct`
+   all score 0% on chat models because their extractors can't parse markdown
+   code blocks. No clean lm-eval path exists.
+3. Standalone `evalplus` Python package: `evalplus.codegen` works via the
+   OpenAI backend, but `evalplus.evaluate`'s `reliability_guard` calls
+   `resource.setrlimit(RLIMIT_AS, ...)` which is broken on macOS — every
+   sample errors during sandbox setup.
+4. `minerva_math500` requires `lm-eval[math]` extras
+   (`sympy`, `math_verify`, `antlr4-python3-runtime==4.11`).
+
+Follow-up issues track a Docker-based EvalPlus scorer,
+bigcode-evaluation-harness evaluation, and a
+`humaneval_plus_instruct` task vendoring effort.
 
 ## History
 

--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -48,7 +48,7 @@ in
         {
           name = "mlx.defaultModel";
           actual = mlxCfg.defaultModel;
-          expected = "mlx-community/Qwen3.5-35B-A3B-4bit";
+          expected = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
         }
         {
           name = "mlx.port";

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -15,14 +15,9 @@
       default = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
       description = ''
         Default mlx-community/ HuggingFace model to serve via vllm-mlx.
-
-        Swapped from Qwen3.5-35B-A3B-4bit on 2026-04-11 after HF upstream
-        silently republished that model as a multimodal variant
-        (pipeline_tag: image-text-to-text, sha 1e20fd8d...) that vllm-mlx
-        cannot load. Qwen3-Coder-30B-A3B-Instruct-4bit is the same Qwen3 MoE
-        architecture family, 21 GB estimated RAM, confirmed loading on
-        vllm-mlx 0.2.6, and scored 47% math_verify on minerva_math500
-        (100-sample subset) in the Phase B benchmark sweep.
+        See `docs/mlx-benchmarks.md` for the current benchmark-driven
+        rationale and `docs/mlx-benchmarks-history.md` for historical
+        default-swap context.
       '';
     };
 

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -12,8 +12,18 @@
 
     defaultModel = lib.mkOption {
       type = lib.types.str;
-      default = "mlx-community/Qwen3.5-35B-A3B-4bit";
-      description = "Default mlx-community/ HuggingFace model to serve via vllm-mlx";
+      default = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      description = ''
+        Default mlx-community/ HuggingFace model to serve via vllm-mlx.
+
+        Swapped from Qwen3.5-35B-A3B-4bit on 2026-04-11 after HF upstream
+        silently republished that model as a multimodal variant
+        (pipeline_tag: image-text-to-text, sha 1e20fd8d...) that vllm-mlx
+        cannot load. Qwen3-Coder-30B-A3B-Instruct-4bit is the same Qwen3 MoE
+        architecture family, 21 GB estimated RAM, confirmed loading on
+        vllm-mlx 0.2.6, and scored 47% math_verify on minerva_math500
+        (100-sample subset) in the Phase B benchmark sweep.
+      '';
     };
 
     port = lib.mkOption {

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -132,16 +132,27 @@ in
         '')
 
         # mlx-eval — accuracy evaluation against the live vllm-mlx server API
+        #
         # MLX_EVAL_CONCURRENT controls parallel requests (default 4). vllm-mlx
         # handles concurrent decode via continuous batching, so raising this
         # from the lm-eval default of 1 is the single biggest speedup lever
         # for long-running suites like evalplus and math-hard.
+        #
+        # max_length=32768 is critical: lm-eval's local-chat-completions backend
+        # defaults max_length to 2048, leaving only ~1023 tokens for the prompt
+        # after max_gen_toks. Chat-wrapped HumanEval/MBPP prompts blow through
+        # that instantly and responses get truncated mid-word (observed
+        # 2026-04-10 with Qwen3-Coder-30B). 32k is a comfortable ceiling.
+        #
+        # The [api,math] extras bring in sympy + math_verify + antlr4 for
+        # minerva_math500 and leaderboard_math_hard used by the math-hard suite.
+        #
         # renovate: datasource=pypi depName=lm-eval
         (pkgs.writeShellScriptBin "mlx-eval" ''
           concurrent="''${MLX_EVAL_CONCURRENT:-4}"
-          exec ${pkgs.uv}/bin/uvx --from "lm-eval[api]==0.4.11" lm-eval run \
+          exec ${pkgs.uv}/bin/uvx --from "lm-eval[api,math]==0.4.11" lm-eval run \
             --model local-chat-completions \
-            --model_args "base_url=''${MLX_API_URL:-${apiUrl}}/chat/completions,model=''${MLX_DEFAULT_MODEL:-${cfg.defaultModel}},tokenizer_backend=None,tokenized_requests=False,num_concurrent=''${concurrent},max_retries=3" \
+            --model_args "base_url=''${MLX_API_URL:-${apiUrl}}/chat/completions,model=''${MLX_DEFAULT_MODEL:-${cfg.defaultModel}},tokenizer_backend=None,tokenized_requests=False,num_concurrent=''${concurrent},max_retries=3,max_length=32768" \
             --apply_chat_template \
             "$@"
         '')

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -145,7 +145,7 @@ in
         # 2026-04-10 with Qwen3-Coder-30B). 32k is a comfortable ceiling.
         #
         # The [api,math] extras bring in sympy + math_verify + antlr4 for
-        # minerva_math500 and leaderboard_math_hard used by the math-hard suite.
+        # minerva_math500, which is the math-hard suite task currently run.
         #
         # renovate: datasource=pypi depName=lm-eval
         (pkgs.writeShellScriptBin "mlx-eval" ''

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -132,11 +132,16 @@ in
         '')
 
         # mlx-eval — accuracy evaluation against the live vllm-mlx server API
+        # MLX_EVAL_CONCURRENT controls parallel requests (default 4). vllm-mlx
+        # handles concurrent decode via continuous batching, so raising this
+        # from the lm-eval default of 1 is the single biggest speedup lever
+        # for long-running suites like evalplus and math-hard.
         # renovate: datasource=pypi depName=lm-eval
         (pkgs.writeShellScriptBin "mlx-eval" ''
+          concurrent="''${MLX_EVAL_CONCURRENT:-4}"
           exec ${pkgs.uv}/bin/uvx --from "lm-eval[api]==0.4.11" lm-eval run \
             --model local-chat-completions \
-            --model_args "base_url=''${MLX_API_URL:-${apiUrl}}/chat/completions,model=''${MLX_DEFAULT_MODEL:-${cfg.defaultModel}},tokenizer_backend=None,tokenized_requests=False,num_concurrent=1,max_retries=3" \
+            --model_args "base_url=''${MLX_API_URL:-${apiUrl}}/chat/completions,model=''${MLX_DEFAULT_MODEL:-${cfg.defaultModel}},tokenizer_backend=None,tokenized_requests=False,num_concurrent=''${concurrent},max_retries=3" \
             --apply_chat_template \
             "$@"
         '')

--- a/scripts/benchmarks/collect-results.py
+++ b/scripts/benchmarks/collect-results.py
@@ -540,7 +540,7 @@ def run_lm_eval_suite(model: str, tasks: list[tuple[str, int]]) -> tuple[list[di
                  "--confirm_run_unsafe_code",
                  "--output_path", f"/tmp/mlx-eval-{task_name}"],
                 capture_output=True, text=True,
-                timeout=1800,  # 30 min per task
+                timeout=7200,  # 2 h per task (minerva_math500 @ 100 is ~18 min)
                 env={
                     **os.environ,
                     "MLX_DEFAULT_MODEL": model,
@@ -562,9 +562,11 @@ def run_lm_eval_suite(model: str, tasks: list[tuple[str, int]]) -> tuple[list[di
             errors_list.append(f"lm-eval/{task_name}: exited {proc.returncode}: {proc.stderr[:200]}")
             continue
 
-        # Parse lm-eval output from results JSON
+        # Parse lm-eval output from results JSON.
+        # lm-eval writes to <output_path>/<model_name>/results_<timestamp>.json
+        # (not bare results.json), so the glob must match the timestamped form.
         results_dir = Path(f"/tmp/mlx-eval-{task_name}")
-        result_files = sorted(results_dir.glob("**/results.json")) if results_dir.exists() else []
+        result_files = sorted(results_dir.glob("**/results_*.json")) if results_dir.exists() else []
 
         if not result_files:
             # Try parsing from stdout — lm-eval prints a summary table
@@ -681,18 +683,20 @@ def run_math_hard_suite(model: str) -> tuple[list[dict], list[str]]:
     used in code review.
 
     Uses minerva_math500 (chain-of-thought variant designed for chat models)
-    instead of hendrycks_math500 (loglikelihood variant designed for base
-    models). Both cover the same MATH500 test set; minerva adds CoT prompting
-    and a sympy-based answer extractor that works with chat templates.
+    with sympy-based math_verify scoring. Covers 500 Hendrycks MATH problems
+    across algebra, geometry, number theory, etc.
 
-    leaderboard_math_hard is a group of 7 subject-specific hard subtasks that
-    already uses generate_until + CoT, so it works fine with chat models.
+    leaderboard_math_hard was originally included but removed on 2026-04-10:
+    it's a task group that applies --limit PER subtask, expanding 80 into
+    7 × 80 = 560 samples and blowing past the 30-min per-task timeout. The
+    minerva_math500 task alone is a sufficient discriminator (47% on
+    Qwen3-Coder-30B, not saturated) and completes in ~18 min/model.
 
-    See run_evalplus_suite for the sample-limit rationale.
+    Verified on 2026-04-10 with Qwen3-Coder-30B-A3B-Instruct-4bit:
+      minerva_math500 @ 100 samples, math_verify: 0.47 (47%), wall: 17m48s
     """
     return run_lm_eval_suite(model, [
         ("minerva_math500", 100),
-        ("leaderboard_math_hard", 80),
     ])
 
 

--- a/scripts/benchmarks/collect-results.py
+++ b/scripts/benchmarks/collect-results.py
@@ -575,20 +575,37 @@ def run_lm_eval_suite(model: str, tasks: list[tuple[str, int]]) -> tuple[list[di
             result_data = json.loads(result_files[-1].read_text())
             task_results = result_data.get("results", {})
 
+            # lm-eval emits metric keys as "<metric>,<filter>" where filter is
+            # task-specific (none, create_test, extract_code, ...). Priority
+            # order below picks the most informative metric regardless of filter.
+            # math_verify (sympy-based equivalence checker) is preferred over
+            # exact_match for minerva_math500 since it handles mathematically
+            # equivalent answer forms (e.g. 1/2 vs 0.5).
+            metric_priority = (
+                "pass@1", "pass_at_1", "acc_norm", "acc",
+                "math_verify", "exact_match", "exact_match_strict",
+            )
             for task_key, metrics in task_results.items():
-                # lm-eval uses various metric names: acc, acc_norm, exact_match, pass@1, etc.
-                for metric_name in ("acc,none", "acc_norm,none", "exact_match,none",
-                                    "pass@1,none", "acc", "acc_norm", "exact_match"):
-                    if metric_name in metrics:
-                        score = metrics[metric_name]
-                        results.append({
-                            "name": task_key,
-                            "metric": metric_name.split(",")[0],
-                            "value": round(float(score), 4),
-                            "unit": "ratio",
-                            "tags": {"task": task_name, "limit": str(limit)},
-                        })
+                picked = None
+                for metric_prefix in metric_priority:
+                    for full_key in metrics:
+                        if full_key == metric_prefix or full_key.startswith(f"{metric_prefix},"):
+                            # Skip stderr twins
+                            if "_stderr" in full_key:
+                                continue
+                            picked = (metric_prefix, metrics[full_key])
+                            break
+                    if picked:
                         break
+                if picked:
+                    metric_prefix, score = picked
+                    results.append({
+                        "name": task_key,
+                        "metric": metric_prefix,
+                        "value": round(float(score), 4),
+                        "unit": "ratio",
+                        "tags": {"task": task_name, "limit": str(limit)},
+                    })
 
         except (json.JSONDecodeError, OSError) as e:
             errors_list.append(f"lm-eval/{task_name}: could not parse results: {e}")
@@ -619,32 +636,62 @@ def run_knowledge_suite(model: str) -> tuple[list[dict], list[str]]:
 
 
 def run_evalplus_suite(model: str) -> tuple[list[dict], list[str]]:
-    """Rigorous code generation: HumanEval+ and MBPP+ from EvalPlus.
+    """EvalPlus coding suite — STUBBED on 2026-04-10 pending a working harness.
 
-    These extend the original HumanEval/MBPP test sets with significantly more
-    edge-case test cases — frontier models typically lose 5–15 percentage points
-    going from the saturated original to the Plus variants.
+    Two attempted backends both failed on macOS with chat models:
 
-    Limits are intentionally short of the full sets. At ~30s/sample with
-    num_concurrent=4 on an M4 Max, the full suites (164 + 378 = 542 samples)
-    would take ~4.5 hours per model. The 60/60 subset still gives enough
-    discriminative signal to rank candidates with ~6 pp margin of error.
-    Bump to full sets for final head-to-head runs on the top 2 finishers.
+    1. lm-eval's humaneval_instruct / mbpp_plus_instruct tasks: max_length fix
+       lets generations complete, but the extractors can't parse markdown code
+       blocks from chat-model responses. Every response is narrative + ```python
+       block + more narrative, and the extractor returns the function signature
+       concatenated with prose. Every score comes back 0.
+
+    2. Standalone `evalplus` Python package (evalplus.codegen + evalplus.evaluate):
+       codegen works and produces clean code via the OpenAI backend against
+       vllm-mlx, but evalplus.evaluate's reliability_guard calls
+       resource.setrlimit(RLIMIT_AS, ...) which is broken on macOS — every
+       sample errors out during sandbox setup, every score is 0.
+
+    Follow-up issues track (a) running evalplus.evaluate in a Docker container,
+    (b) evaluating bigcode-evaluation-harness which has native chat-model
+    support, and (c) vendoring a humaneval_plus_instruct YAML into lm-eval.
+
+    Until one of those ships, this suite returns a single skip record so
+    downstream tooling (generate-summary.py, schema validation) doesn't
+    fall over, and the suite name stays registered in the enum.
     """
-    return run_lm_eval_suite(model, [
-        ("humaneval_plus", 60),
-        ("mbpp_plus", 60),
-    ])
+    return [{
+        "name": "evalplus",
+        "metric": "skipped",
+        "value": 0,
+        "unit": "ratio",
+        "tags": {
+            "task": "evalplus",
+            "status": "skipped",
+            "reason": "lm-eval extractor broken on markdown code blocks; "
+                      "evalplus.evaluate broken on macOS RLIMIT_AS; "
+                      "tracked in follow-up issues",
+            "model": model,
+        },
+    }], []
 
 
 def run_math_hard_suite(model: str) -> tuple[list[dict], list[str]]:
     """Competition math reasoning — proxy for structured multi-step thinking
-    used in code review. Hendrycks MATH500 + leaderboard hard subset.
+    used in code review.
+
+    Uses minerva_math500 (chain-of-thought variant designed for chat models)
+    instead of hendrycks_math500 (loglikelihood variant designed for base
+    models). Both cover the same MATH500 test set; minerva adds CoT prompting
+    and a sympy-based answer extractor that works with chat templates.
+
+    leaderboard_math_hard is a group of 7 subject-specific hard subtasks that
+    already uses generate_until + CoT, so it works fine with chat models.
 
     See run_evalplus_suite for the sample-limit rationale.
     """
     return run_lm_eval_suite(model, [
-        ("hendrycks_math500", 100),
+        ("minerva_math500", 100),
         ("leaderboard_math_hard", 80),
     ])
 

--- a/scripts/benchmarks/collect-results.py
+++ b/scripts/benchmarks/collect-results.py
@@ -624,20 +624,28 @@ def run_evalplus_suite(model: str) -> tuple[list[dict], list[str]]:
     These extend the original HumanEval/MBPP test sets with significantly more
     edge-case test cases — frontier models typically lose 5–15 percentage points
     going from the saturated original to the Plus variants.
+
+    Limits are intentionally short of the full sets. At ~30s/sample with
+    num_concurrent=4 on an M4 Max, the full suites (164 + 378 = 542 samples)
+    would take ~4.5 hours per model. The 60/60 subset still gives enough
+    discriminative signal to rank candidates with ~6 pp margin of error.
+    Bump to full sets for final head-to-head runs on the top 2 finishers.
     """
     return run_lm_eval_suite(model, [
-        ("humaneval_plus", 164),  # full HumanEval+ set
-        ("mbpp_plus", 378),       # full MBPP+ sanitized set
+        ("humaneval_plus", 60),
+        ("mbpp_plus", 60),
     ])
 
 
 def run_math_hard_suite(model: str) -> tuple[list[dict], list[str]]:
     """Competition math reasoning — proxy for structured multi-step thinking
     used in code review. Hendrycks MATH500 + leaderboard hard subset.
+
+    See run_evalplus_suite for the sample-limit rationale.
     """
     return run_lm_eval_suite(model, [
-        ("hendrycks_math500", 500),
-        ("leaderboard_math_hard", 200),
+        ("hendrycks_math500", 100),
+        ("leaderboard_math_hard", 80),
     ])
 
 

--- a/scripts/benchmarks/generate-summary.py
+++ b/scripts/benchmarks/generate-summary.py
@@ -272,6 +272,11 @@ def _summarize_run(suite: str, run: dict) -> str:
     errors = run.get("errors", [])
     if not results and not errors:
         return "—"
+    # Suite-level skip sentinel: a single record with metric=="skipped" means
+    # the suite is intentionally not run (see run_evalplus_suite for the
+    # macOS/chat-model incompatibility reason).
+    if len(results) == 1 and results[0].get("metric") == "skipped":
+        return "skipped"
 
     if suite == "throughput":
         # Peak sustained tok/s across the sweep is the headline number.

--- a/scripts/benchmarks/generate-summary.py
+++ b/scripts/benchmarks/generate-summary.py
@@ -35,6 +35,8 @@ SUITE_LABELS = {
     "coding": "Coding (HumanEval)",
     "reasoning": "Reasoning (GSM8K / HellaSwag / ARC)",
     "knowledge": "Knowledge (MMLU / IFEval)",
+    "evalplus": "EvalPlus (stubbed)",
+    "math-hard": "Math-Hard (minerva_math500)",
 }
 
 


### PR DESCRIPTION
<!-- cspell:words evalplus RLIMIT setrlimit codegen MBPP rlimit multimodal humaneval mbpp minerva bigcode sympy vllm mlx unloadable toks antlr -->

# Phase B MLX Benchmark Sweep — PR Body Draft

## Summary

- Pivot the `evalplus` + `math-hard` benchmark suites to work with chat models
  served via vllm-mlx
- Ship a post-multimodal-incident default model swap (former default was
  silently republished as unloadable multimodal variant)
- Record real math-hard results for ~11 candidate MLX models in the 13–80 GB
  range on M4 Max 128 GB

## Context — why the default swap is mandatory

On 2026-02-24 HuggingFace upstream silently republished
`mlx-community/Qwen3.5-35B-A3B-4bit` as a multimodal variant
(`Qwen3_5MoeForConditionalGeneration`, `pipeline_tag: image-text-to-text`,
sha `1e20fd8d42056f870933bf98ca6211024744f7ec`). vllm-mlx cannot load it —
every fresh Claude Code session on main raised a `TypeError` from
`load_model_with_fallback`. The prior PR 465 default (`Qwen3.5-35B-A3B-4bit`)
was therefore broken on main. This PR swaps the default to the new winner
and closes the incident.

## Benchmark infrastructure fixes

Four independent bugs surfaced while exercising the `evalplus` and `math-hard`
suites added in 61cda7f:

1. **`max_length=2048` default in `local-chat-completions`** — lm-eval's chat
   backend defaults to a 2k context, which with `max_gen_toks=1024` leaves
   ~1023 tokens for the prompt. Chat-wrapped HumanEval + MBPP prompts blow
   through it, responses get truncated mid-word. **Fix**: `max_length=32768`
   in the `mlx-eval` wrapper `model_args`.
2. **Chat models fail on completion-style tasks** — `humaneval_plus`,
   `mbpp_plus`, `humaneval` are raw-continuation tasks. Chat models wrap code
   in markdown and score 0%. Instruct variants (`humaneval_instruct`,
   `mbpp_plus_instruct`) have different extractors but still fail on markdown
   blocks — the extractor prepends the signature to prose and loses the code.
3. **Standalone `evalplus` package RLIMIT_AS on macOS** — `evalplus.codegen`
   works cleanly via the OpenAI backend against vllm-mlx, but
   `evalplus.evaluate`'s `reliability_guard` calls
   `resource.setrlimit(RLIMIT_AS, ...)` which is broken on Darwin. Every
   sample errors out during sandbox setup, every score is 0. `--i_just_wanna_run`
   does not bypass this.
4. **`lm-eval[math]` extras required** — `minerva_math*` and
   `leaderboard_math*` need `sympy`, `math_verify`, and
   `antlr4-python3-runtime==4.11`.

## Pivot decision

Dropping the `evalplus` coding suite from this PR. The suite is stubbed with
an informative skip record so `generate-summary.py` and schema validation keep
working, and the suite name stays registered in the enum for future use.
Ranking is now done on `math-hard` (working, chat-compatible via
`minerva_math500`) plus the existing `tool-calling` suite from PR 465.

## Wrapper changes

- `mlx-eval`: `lm-eval[api,math]==0.4.11`, `max_length=32768`, honors
  `MLX_EVAL_CONCURRENT` (default 4)
- `run_evalplus_suite`: returns a `skipped` record with the reason and
  follow-up tracking
- `run_math_hard_suite`: simplified to `minerva_math500 @ 100` (removed
  `leaderboard_math_hard` which is a task group that multiplied `--limit`
  across 7 subtasks and hit the 30-min timeout)
- Result parser: prefix-match for filter-suffixed metric keys
  (`pass@1,create_test`, `math_verify,none`, etc.)
- Result glob: `results_*.json` instead of bare `results.json`
- Per-task timeout bumped from 30 min to 2 h

## New benchmark results

See `docs/mlx-benchmarks.md` math-hard section. Summary of candidates
measured this arc (sample: minerva_math500 @ 100, metric: math_verify):

```text
## Ranked (highest math_verify first)

0.47  mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit
0.42  mlx-community/gpt-oss-120b-4bit
0.42  mlx-community/Devstral-2-123B-Instruct-2512-4bit
0.37  mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit
0.37  mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit
0.34  mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit
0.08  mlx-community/Qwen3.5-122B-A10B-4bit
0.08  mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
0.08  mlx-community/GLM-4.5-Air-4bit
```

## Default model swap rationale

Files updated:

- `modules/mlx/options.nix:15` — `default = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit"` (rescue baseline; may be updated to sweep winner in a follow-up commit)
- `lib/checks/mlx.nix:51` — matching `expected` in `mlx-defaults-regression`
- `docs/mlx-benchmarks.md` — dated decision block
- `docs/mlx-benchmarks-history.md` — narrative entry

## Follow-up issues

Filed as separate issues to keep this PR focused:

- #472 feat(benchmarks): run evalplus.evaluate in Docker to bypass macOS RLIMIT_AS bug
- #473 chore(benchmarks): free /Volumes/HuggingFace, download Qwen3-Next-80B-Thinking-8bit and GLM-4.5-Air-8bit
- #474 feat(mlx): add nix flake check validator for defaultModel HF pipeline_tag
- #475 fix(benchmarks): re-run coding/reasoning/knowledge suites on main with max_length=32768
- #476 chore(benchmarks): re-run top math-hard finishers on full minerva_math500 plus EvalPlus
- #477 feat(benchmarks): vendor humaneval_plus_instruct task YAML for chat models
- #478 chore(benchmarks): calibrate MLX_EVAL_CONCURRENT — is continuous batching actually helping?
- #479 research(benchmarks): evaluate bigcode-evaluation-harness for chat-model code benchmarks
- #480 fix(benchmarks): record vllm-mlx version in result JSON system block

Closes #334.

## Test plan

- [x] `nix flake check` green (all 16 checks including 5 MLX regression tests)
- [x] `sudo darwin-rebuild switch --flake "$HOME/git/nix-darwin/main"
      --override-input nix-ai "$HOME/git/nix-ai/chore/benchmark-large-mlx-models"`
      succeeds
- [x] Fresh Claude Code session: `mlx-status` shows new default loads
- [x] Coding prompt against new default returns actual code (not a TypeError)
- [x] `uv run scripts/benchmarks/validate-schema.py data/benchmarks/*.json`
      passes on every new result
- [x] `uv run scripts/benchmarks/generate-summary.py --dry-run` stays under
      50 KB file-size limit
- [x] CI green: AI Merge Gate, Benchmark CI, CI Gate, CodeQL

(claude)
