### PR TITLE
docs(bench): mark 2026-04-10 benchmark report as historical (Gemini 2.5 decom)

### DIFF
--- a/docs/session-reports/2026-04-10-bifrost-benchmark-session.md
+++ b/docs/session-reports/2026-04-10-bifrost-benchmark-session.md
@@ -1,7 +1,24 @@
-<!-- cspell:words mistralai ttft jsonc -->
+<!-- cspell:words mistralai ttft jsonc decom -->
 # Bifrost AI Gateway — Live Benchmark Session
 
 **Date:** 2026-04-10 · **Umbrella:** [JacobPEvans/nix-ai#450](https://github.com/JacobPEvans/nix-ai/issues/450)
+
+> **HISTORICAL — DO NOT COPY MODEL IDENTIFIERS FROM THIS REPORT.**
+>
+> This report references `gemini-2.5-flash` in Bench H, Bench H2, and
+> Finding #2. **Gemini 2.5 Flash is a decommissioned model and must not
+> be used in new code or configuration.** The benchmark data is retained
+> here for historical validation of Bifrost gateway routing behavior and
+> the Gemini thinking-model reasoning-token pattern (which is stable
+> across all current Gemini thinking-model variants). Any new work should
+> target the current supported Gemini models (e.g. `gemini-3-pro-preview`,
+> current flash variants).
+>
+> The general `max_tokens >= 100` rule-of-thumb from Finding #2 **is still
+> valid** for all Gemini thinking models — the rule concerns the
+> reasoning-token API surface, not a specific model version. See
+> `JacobPEvans/ai-assistant-instructions#553` for the model-agnostic
+> guidance now in the canonical Model Routing Rules.
 
 Post-activation validation of Bifrost after the PAL → Bifrost migration.
 Stress tests against local MLX + cloud providers. All local tests ran on

--- a/docs/session-reports/2026-04-10-bifrost-benchmark-session.md
+++ b/docs/session-reports/2026-04-10-bifrost-benchmark-session.md
@@ -5,20 +5,20 @@
 
 > **HISTORICAL — DO NOT COPY MODEL IDENTIFIERS FROM THIS REPORT.**
 >
-> This report references `gemini-2.5-flash` in Bench H, Bench H2, and
-> Finding #2. **Gemini 2.5 Flash is a decommissioned model and must not
-> be used in new code or configuration.** The benchmark data is retained
-> here for historical validation of Bifrost gateway routing behavior and
-> the Gemini thinking-model reasoning-token pattern (which is stable
-> across all current Gemini thinking-model variants). Any new work should
-> target the current supported Gemini models (e.g. `gemini-3-pro-preview`,
-> current flash variants).
+> This report discusses Gemini 2.5 Flash (decommissioned) in Bench H,
+> Bench H2, and Finding #2. **Gemini 2.5 Flash is a decommissioned model
+> and must not be used in new code or configuration.** The benchmark
+> data is retained here for historical validation of Bifrost gateway
+> routing behavior and the Gemini thinking-model reasoning-token pattern
+> (which appears stable across current Gemini thinking-model variants).
+> Use the current supported Gemini models listed in the canonical Model
+> Routing Rules rather than copying any model identifiers from this report.
 >
 > The general `max_tokens >= 100` rule-of-thumb from Finding #2 **is still
 > valid** for all Gemini thinking models — the rule concerns the
 > reasoning-token API surface, not a specific model version. See
-> `JacobPEvans/ai-assistant-instructions#553` for the model-agnostic
-> guidance now in the canonical Model Routing Rules.
+> [JacobPEvans/ai-assistant-instructions#553](https://github.com/JacobPEvans/ai-assistant-instructions/pull/553)
+> for the model-agnostic guidance now in the canonical Model Routing Rules.
 
 Post-activation validation of Bifrost after the PAL → Bifrost migration.
 Stress tests against local MLX + cloud providers. All local tests ran on


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450, JacobPEvans/ai-assistant-instructions#553

## Summary

The merged 2026-04-10 Bifrost benchmark session report at \`docs/session-reports/2026-04-10-bifrost-benchmark-session.md\` references \`gemini-2.5-flash\` in three places (Bench H, Bench H2, Finding #2). **Gemini 2.5 Flash is a decommissioned model and must not be used in new code or configuration.**

Per the repo's benchmark retention policy (historical benchmark data can be retained if clearly flagged as no longer relevant), this PR adds a prominent HISTORICAL callout at the top of the report.

## Changes

- 18-line \`> HISTORICAL — DO NOT COPY MODEL IDENTIFIERS FROM THIS REPORT.\` blockquote inserted between the umbrella link and the \`## Setup\` section
- Explains that \`gemini-2.5-flash\` is decom but the benchmark data is retained for historical Bifrost-routing validation
- Points at the model-agnostic guidance in \`JacobPEvans/ai-assistant-instructions#553\` for the current canonical Model Routing Rules
- Adds \`decom\` to the cspell inline directive
- File still under the 12 KB hard limit (11,121 bytes, was 10,179)

## Why not edit the model IDs in the report body?

The benchmark was literally run against \`gemini-2.5-flash\`. Rewriting the body to say e.g. \`gemini-3-pro-preview\` would falsify the historical record — future readers wouldn't know which model version produced the reasoning-token trap evidence in Finding #2. A clear historical callout at the top is the honest approach: retain the truthful record, prevent accidental copy-paste of decom identifiers into new code.

## Test plan

- [x] Pre-commit passes (markdownlint, cspell with \`decom\` added)
- [x] File size still under 12 KB limit
- [ ] CI passes