### PR TITLE
feat(pal): Phase 5 — disable tools with native/Bifrost equivalents

### DIFF
--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -89,8 +89,16 @@ in
     command = "doppler-mcp";
     args = [ "pal-mcp-server" ];
     env = {
-      # Enable ALL PAL tools (default disables: analyze,refactor,testgen,secaudit,docgen,tracer)
-      DISABLED_TOOLS = "";
+      # Phase 5 of the PAL → Bifrost migration (JacobPEvans/nix-ai#450):
+      # disable the 15 PAL tools that have native Claude Code / Bifrost
+      # equivalents, plus drop `version` (no functional value). Only `clink`
+      # (parallel multi-model) and `consensus` (multi-model voting) remain
+      # enabled — neither has a Bifrost equivalent.
+      #
+      # Audit matrix (15 REPLACE / 2 KEEP / 1 DROP) posted as a comment on
+      # nix-ai#450. See also modules/claude/rules/pal-mcp-policy.md for the
+      # scoped availability-check protocol.
+      DISABLED_TOOLS = "chat,thinkdeep,planner,listmodels,codereview,precommit,debug,analyze,tracer,refactor,testgen,secaudit,docgen,apilookup,challenge,version";
       # 'auto' = PAL picks a model alias per-task; Bifrost then routes the
       # resulting request to the right provider based on the model name.
       # Run PAL's `listmodels` (or curl http://localhost:30080/v1/models)

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -89,20 +89,36 @@ in
     command = "doppler-mcp";
     args = [ "pal-mcp-server" ];
     env = {
-      # Phase 5 of the PAL → Bifrost migration (JacobPEvans/nix-ai#450):
-      # disable the 15 PAL tools that have native Claude Code / Bifrost
-      # equivalents, plus drop `version` (no functional value). Only `clink`
-      # (parallel multi-model) and `consensus` (multi-model voting) remain
-      # enabled — neither has a Bifrost equivalent.
-      #
-      # Audit matrix (15 REPLACE / 2 KEEP / 1 DROP) posted as a comment on
-      # nix-ai#450. See also modules/claude/rules/pal-mcp-policy.md for the
-      # scoped availability-check protocol.
-      DISABLED_TOOLS = "chat,thinkdeep,planner,listmodels,codereview,precommit,debug,analyze,tracer,refactor,testgen,secaudit,docgen,apilookup,challenge,version";
+      # Disable PAL tools that have native Claude Code / Bifrost equivalents,
+      # plus drop `version` (no functional value). Only `clink` (parallel
+      # multi-model) and `consensus` (multi-model voting) remain enabled —
+      # neither has a Bifrost equivalent, and the canonical
+      # `modules/claude/rules/pal-mcp-policy.md` rule scopes PAL's
+      # availability-check protocol to exactly those two tools. The
+      # audit matrix that decided this split was posted as a comment on
+      # JacobPEvans/nix-ai#450.
+      DISABLED_TOOLS = builtins.concatStringsSep "," [
+        "chat"
+        "thinkdeep"
+        "planner"
+        "listmodels"
+        "codereview"
+        "precommit"
+        "debug"
+        "analyze"
+        "tracer"
+        "refactor"
+        "testgen"
+        "secaudit"
+        "docgen"
+        "apilookup"
+        "challenge"
+        "version"
+      ];
       # 'auto' = PAL picks a model alias per-task; Bifrost then routes the
       # resulting request to the right provider based on the model name.
-      # Run PAL's `listmodels` (or curl http://localhost:30080/v1/models)
-      # for current aliases and providers.
+      # `listmodels` is disabled (see above) — query available models via
+      # `curl http://localhost:30080/v1/models` instead.
       DEFAULT_MODEL = "auto";
       # Route PAL through Bifrost AI gateway (localhost:30080) instead of
       # vllm-mlx directly. Bifrost fans out to OpenAI/Gemini/OpenRouter/MLX


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450 — PAL → Bifrost migration umbrella

## Summary

Completes **Phase 5** of the PAL → Bifrost migration. With Bifrost now the primary single-model router for the entire AI stack, the 15 PAL tools that have native Claude Code subagents or direct Bifrost HTTP equivalents are no longer needed. \`version\` is dropped (no functional value). Only \`clink\` (parallel multi-model prompting) and \`consensus\` (multi-model voting/agreement) remain enabled — neither has a Bifrost equivalent and both are documented in \`modules/claude/rules/pal-mcp-policy.md\` as the only remaining in-scope tools.

## Change

One-line update to \`pal.env.DISABLED_TOOLS\` in \`modules/mcp/default.nix\`:

\`\`\`diff
-      DISABLED_TOOLS = \"\";
+      DISABLED_TOOLS = \"chat,thinkdeep,planner,listmodels,codereview,precommit,debug,analyze,tracer,refactor,testgen,secaudit,docgen,apilookup,challenge,version\";
\`\`\`

Plus a comment block above documenting the migration phase, the audit matrix source of truth, and the two kept tools.

## Audit matrix (posted on nix-ai#450 earlier)

| Status | Count | Tools |
|---|---|---|
| **REPLACE** (native/Bifrost equivalent) | 15 | chat, thinkdeep, planner, listmodels, codereview, precommit, debug, analyze, tracer, refactor, testgen, secaudit, docgen, apilookup, challenge |
| **DROP** (no functional value) | 1 | version |
| **KEEP** (no Bifrost equivalent) | 2 | clink, consensus |

Each replacement mapping is documented in the audit matrix comment on #450.

## Verification after merge + darwin-rebuild

\`\`\`bash
# 1. PAL MCP still connects
claude mcp list | grep pal   # ✓ Connected

# 2. Kept tools still available
ToolSearch(\"select:mcp__pal__clink\", max_results=5)       # finds clink
ToolSearch(\"select:mcp__pal__consensus\", max_results=5)   # finds consensus

# 3. Disabled tools no longer available
ToolSearch(\"select:mcp__pal__chat\", max_results=5)        # empty
ToolSearch(\"select:mcp__pal__planner\", max_results=5)     # empty
ToolSearch(\"select:mcp__pal__codereview\", max_results=5)  # empty
\`\`\`

## Post-merge follow-up

After this lands and release-please cuts the next nix-ai release, a companion nix-darwin flake lock bump is needed to pull the new nix-ai version into the live system. Not blocking for this PR.

## Test plan

- [x] \`nix flake check --no-build\` passes all 14 checks
- [x] Pre-commit passes (nixfmt, statix, deadnix)
- [ ] CI passes
- [ ] Post-merge: darwin-rebuild + new Claude session sees pal with only clink/consensus