### PR TITLE
feat(ai-tools): add whisper-cpp and openai-whisper moved from nix-darwin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,8 @@ inputs.nix-ai.inputs.home-manager.follows = "home-manager";
 
 ### Package placement
 
-- `home.packages` (this repo): AI tools, MCP servers, AI-specific CLI wrappers
-- `programs.gh.extensions` (this repo): AI GitHub CLI extensions only
-- `home.file` (this repo): AI tool configuration files (`.claude/`, `.gemini/`, etc.)
-- `environment.systemPackages` (nix-darwin): AI/ML system libs requiring system-level install (whisper-cpp, openai-whisper)
+See the `nix-package-placement` rule — auto-loads for `.nix` files, contains the full
+decision matrix for all four repos including homebrew constraints and on-demand patterns.
 
 ## Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,11 @@ inputs.nix-ai.inputs.home-manager.follows = "home-manager";
 
 ### Package placement
 
-See the `nix-package-placement` rule — auto-loads for `.nix` files, contains the full
-decision matrix for all four repos including homebrew constraints and on-demand patterns.
+See the `nix-package-placement` rule — lives in
+[ai-assistant-instructions/agentsmd/rules/nix-package-placement.md](https://github.com/JacobPEvans/ai-assistant-instructions/blob/main/agentsmd/rules/nix-package-placement.md)
+and auto-loads via path-scoping when `.nix` / `flake.*` files are in context.
+Contains the full decision matrix for all four repos including homebrew constraints
+and on-demand patterns.
 
 ## Key Files
 

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -80,6 +80,15 @@
   # See CURRENT STATUS section at the top of this file for package details.
   packages = with pkgs; [
     # ==========================================================================
+    # Speech-to-Text / Audio AI
+    # ==========================================================================
+    # Moved from nix-darwin environment.systemPackages — these are AI tools,
+    # not system bootstrapping. sox/portaudio remain in nix-darwin (general C libs).
+
+    whisper-cpp # Local speech-to-text (OpenAI Whisper C++ port, CoreML/Metal)
+    openai-whisper # Original OpenAI Whisper (Python, GPU/CPU, broader model support)
+
+    # ==========================================================================
     # Claude Code Ecosystem
     # ==========================================================================
 
@@ -296,12 +305,11 @@
     # ==========================================================================
     # Aider - AI pair programming in the terminal
     # ==========================================================================
-    # Not available in nixpkgs - python package, use pip/pipx
+    # Not available in nixpkgs - python package
     # Source: https://github.com/paul-gauthier/aider
     # PyPI: aider-chat
-    # Note: Using python3.withPackages pipx from common/packages.nix
-    # Install: pipx install aider-chat
-    # This creates a marker comment so users know aider is via pipx
+    # Install: uvx aider-chat  (pipx removed from nix-home — use uvx or nix run instead)
+    # This creates a marker comment so users know aider is via uvx
 
   ];
 }

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -28,17 +28,18 @@
 #    - Benefits: Simple, minimal code, easy version updates
 #    - Pattern: writeShellScriptBin with bunx --bun
 #
-# 4. **pipx** (for Python packages not in nixpkgs)
+# 4. **uvx** (for Python packages not in nixpkgs or version-lagging)
 #    - Standard solution for Python CLI tools
-#    - Installed separately via: pipx install <package>
-#    - Benefits: Isolated environments, easy updates
+#    - Run on-demand: uvx <package>
+#    - Benefits: Isolated environments, always-latest, no global pollution
+#    - Replaced pipx (pipx removed from nix-home — antipattern in Nix env)
 #
 # ============================================================================
 # CURRENT STATUS
 # ============================================================================
 #
 # NIXPKGS PACKAGES (from nixpkgs, available on stable 25.11):
-#   github-mcp-server, terraform-mcp-server
+#   github-mcp-server, terraform-mcp-server, whisper-cpp, openai-whisper
 #
 # HOMEBREW PACKAGES (from modules/darwin/homebrew.nix):
 #   codex: OpenAI Codex CLI (moved from nixpkgs to match claude/gemini pattern)
@@ -56,8 +57,9 @@
 #   hf: huggingface-hub CLI (model downloads, used with HuggingFace MCP)
 #   vllm-mlx: defined in modules/mlx.nix (owns the wrapper + LaunchAgent)
 #
-# PIPX PACKAGES (Python, installed separately):
-#   aider: aider-chat (AI pair programming)
+# UVX ON-DEMAND (documented here; users run uvx <pkg> manually):
+#   aider-chat: AI pair programming (nixpkgs has 0.86.1 but lags upstream;
+#               uvx keeps latest. Run: uvx aider-chat)
 #
 # NOTE: These are home-manager packages, not system packages.
 # Imported in hosts/macbook-m4/home.nix via home.packages.
@@ -305,11 +307,14 @@
     # ==========================================================================
     # Aider - AI pair programming in the terminal
     # ==========================================================================
-    # Not available in nixpkgs - python package
+    # Available in nixpkgs as `aider-chat` but version lags upstream (0.86.1 as of
+    # 2026-04). We intentionally do NOT package it here — users run `uvx aider-chat`
+    # to always get the latest release. Migrating to the nixpkgs package would
+    # trade "always-latest" for "reproducible pin", which is the opposite of our
+    # preference for AI tooling that ships fixes weekly.
     # Source: https://github.com/paul-gauthier/aider
     # PyPI: aider-chat
-    # Install: uvx aider-chat  (pipx removed from nix-home — use uvx or nix run instead)
-    # This creates a marker comment so users know aider is via uvx
+    # Run: uvx aider-chat
 
   ];
 }


### PR DESCRIPTION
## Summary

- Add `whisper-cpp` and `openai-whisper` to `home.packages` in `modules/ai-tools.nix` — these are AI/speech tools and belong in nix-ai, not nix-darwin system packages.
- `sox`/`portaudio` intentionally NOT added here — they're general-purpose C libs that stay system-level in nix-darwin.
- Replace inline Package placement section in `CLAUDE.md` with reference to the new `nix-package-placement` rule.

## Part of a coordinated 5-repo audit

| Repo | What changed |
| ---- | ------------ |
| nix-darwin | Remove whisper tools, comment-group AI brews |
| **nix-ai** (this) | Add whisper-cpp + openai-whisper |
| nix-home | Remove project-scoped tools |
| nix-devenv | Add bats, actionlint, python-base module |
| ai-assistant-instructions | New nix-package-placement decision matrix rule |

## Test plan

- [ ] `nix flake check` passes
- [ ] After `darwin-rebuild switch`, `whisper-cpp --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)