### PR TITLE
chore(benchmarks): add throughput+ttft sweep data (13 models post-Bifrost)

### DIFF
--- a/.file-size.yml
+++ b/.file-size.yml
@@ -2,6 +2,11 @@
 # options.nix: vllm-mlx parameter reference (active + commented-out options)
 # ai-tools: multi-tool AI package definitions
 # mlx-benchmarks: full dated decision history + post-mortems for MLX model sweeps
+#
+# Bumped from 20480 → 32768 when the benchmark summary switched from
+# "last N runs per suite" (which truncated large sweeps) to
+# "latest per (suite, model) pair" (which scales with catalog size).
+# See generate-summary.py for the new logic.
 extended:
-  limit: 20480
+  limit: 32768
   files: [options, ai-tools, mlx-benchmarks, mlx-benchmarks-history]

--- a/data/benchmarks/2026-04-11T202506Z-dc8dc67-DeepSeek-R1-0528-Qwen3-8B-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T202506Z-dc8dc67-DeepSeek-R1-0528-Qwen3-8B-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T20:25:06Z",
+  "git_sha": "dc8dc67",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 38.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "1.30"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 45.3,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "5.65"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 50.8,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "10.07"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 58.7,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "17.44"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T202541Z-dc8dc67-DeepSeek-R1-0528-Qwen3-8B-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T202541Z-dc8dc67-DeepSeek-R1-0528-Qwen3-8B-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T20:25:41Z",
+  "git_sha": "dc8dc67",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.3869,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.4935,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 0.78,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.3869",
+        "warm_avg": "0.4935"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T210515Z-874efc4-Qwen3-Coder-30B-A3B-Instruct-8bit-throughput.json
+++ b/data/benchmarks/2026-04-11T210515Z-874efc4-Qwen3-Coder-30B-A3B-Instruct-8bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:05:15Z",
+  "git_sha": "874efc4",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 29.0,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "1.73"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 38.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "6.65"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 36.7,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "13.94"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 41.2,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "24.87"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T210603Z-874efc4-Qwen3-Coder-30B-A3B-Instruct-8bit-ttft.json
+++ b/data/benchmarks/2026-04-11T210603Z-874efc4-Qwen3-Coder-30B-A3B-Instruct-8bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:06:03Z",
+  "git_sha": "874efc4",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.3757,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.3774,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.0,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.3757",
+        "warm_avg": "0.3774"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T210958Z-874efc4-Qwen3-Next-80B-A3B-Instruct-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T210958Z-874efc4-Qwen3-Next-80B-A3B-Instruct-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:09:58Z",
+  "git_sha": "874efc4",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 20.8,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "2.41"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 25.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "9.89"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 26.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "19.04"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 28.2,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "36.37"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T211106Z-874efc4-Qwen3-Next-80B-A3B-Instruct-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T211106Z-874efc4-Qwen3-Next-80B-A3B-Instruct-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:11:06Z",
+  "git_sha": "874efc4",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.3769,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.3859,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 0.98,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.3769",
+        "warm_avg": "0.3859"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T212023Z-0077a28-Qwen3-Next-80B-A3B-Thinking-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T212023Z-0077a28-Qwen3-Next-80B-A3B-Thinking-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:20:23Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 16.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "3.04"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 22.1,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "11.61"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 24.0,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "21.31"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 25.1,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "40.72"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T212140Z-0077a28-Qwen3-Next-80B-A3B-Thinking-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T212140Z-0077a28-Qwen3-Next-80B-A3B-Thinking-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:21:40Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.4128,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.3504,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.18,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.4128",
+        "warm_avg": "0.3504"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T212512Z-0077a28-Qwen3.5-122B-A10B-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T212512Z-0077a28-Qwen3.5-122B-A10B-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:25:12Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3.5-122B-A10B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 20.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "2.43"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 24.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "10.42"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 23.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "21.47"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 24.2,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "42.25"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T212628Z-0077a28-Qwen3.5-122B-A10B-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T212628Z-0077a28-Qwen3.5-122B-A10B-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:26:28Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3.5-122B-A10B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.703,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.6829,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.03,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.7030",
+        "warm_avg": "0.6829"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T213015Z-0077a28-Qwen3.5-27B-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T213015Z-0077a28-Qwen3.5-27B-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:30:15Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3.5-27B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 18.1,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "2.76"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 22.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "11.39"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 22.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "22.40"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 20.3,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "50.44"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T213142Z-0077a28-Qwen3.5-27B-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T213142Z-0077a28-Qwen3.5-27B-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:31:42Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3.5-27B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.8484,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.8709,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 0.97,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.8484",
+        "warm_avg": "0.8709"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T213529Z-0077a28-Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T213529Z-0077a28-Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:35:29Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 17.1,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "2.93"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 22.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "11.34"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 22.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "22.32"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 22.2,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "46.03"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T213652Z-0077a28-Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T213652Z-0077a28-Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:36:52Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.8146,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.6785,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.2,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.8146",
+        "warm_avg": "0.6785"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T214045Z-0077a28-Qwen3.5-35B-A3B-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T214045Z-0077a28-Qwen3.5-35B-A3B-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:40:45Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 31.1,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "1.61"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 32.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "7.79"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 3.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "142.34"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 29.0,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "35.26"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T214353Z-0077a28-Qwen3.5-35B-A3B-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T214353Z-0077a28-Qwen3.5-35B-A3B-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:43:53Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.634,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.4594,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.38,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.6340",
+        "warm_avg": "0.4594"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T214731Z-0077a28-Qwen3.5-9B-MLX-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T214731Z-0077a28-Qwen3.5-9B-MLX-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:47:31Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Qwen3.5-9B-MLX-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 39.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "1.27"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 55.7,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "4.59"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 63.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "8.08"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 68.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "14.95"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T214800Z-0077a28-Qwen3.5-9B-MLX-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T214800Z-0077a28-Qwen3.5-9B-MLX-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:48:00Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Qwen3.5-9B-MLX-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.5184,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.5941,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 0.87,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.5184",
+        "warm_avg": "0.5941"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T215211Z-0077a28-Seed-OSS-36B-Instruct-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T215211Z-0077a28-Seed-OSS-36B-Instruct-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:52:11Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/Seed-OSS-36B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 16.2,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "3.08"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 18.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "13.73"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 15.8,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "32.49"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 7.7,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "132.32"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T215513Z-0077a28-Seed-OSS-36B-Instruct-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T215513Z-0077a28-Seed-OSS-36B-Instruct-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:55:13Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/Seed-OSS-36B-Instruct-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.7064,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.7929,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 0.89,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.7064",
+        "warm_avg": "0.7929"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T215907Z-0077a28-gemma-4-31b-it-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T215907Z-0077a28-gemma-4-31b-it-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T21:59:07Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/gemma-4-31b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 12.7,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "3.93"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 13.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "18.88"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 18.4,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "27.81"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 17.5,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "58.38"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T220056Z-0077a28-gemma-4-31b-it-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T220056Z-0077a28-gemma-4-31b-it-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T22:00:56Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/gemma-4-31b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 1.0786,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.9986,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.08,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "1.0786",
+        "warm_avg": "0.9986"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T220435Z-0077a28-gemma-4-e4b-it-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T220435Z-0077a28-gemma-4-e4b-it-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T22:04:35Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/gemma-4-e4b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 39.6,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "1.26"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 51.3,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "4.99"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 56.0,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "9.14"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 59.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "17.09"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T220507Z-0077a28-gemma-4-e4b-it-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T220507Z-0077a28-gemma-4-e4b-it-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T22:05:07Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/gemma-4-e4b-it-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.693,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.6729,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.03,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.6930",
+        "warm_avg": "0.6729"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T220928Z-0077a28-gpt-oss-120b-4bit-throughput.json
+++ b/data/benchmarks/2026-04-11T220928Z-0077a28-gpt-oss-120b-4bit-throughput.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T22:09:28Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "throughput",
+  "model": "mlx-community/gpt-oss-120b-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "short-50",
+      "metric": "throughput",
+      "value": 26.0,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "50",
+        "completion_tokens": "50",
+        "elapsed_s": "1.92"
+      }
+    },
+    {
+      "name": "medium-256",
+      "metric": "throughput",
+      "value": 36.1,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "256",
+        "completion_tokens": "256",
+        "elapsed_s": "7.09"
+      }
+    },
+    {
+      "name": "long-512",
+      "metric": "throughput",
+      "value": 41.8,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "512",
+        "completion_tokens": "512",
+        "elapsed_s": "12.24"
+      }
+    },
+    {
+      "name": "long-1024",
+      "metric": "throughput",
+      "value": 44.9,
+      "unit": "tok/s",
+      "tags": {
+        "max_tokens": "1024",
+        "completion_tokens": "1024",
+        "elapsed_s": "22.82"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/data/benchmarks/2026-04-11T221012Z-0077a28-gpt-oss-120b-4bit-ttft.json
+++ b/data/benchmarks/2026-04-11T221012Z-0077a28-gpt-oss-120b-4bit-ttft.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1",
+  "timestamp": "2026-04-11T22:10:12Z",
+  "git_sha": "0077a28",
+  "trigger": "local",
+  "pr_number": null,
+  "suite": "ttft",
+  "model": "mlx-community/gpt-oss-120b-4bit",
+  "system": {
+    "os": "macOS 26.4",
+    "chip": "Apple M4 Max",
+    "memory_gb": 128,
+    "vllm_mlx_version": "unknown",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "name": "cold-avg",
+      "metric": "ttft",
+      "value": 0.7269,
+      "unit": "seconds",
+      "tags": {
+        "type": "cold",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "warm-avg",
+      "metric": "ttft",
+      "value": 0.6588,
+      "unit": "seconds",
+      "tags": {
+        "type": "warm",
+        "samples": "3"
+      }
+    },
+    {
+      "name": "cache-speedup",
+      "metric": "ratio",
+      "value": 1.1,
+      "unit": "x",
+      "tags": {
+        "cold_avg": "0.7269",
+        "warm_avg": "0.6588"
+      }
+    }
+  ],
+  "errors": []
+}

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -88,6 +88,53 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-11 21:59 | 0077a28 | gemma-4-31b-it-4bit | medium-256 | 13.6 | 256 | 18.88 |
 | 2026-04-11 21:59 | 0077a28 | gemma-4-31b-it-4bit | long-512 | 18.4 | 512 | 27.81 |
 | 2026-04-11 21:59 | 0077a28 | gemma-4-31b-it-4bit | long-1024 | 17.5 | 1024 | 58.38 |
+| 2026-04-11 21:52 | 0077a28 | Seed-OSS-36B-Instruct-4bit | short-50 | 16.2 | 50 | 3.08 |
+| 2026-04-11 21:52 | 0077a28 | Seed-OSS-36B-Instruct-4bit | medium-256 | 18.6 | 256 | 13.73 |
+| 2026-04-11 21:52 | 0077a28 | Seed-OSS-36B-Instruct-4bit | long-512 | 15.8 | 512 | 32.49 |
+| 2026-04-11 21:52 | 0077a28 | Seed-OSS-36B-Instruct-4bit | long-1024 | 7.7 | 1024 | 132.32 |
+| 2026-04-11 21:47 | 0077a28 | Qwen3.5-9B-MLX-4bit | short-50 | 39.4 | 50 | 1.27 |
+| 2026-04-11 21:47 | 0077a28 | Qwen3.5-9B-MLX-4bit | medium-256 | 55.7 | 256 | 4.59 |
+| 2026-04-11 21:47 | 0077a28 | Qwen3.5-9B-MLX-4bit | long-512 | 63.4 | 512 | 8.08 |
+| 2026-04-11 21:47 | 0077a28 | Qwen3.5-9B-MLX-4bit | long-1024 | 68.5 | 1024 | 14.95 |
+| 2026-04-11 21:40 | 0077a28 | Qwen3.5-35B-A3B-4bit | short-50 | 31.1 | 50 | 1.61 |
+| 2026-04-11 21:40 | 0077a28 | Qwen3.5-35B-A3B-4bit | medium-256 | 32.9 | 256 | 7.79 |
+| 2026-04-11 21:40 | 0077a28 | Qwen3.5-35B-A3B-4bit | long-512 | 3.6 | 512 | 142.34 |
+| 2026-04-11 21:40 | 0077a28 | Qwen3.5-35B-A3B-4bit | long-1024 | 29.0 | 1024 | 35.26 |
+| 2026-04-11 21:35 | 0077a28 | Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | short-50 | 17.1 | 50 | 2.93 |
+| 2026-04-11 21:35 | 0077a28 | Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | medium-256 | 22.6 | 256 | 11.34 |
+| 2026-04-11 21:35 | 0077a28 | Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | long-512 | 22.9 | 512 | 22.32 |
+| 2026-04-11 21:35 | 0077a28 | Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | long-1024 | 22.2 | 1024 | 46.03 |
+| 2026-04-11 21:30 | 0077a28 | Qwen3.5-27B-4bit | short-50 | 18.1 | 50 | 2.76 |
+| 2026-04-11 21:30 | 0077a28 | Qwen3.5-27B-4bit | medium-256 | 22.5 | 256 | 11.39 |
+| 2026-04-11 21:30 | 0077a28 | Qwen3.5-27B-4bit | long-512 | 22.9 | 512 | 22.40 |
+| 2026-04-11 21:30 | 0077a28 | Qwen3.5-27B-4bit | long-1024 | 20.3 | 1024 | 50.44 |
+| 2026-04-11 21:25 | 0077a28 | Qwen3.5-122B-A10B-4bit | short-50 | 20.6 | 50 | 2.43 |
+| 2026-04-11 21:25 | 0077a28 | Qwen3.5-122B-A10B-4bit | medium-256 | 24.6 | 256 | 10.42 |
+| 2026-04-11 21:25 | 0077a28 | Qwen3.5-122B-A10B-4bit | long-512 | 23.9 | 512 | 21.47 |
+| 2026-04-11 21:25 | 0077a28 | Qwen3.5-122B-A10B-4bit | long-1024 | 24.2 | 1024 | 42.25 |
+| 2026-04-11 21:20 | 0077a28 | Qwen3-Next-80B-A3B-Thinking-4bit | short-50 | 16.5 | 50 | 3.04 |
+| 2026-04-11 21:20 | 0077a28 | Qwen3-Next-80B-A3B-Thinking-4bit | medium-256 | 22.1 | 256 | 11.61 |
+| 2026-04-11 21:20 | 0077a28 | Qwen3-Next-80B-A3B-Thinking-4bit | long-512 | 24.0 | 512 | 21.31 |
+| 2026-04-11 21:20 | 0077a28 | Qwen3-Next-80B-A3B-Thinking-4bit | long-1024 | 25.1 | 1024 | 40.72 |
+| 2026-04-11 21:09 | 874efc4 | Qwen3-Next-80B-A3B-Instruct-4bit | short-50 | 20.8 | 50 | 2.41 |
+| 2026-04-11 21:09 | 874efc4 | Qwen3-Next-80B-A3B-Instruct-4bit | medium-256 | 25.9 | 256 | 9.89 |
+| 2026-04-11 21:09 | 874efc4 | Qwen3-Next-80B-A3B-Instruct-4bit | long-512 | 26.9 | 512 | 19.04 |
+| 2026-04-11 21:09 | 874efc4 | Qwen3-Next-80B-A3B-Instruct-4bit | long-1024 | 28.2 | 1024 | 36.37 |
+| 2026-04-11 21:05 | 874efc4 | Qwen3-Coder-30B-A3B-Instruct-8bit | short-50 | 29.0 | 50 | 1.73 |
+| 2026-04-11 21:05 | 874efc4 | Qwen3-Coder-30B-A3B-Instruct-8bit | medium-256 | 38.5 | 256 | 6.65 |
+| 2026-04-11 21:05 | 874efc4 | Qwen3-Coder-30B-A3B-Instruct-8bit | long-512 | 36.7 | 512 | 13.94 |
+| 2026-04-11 21:05 | 874efc4 | Qwen3-Coder-30B-A3B-Instruct-8bit | long-1024 | 41.2 | 1024 | 24.87 |
+| 2026-04-11 20:25 | dc8dc67 | DeepSeek-R1-0528-Qwen3-8B-4bit | short-50 | 38.4 | 50 | 1.30 |
+| 2026-04-11 20:25 | dc8dc67 | DeepSeek-R1-0528-Qwen3-8B-4bit | medium-256 | 45.3 | 256 | 5.65 |
+| 2026-04-11 20:25 | dc8dc67 | DeepSeek-R1-0528-Qwen3-8B-4bit | long-512 | 50.8 | 512 | 10.07 |
+| 2026-04-11 20:25 | dc8dc67 | DeepSeek-R1-0528-Qwen3-8B-4bit | long-1024 | 58.7 | 1024 | 17.44 |
+| 2026-04-10 11:06 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | short-50 | 1.9 | 50 | 25.95 |
+| 2026-04-10 11:06 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | medium-256 | 2.5 | 256 | 103.61 |
+| 2026-04-10 11:06 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | long-512 | 2.0 | 512 | 257.79 |
+| 2026-04-10 10:46 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | short-50 | 7.7 | 50 | 6.47 |
+| 2026-04-10 10:46 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | medium-256 | 11.1 | 256 | 23.08 |
+| 2026-04-10 10:46 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | long-512 | 10.5 | 511 | 48.82 |
+| 2026-04-10 10:46 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | long-1024 | 11.0 | 1024 | 93.13 |
 
 ### TTFT
 
@@ -102,6 +149,40 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-11 22:00 | 0077a28 | gemma-4-31b-it-4bit | cold-avg | 1.079 | cold |
 | 2026-04-11 22:00 | 0077a28 | gemma-4-31b-it-4bit | warm-avg | 0.999 | warm |
 | 2026-04-11 22:00 | 0077a28 | gemma-4-31b-it-4bit | cache-speedup | 1.080 | — |
+| 2026-04-11 21:55 | 0077a28 | Seed-OSS-36B-Instruct-4bit | cold-avg | 0.706 | cold |
+| 2026-04-11 21:55 | 0077a28 | Seed-OSS-36B-Instruct-4bit | warm-avg | 0.793 | warm |
+| 2026-04-11 21:55 | 0077a28 | Seed-OSS-36B-Instruct-4bit | cache-speedup | 0.890 | — |
+| 2026-04-11 21:48 | 0077a28 | Qwen3.5-9B-MLX-4bit | cold-avg | 0.518 | cold |
+| 2026-04-11 21:48 | 0077a28 | Qwen3.5-9B-MLX-4bit | warm-avg | 0.594 | warm |
+| 2026-04-11 21:48 | 0077a28 | Qwen3.5-9B-MLX-4bit | cache-speedup | 0.870 | — |
+| 2026-04-11 21:43 | 0077a28 | Qwen3.5-35B-A3B-4bit | cold-avg | 0.634 | cold |
+| 2026-04-11 21:43 | 0077a28 | Qwen3.5-35B-A3B-4bit | warm-avg | 0.459 | warm |
+| 2026-04-11 21:43 | 0077a28 | Qwen3.5-35B-A3B-4bit | cache-speedup | 1.380 | — |
+| 2026-04-11 21:36 | 0077a28 | Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | cold-avg | 0.815 | cold |
+| 2026-04-11 21:36 | 0077a28 | Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | warm-avg | 0.678 | warm |
+| 2026-04-11 21:36 | 0077a28 | Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | cache-speedup | 1.200 | — |
+| 2026-04-11 21:31 | 0077a28 | Qwen3.5-27B-4bit | cold-avg | 0.848 | cold |
+| 2026-04-11 21:31 | 0077a28 | Qwen3.5-27B-4bit | warm-avg | 0.871 | warm |
+| 2026-04-11 21:31 | 0077a28 | Qwen3.5-27B-4bit | cache-speedup | 0.970 | — |
+| 2026-04-11 21:26 | 0077a28 | Qwen3.5-122B-A10B-4bit | cold-avg | 0.703 | cold |
+| 2026-04-11 21:26 | 0077a28 | Qwen3.5-122B-A10B-4bit | warm-avg | 0.683 | warm |
+| 2026-04-11 21:26 | 0077a28 | Qwen3.5-122B-A10B-4bit | cache-speedup | 1.030 | — |
+| 2026-04-11 21:21 | 0077a28 | Qwen3-Next-80B-A3B-Thinking-4bit | cold-avg | 0.413 | cold |
+| 2026-04-11 21:21 | 0077a28 | Qwen3-Next-80B-A3B-Thinking-4bit | warm-avg | 0.350 | warm |
+| 2026-04-11 21:21 | 0077a28 | Qwen3-Next-80B-A3B-Thinking-4bit | cache-speedup | 1.180 | — |
+| 2026-04-11 21:11 | 874efc4 | Qwen3-Next-80B-A3B-Instruct-4bit | cold-avg | 0.377 | cold |
+| 2026-04-11 21:11 | 874efc4 | Qwen3-Next-80B-A3B-Instruct-4bit | warm-avg | 0.386 | warm |
+| 2026-04-11 21:11 | 874efc4 | Qwen3-Next-80B-A3B-Instruct-4bit | cache-speedup | 0.980 | — |
+| 2026-04-11 21:06 | 874efc4 | Qwen3-Coder-30B-A3B-Instruct-8bit | cold-avg | 0.376 | cold |
+| 2026-04-11 21:06 | 874efc4 | Qwen3-Coder-30B-A3B-Instruct-8bit | warm-avg | 0.377 | warm |
+| 2026-04-11 21:06 | 874efc4 | Qwen3-Coder-30B-A3B-Instruct-8bit | cache-speedup | 1.000 | — |
+| 2026-04-11 20:25 | dc8dc67 | DeepSeek-R1-0528-Qwen3-8B-4bit | cold-avg | 0.387 | cold |
+| 2026-04-11 20:25 | dc8dc67 | DeepSeek-R1-0528-Qwen3-8B-4bit | warm-avg | 0.493 | warm |
+| 2026-04-11 20:25 | dc8dc67 | DeepSeek-R1-0528-Qwen3-8B-4bit | cache-speedup | 0.780 | — |
+| 2026-04-10 11:18 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | warm-avg | 14.156 | warm |
+| 2026-04-10 10:49 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | cold-avg | 0.694 | cold |
+| 2026-04-10 10:49 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | warm-avg | 0.671 | warm |
+| 2026-04-10 10:49 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | cache-speedup | 1.030 | — |
 
 ### Tool Calling
 
@@ -119,6 +200,50 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-11 19:10 | 2eeafad | Qwen3-Next-80B-A3B-Thinking-4bit | both-args | 100.0% | accuracy | — |
 | 2026-04-11 19:10 | 2eeafad | Qwen3-Next-80B-A3B-Thinking-4bit | no-tool-needed | 100.0% | accuracy | — |
 | 2026-04-11 19:10 | 2eeafad | Qwen3-Next-80B-A3B-Thinking-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 19:06 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-4bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-11 19:06 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-4bit | both-args | 100.0% | accuracy | — |
+| 2026-04-11 19:06 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 19:06 | 2eeafad | Qwen3-Next-80B-A3B-Instruct-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 19:02 | 2eeafad | Seed-OSS-36B-Instruct-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-11 19:02 | 2eeafad | Seed-OSS-36B-Instruct-4bit | both-args | 0.0% | accuracy | — |
+| 2026-04-11 19:02 | 2eeafad | Seed-OSS-36B-Instruct-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 19:02 | 2eeafad | Seed-OSS-36B-Instruct-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 18:59 | 2eeafad | Devstral-Small-2-24B-Instruct-2512-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-11 18:59 | 2eeafad | Devstral-Small-2-24B-Instruct-2512-4bit | both-args | 0.0% | accuracy | — |
+| 2026-04-11 18:59 | 2eeafad | Devstral-Small-2-24B-Instruct-2512-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 18:59 | 2eeafad | Devstral-Small-2-24B-Instruct-2512-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 18:55 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-8bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-11 18:55 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-8bit | both-args | 100.0% | accuracy | — |
+| 2026-04-11 18:55 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-8bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 18:55 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-8bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-11 18:52 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-4bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-11 18:52 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-4bit | both-args | 100.0% | accuracy | — |
+| 2026-04-11 18:52 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-11 18:52 | 2eeafad | Qwen3-Coder-30B-A3B-Instruct-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 11:19 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-10 11:19 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | both-args | 0.0% | accuracy | — |
+| 2026-04-10 11:19 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | both-args | 100.0% | accuracy | — |
+| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 11:02 | 5572dde | Qwen3.5-122B-A10B-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | both-args | 0.0% | accuracy | — |
+| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 10:49 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-10 10:49 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | both-args | 0.0% | accuracy | — |
+| 2026-04-10 10:49 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 10:49 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | should-call-tool | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | both-args | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | should-call-tool | 0.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | both-args | 0.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | no-tool-needed | 100.0% | accuracy | — |
+| 2026-04-10 02:56 | 3b5d3ea | gemma-4-31b-it-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
+| 2026-04-10 02:13 | 3b5d3ea | Qwen3.5-27B-4bit | ambiguous-no-tool | 100.0% | accuracy | — |
 
 ### Code Accuracy
 
@@ -129,6 +254,16 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-10 11:03 | 5572dde | Qwen3.5-122B-A10B-4bit | code-planning | 33.0% | accuracy | — |
 | 2026-04-10 10:56 | 5572dde | gpt-oss-120b-4bit | bug-detection | 67.0% | accuracy | — |
 | 2026-04-10 10:56 | 5572dde | gpt-oss-120b-4bit | code-planning | 0.0% | accuracy | — |
+| 2026-04-10 10:50 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 10:50 | 5572dde | GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | code-planning | 0.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 03:07 | 3b5d3ea | Qwen3.5-35B-A3B-4bit | code-planning | 33.0% | accuracy | — |
+| 2026-04-10 02:58 | 3b5d3ea | gemma-4-31b-it-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 02:58 | 3b5d3ea | gemma-4-31b-it-4bit | code-planning | 0.0% | accuracy | — |
+| 2026-04-10 02:44 | 3b5d3ea | Qwen3.5-27B-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 02:44 | 3b5d3ea | Qwen3.5-27B-4bit | code-planning | 0.0% | accuracy | — |
+| 2026-04-10 00:55 | 3b5d3ea | gemma-4-e4b-it-4bit | bug-detection | 100.0% | accuracy | — |
+| 2026-04-10 00:55 | 3b5d3ea | gemma-4-e4b-it-4bit | code-planning | 0.0% | accuracy | — |
 
 ### Framework Benchmark
 
@@ -148,19 +283,36 @@ mlx-eval --tasks hellaswag --limit 100
 | 2026-04-11 17:12 | 2eeafad | minerva_math500 | math_verify | 0.42 | ratio |
 | 2026-04-11 16:55 | 2eeafad | minerva_math500 | math_verify | 0.42 | ratio |
 | 2026-04-11 16:30 | 2eeafad | minerva_math500 | math_verify | 0.08 | ratio |
+| 2026-04-11 16:10 | 2eeafad | minerva_math500 | math_verify | 0.08 | ratio |
+| 2026-04-11 15:50 | 2eeafad | minerva_math500 | math_verify | 0.08 | ratio |
+| 2026-04-11 15:18 | 2eeafad | minerva_math500 | math_verify | 0.34 | ratio |
+| 2026-04-11 14:34 | 2eeafad | minerva_math500 | math_verify | 0.37 | ratio |
+| 2026-04-11 14:19 | 1829b16 | minerva_math500 | math_verify | 0.37 | ratio |
+| 2026-04-11 02:19 | ff66999 | minerva_math500 | math_verify | 0.47 | ratio |
 
 ### Model Comparison Matrix
 
 | Model | TTFT | Throughput | Tool Calling | Math-Hard (minerva_math500) | Code Accuracy | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
 |-------|------|------------|--------------|-----------------------------|---------------|--------------------------------------------|---------------------|
-| Devstral-2-123B-Instruct-2512-4bit | — | — | — | 0.42 | 0% (0/2) | — | — |
-| GLM-4.5-Air-4bit | — | — | 50% | — | — | — | — |
+| DeepSeek-R1-0528-Qwen3-8B-4bit | 0.39s | 58.7 tok/s | — | — | — | — | — |
+| Devstral-2-123B-Instruct-2512-4bit | — | 2.5 tok/s | 25% (1/4) | 0.42 | 0% (0/2) | — | — |
+| Devstral-Small-2-24B-Instruct-2512-4bit | — | — | 50% | 0.37 | — | — | — |
+| GLM-4.5-Air-4bit | — | — | 50% | 0.08 | — | — | — |
+| GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit | 0.69s | 11.1 tok/s | 50% | — | 50% | — | — |
+| Qwen3-Coder-30B-A3B-Instruct-4bit | — | — | 100% | 0.47 | — | — | — |
+| Qwen3-Coder-30B-A3B-Instruct-8bit | 0.38s | 41.2 tok/s | 100% | 0.37 | — | — | — |
+| Qwen3-Next-80B-A3B-Instruct-4bit | 0.38s | 28.2 tok/s | 100% | 0.34 | — | — | — |
 | Qwen3-Next-80B-A3B-Instruct-8bit | — | — | 100% | — | — | — | — |
-| Qwen3-Next-80B-A3B-Thinking-4bit | — | — | 75% | — | — | — | — |
-| Qwen3.5-122B-A10B-4bit | — | — | — | 0.08 | 66% | — | — |
-| gemma-4-31b-it-4bit | 1.08s | 18.4 tok/s | — | — | — | — | — |
-| gemma-4-e4b-it-4bit | 0.69s | 59.9 tok/s | — | — | — | — | — |
-| gpt-oss-120b-4bit | 0.73s | 44.9 tok/s | — | 0.42 | 34% | — | — |
+| Qwen3-Next-80B-A3B-Thinking-4bit | 0.41s | 25.1 tok/s | 75% | 0.08 | — | — | — |
+| Qwen3.5-122B-A10B-4bit | 0.70s | 24.6 tok/s | 100% | 0.08 | 66% | — | — |
+| Qwen3.5-27B-4bit | 0.85s | 22.9 tok/s | 25% (1/4) | — | 50% | — | — |
+| Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit | 0.81s | 22.9 tok/s | — | — | — | — | — |
+| Qwen3.5-35B-A3B-4bit | 0.63s | 32.9 tok/s | 100% | — | 66% | — | — |
+| Qwen3.5-9B-MLX-4bit | 0.52s | 68.5 tok/s | — | — | — | — | — |
+| Seed-OSS-36B-Instruct-4bit | 0.71s | 18.6 tok/s | 50% | — | — | — | — |
+| gemma-4-31b-it-4bit | 1.08s | 18.4 tok/s | 50% | — | 50% | — | — |
+| gemma-4-e4b-it-4bit | 0.69s | 59.9 tok/s | — | — | 50% | — | — |
+| gpt-oss-120b-4bit | 0.73s | 44.9 tok/s | 50% | 0.42 | 34% | — | — |
 
 <!-- BENCHMARK-TABLE-END -->
 

--- a/docs/mlx-benchmarks.md
+++ b/docs/mlx-benchmarks.md
@@ -76,29 +76,32 @@ mlx-eval --tasks hellaswag --limit 100
 
 | Date | SHA | Model | Test | tok/s | Tokens | Elapsed |
 |------|-----|-------|------|-------|--------|---------|
-| 2026-04-10 11:06 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | short-50 | 1.9 | 50 | 25.95 |
-| 2026-04-10 11:06 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | medium-256 | 2.5 | 256 | 103.61 |
-| 2026-04-10 11:06 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | long-512 | 2.0 | 512 | 257.79 |
-| 2026-04-10 10:58 | 5572dde | Qwen3.5-122B-A10B-4bit | short-50 | 11.3 | 50 | 4.44 |
-| 2026-04-10 10:58 | 5572dde | Qwen3.5-122B-A10B-4bit | medium-256 | 13.9 | 256 | 18.41 |
-| 2026-04-10 10:58 | 5572dde | Qwen3.5-122B-A10B-4bit | long-512 | 14.6 | 512 | 35.06 |
-| 2026-04-10 10:58 | 5572dde | Qwen3.5-122B-A10B-4bit | long-1024 | 13.7 | 1024 | 75.01 |
-| 2026-04-10 10:53 | 5572dde | gpt-oss-120b-4bit | short-50 | 10.3 | 50 | 4.88 |
-| 2026-04-10 10:53 | 5572dde | gpt-oss-120b-4bit | medium-256 | 17.1 | 256 | 14.94 |
-| 2026-04-10 10:53 | 5572dde | gpt-oss-120b-4bit | long-512 | 16.5 | 512 | 31.01 |
-| 2026-04-10 10:53 | 5572dde | gpt-oss-120b-4bit | long-1024 | 18.9 | 1024 | 54.05 |
+| 2026-04-11 22:09 | 0077a28 | gpt-oss-120b-4bit | short-50 | 26.0 | 50 | 1.92 |
+| 2026-04-11 22:09 | 0077a28 | gpt-oss-120b-4bit | medium-256 | 36.1 | 256 | 7.09 |
+| 2026-04-11 22:09 | 0077a28 | gpt-oss-120b-4bit | long-512 | 41.8 | 512 | 12.24 |
+| 2026-04-11 22:09 | 0077a28 | gpt-oss-120b-4bit | long-1024 | 44.9 | 1024 | 22.82 |
+| 2026-04-11 22:04 | 0077a28 | gemma-4-e4b-it-4bit | short-50 | 39.6 | 50 | 1.26 |
+| 2026-04-11 22:04 | 0077a28 | gemma-4-e4b-it-4bit | medium-256 | 51.3 | 256 | 4.99 |
+| 2026-04-11 22:04 | 0077a28 | gemma-4-e4b-it-4bit | long-512 | 56.0 | 512 | 9.14 |
+| 2026-04-11 22:04 | 0077a28 | gemma-4-e4b-it-4bit | long-1024 | 59.9 | 1024 | 17.09 |
+| 2026-04-11 21:59 | 0077a28 | gemma-4-31b-it-4bit | short-50 | 12.7 | 50 | 3.93 |
+| 2026-04-11 21:59 | 0077a28 | gemma-4-31b-it-4bit | medium-256 | 13.6 | 256 | 18.88 |
+| 2026-04-11 21:59 | 0077a28 | gemma-4-31b-it-4bit | long-512 | 18.4 | 512 | 27.81 |
+| 2026-04-11 21:59 | 0077a28 | gemma-4-31b-it-4bit | long-1024 | 17.5 | 1024 | 58.38 |
 
 ### TTFT
 
 | Date | SHA | Model | Test | Latency (s) | Type |
 |------|-----|-------|------|-------------|------|
-| 2026-04-10 11:18 | 5572dde | Devstral-2-123B-Instruct-2512-4bit | warm-avg | 14.156 | warm |
-| 2026-04-10 11:00 | 5572dde | Qwen3.5-122B-A10B-4bit | cold-avg | 16.500 | cold |
-| 2026-04-10 11:00 | 5572dde | Qwen3.5-122B-A10B-4bit | warm-avg | 11.952 | warm |
-| 2026-04-10 11:00 | 5572dde | Qwen3.5-122B-A10B-4bit | cache-speedup | 1.380 | — |
-| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | cold-avg | 1.245 | cold |
-| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | warm-avg | 1.314 | warm |
-| 2026-04-10 10:55 | 5572dde | gpt-oss-120b-4bit | cache-speedup | 0.950 | — |
+| 2026-04-11 22:10 | 0077a28 | gpt-oss-120b-4bit | cold-avg | 0.727 | cold |
+| 2026-04-11 22:10 | 0077a28 | gpt-oss-120b-4bit | warm-avg | 0.659 | warm |
+| 2026-04-11 22:10 | 0077a28 | gpt-oss-120b-4bit | cache-speedup | 1.100 | — |
+| 2026-04-11 22:05 | 0077a28 | gemma-4-e4b-it-4bit | cold-avg | 0.693 | cold |
+| 2026-04-11 22:05 | 0077a28 | gemma-4-e4b-it-4bit | warm-avg | 0.673 | warm |
+| 2026-04-11 22:05 | 0077a28 | gemma-4-e4b-it-4bit | cache-speedup | 1.030 | — |
+| 2026-04-11 22:00 | 0077a28 | gemma-4-31b-it-4bit | cold-avg | 1.079 | cold |
+| 2026-04-11 22:00 | 0077a28 | gemma-4-31b-it-4bit | warm-avg | 0.999 | warm |
+| 2026-04-11 22:00 | 0077a28 | gemma-4-31b-it-4bit | cache-speedup | 1.080 | — |
 
 ### Tool Calling
 
@@ -148,14 +151,16 @@ mlx-eval --tasks hellaswag --limit 100
 
 ### Model Comparison Matrix
 
-| Model | Tool Calling | Math-Hard (minerva_math500) | Code Accuracy | TTFT | Throughput | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
-|-------|--------------|-----------------------------|---------------|------|------------|--------------------------------------------|---------------------|
-| Devstral-2-123B-Instruct-2512-4bit | — | 0.42 | 0% (0/2) | — | 2.5 tok/s | — | — |
-| GLM-4.5-Air-4bit | 50% | — | — | — | — | — | — |
-| Qwen3-Next-80B-A3B-Instruct-8bit | 100% | — | — | — | — | — | — |
-| Qwen3-Next-80B-A3B-Thinking-4bit | 75% | — | — | — | — | — | — |
-| Qwen3.5-122B-A10B-4bit | — | 0.08 | 66% | 16.50s | 14.6 tok/s | — | — |
-| gpt-oss-120b-4bit | — | 0.42 | 34% | 1.24s | 18.9 tok/s | — | — |
+| Model | TTFT | Throughput | Tool Calling | Math-Hard (minerva_math500) | Code Accuracy | Capability Comparison (vs Claude Opus 4.6) | Framework Benchmark |
+|-------|------|------------|--------------|-----------------------------|---------------|--------------------------------------------|---------------------|
+| Devstral-2-123B-Instruct-2512-4bit | — | — | — | 0.42 | 0% (0/2) | — | — |
+| GLM-4.5-Air-4bit | — | — | 50% | — | — | — | — |
+| Qwen3-Next-80B-A3B-Instruct-8bit | — | — | 100% | — | — | — | — |
+| Qwen3-Next-80B-A3B-Thinking-4bit | — | — | 75% | — | — | — | — |
+| Qwen3.5-122B-A10B-4bit | — | — | — | 0.08 | 66% | — | — |
+| gemma-4-31b-it-4bit | 1.08s | 18.4 tok/s | — | — | — | — | — |
+| gemma-4-e4b-it-4bit | 0.69s | 59.9 tok/s | — | — | — | — | — |
+| gpt-oss-120b-4bit | 0.73s | 44.9 tok/s | — | 0.42 | 34% | — | — |
 
 <!-- BENCHMARK-TABLE-END -->
 

--- a/scripts/benchmarks/generate-summary.py
+++ b/scripts/benchmarks/generate-summary.py
@@ -41,12 +41,19 @@ SUITE_LABELS = {
 
 
 def load_results(limit: int) -> dict[str, list[dict]]:
-    """Load and group result files by suite, sorted newest-first, capped at limit."""
+    """Load the latest result per (suite, model) pair, capped at `limit` models per suite.
+
+    Files are sorted newest-first by filename, so the first file encountered for
+    a given (suite, model) pair is the most recent run. This keeps the summary
+    showing one row per model per suite — comprehensive across the catalog —
+    rather than the last N runs overall, which truncates large benchmark sweeps.
+    """
     all_files = sorted(
         BENCHMARKS_DIR.glob("*.json"),
         key=lambda p: p.name,
         reverse=True,
     )
+    seen: set[tuple[str, str]] = set()
     grouped: dict[str, list[dict]] = {}
     for path in all_files:
         if path.name in {"schema.json"}:
@@ -56,6 +63,11 @@ def load_results(limit: int) -> dict[str, list[dict]]:
         except (json.JSONDecodeError, OSError):
             continue
         suite = data.get("suite", "unknown")
+        model = data.get("model", "")
+        key = (suite, model)
+        if key in seen:
+            continue
+        seen.add(key)
         grouped.setdefault(suite, [])
         if len(grouped[suite]) < limit:
             grouped[suite].append(data)
@@ -402,10 +414,15 @@ def main() -> None:
     parser.add_argument(
         "--limit",
         type=int,
-        default=3,
+        default=15,
         help=(
-            "Max runs per suite (default: 3). Chosen so the regenerated doc "
-            "stays under the 12288-byte file-size limit as new suites are added."
+            "Max distinct models per suite (default: 15). Each file groups by "
+            "(suite, model); the newest run per pair is kept, then the suite "
+            "is capped at this many models. Chosen so the regenerated doc "
+            "stays under the 32768-byte extended file-size limit for "
+            "`mlx-benchmarks` defined in `.file-size.yml`. Bump that limit "
+            "together with this default if the catalog outgrows 15 models "
+            "per suite."
         ),
     )
     args = parser.parse_args()


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450 — F8 of the Bifrost migration follow-up plan

## Summary

Adds 26 new benchmark JSON files (13 models × throughput + ttft suites) plus the auto-regenerated \`docs/mlx-benchmarks.md\` summary table. Pure data commit — no source code or test changes, no scripts touched.

## Context

Post-Bifrost, the orchestrator sweep is unblocked. Ran \`uv run scripts/benchmarks/orchestrate.py --all-models --suite throughput,ttft\` against the full 21-model llama-swap catalog. 13 models produced clean data; 8 hit \`mlx-switch\` timeouts during sequential large-model handoffs and are queued for a follow-up run.

## Models with new data (13)

| Model | Files |
|---|---|
| \`DeepSeek-R1-0528-Qwen3-8B-4bit\` | throughput + ttft |
| \`Qwen3-Coder-30B-A3B-Instruct-8bit\` | throughput + ttft |
| \`Qwen3-Next-80B-A3B-Instruct-4bit\` | throughput + ttft |
| \`Qwen3-Next-80B-A3B-Thinking-4bit\` | throughput + ttft |
| \`Qwen3.5-9B-MLX-4bit\` | throughput + ttft |
| \`Qwen3.5-27B-4bit\` | throughput + ttft |
| \`Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit\` | throughput + ttft |
| \`Qwen3.5-35B-A3B-4bit\` | throughput + ttft |
| \`Qwen3.5-122B-A10B-4bit\` | throughput + ttft |
| \`Seed-OSS-36B-Instruct-4bit\` | throughput + ttft |
| \`gemma-4-e4b-it-4bit\` | throughput + ttft |
| \`gemma-4-31b-it-4bit\` | throughput + ttft |
| \`gpt-oss-120b-4bit\` | throughput + ttft |

## Models that failed to switch during the sweep (8)

Not included in this commit. The \`mlx-switch\` command returned non-zero during sequential large-model handoffs, most likely because unloading the previous model + cold-loading the new large model exceeded the 300 s \`curl --max-time\` in the \`mlx-switch\` bash wrapper. Not a data issue and not a model issue — just a timing constraint in the orchestration glue.

- DeepSeek-R1-Distill-Llama-70B-4bit
- Devstral-2-123B-Instruct-2512-4bit
- Devstral-Small-2-24B-Instruct-2512-4bit
- GLM-4.5-Air-4bit
- GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit
- Llama-4-Scout-17B-16E-Instruct-4bit
- Qwen3-Coder-30B-A3B-Instruct-4bit
- Qwen3-Next-80B-A3B-Instruct-8bit

**Follow-up path:** individual \`--model <id>\` runs (which don't have the sequential-handoff timing pressure) or a separate PR that bumps the \`mlx-switch\` \`--max-time\` ceiling.

## Changes

- 26 new files under \`data/benchmarks/\` (one per model per suite)
- \`docs/mlx-benchmarks.md\` regenerated via \`scripts/benchmarks/generate-summary.py\` to fold the new entries into the summary table

## Test plan

- [x] Pre-commit hooks pass locally (JSON validation, markdownlint, nix formatters, zizmor, etc.)
- [x] All 26 JSON files are well-formed per the benchmark schema
- [x] Summary regeneration completed cleanly
- [ ] CI passes