### PR TITLE
fix(ai-tools): bump huggingface-hub pin 1.9.0 -> 1.10.1

### DIFF
--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -301,7 +301,7 @@
     # PyPI: huggingface-hub (provides `hf` entry point)
     # Requires: HF_TOKEN env var (from macOS Keychain via nix-darwin shell init)
     (writeShellScriptBin "hf" ''
-      exec ${uv}/bin/uvx --from "huggingface-hub==1.9.0" hf "$@"
+      exec ${uv}/bin/uvx --from "huggingface-hub==1.10.1" hf "$@"
     '')
 
     # ==========================================================================


### PR DESCRIPTION
## Summary
- Bumps the `hf` CLI wrapper pin in `modules/ai-tools.nix` from 1.9.0 to 1.10.1 (current PyPI latest)
- Unblocks upcoming benchmark-extraction work that relies on the `HfApi.create_commit` append pattern and current `hf repos` / `hf datasets` subcommand surface

## Context
During research for extracting benchmark results to a HuggingFace dataset, I verified the wrapper's pin against current HF docs. 1.10.1 is a strict superset of 1.9.0 for the wrapper's use cases (model downloads, dataset push/upload, repo metadata queries). No breaking changes to command invocation.

Note: this PR does NOT address the adjacent finding that `~/.local/bin/hf` (from a stray `uv tool install huggingface-hub`) is shadowing the Nix-managed wrapper in PATH. That's a separate `nix-tool-policy` violation I'll flag in a follow-up.

## Test plan
- [x] `nix flake check` — statix, deadnix, shellcheck, formatting, all regression tests pass
- [ ] Runtime verification via `sudo darwin-rebuild switch --flake ~/git/nix-darwin/main --override-input nix-ai ~/git/nix-ai/chore/hf-cli-bump` — user to run locally before merge
- [ ] After merge, confirm `hf --version` returns 1.10.1 in a fresh shell (once PATH shadow is cleaned up)

(claude)