### PR TITLE
fix(docs): drop 'quartet' and numeric group words from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,11 @@ inputs.nix-ai.inputs.home-manager.follows = "home-manager";
 
 ### Package placement
 
-See the `nix-package-placement` rule — lives in
+The `nix-package-placement` rule lives in
 [ai-assistant-instructions/agentsmd/rules/nix-package-placement.md](https://github.com/JacobPEvans/ai-assistant-instructions/blob/main/agentsmd/rules/nix-package-placement.md)
 and auto-loads via path-scoping when `.nix` / `flake.*` files are in context.
-Contains the full decision matrix for all four repos including homebrew constraints
-and on-demand patterns.
+It contains the full decision matrix for the nix repos, including homebrew
+constraints and on-demand patterns.
 
 ## Key Files
 
@@ -142,7 +142,7 @@ graph TD
 ### Version management
 
 - **Version constants**: `modules/mlx/default.nix` — single source of truth with Renovate annotations
-- **uvx wrappers**: `modules/mlx/packages.nix` — declarative Nix derivations for all three tools
+- **uvx wrappers**: `modules/mlx/packages.nix` — declarative Nix derivations for the MLX tools
 - **Auto-update**: Renovate annotation-based manager bumps version constants, weekly schedule
 
 ## Port Allocation
@@ -161,11 +161,11 @@ new ports to avoid collisions (e.g., the 11434/11435/11436 fragmentation during 
 
 - 11435: reserved — external macOS app conflict (see PR #230)
 
-## Part of a Quartet
+## Related Repos
 
 | Repo | Purpose |
 | ---- | ------- |
 | **nix-ai** (this repo) | AI coding tools |
 | [nix-devenv](https://github.com/JacobPEvans/nix-devenv) | Reusable dev shells (Terraform, Ansible, K8s, AI/ML) |
 | [nix-home](https://github.com/JacobPEvans/nix-home) | Dev environment (git, zsh, VS Code, tmux) |
-| [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes all three) |
+| [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes the others) |


### PR DESCRIPTION
## Summary

Removes numeric-type group words ("quartet", "all four repos", "all three") from CLAUDE.md. These words bake a repo or tool count into docs, requiring updates whenever the set grows or shrinks. Neutral phrasing eliminates this maintenance burden.

**Context**: Follow-up cleanup from #482, already applied to nix-darwin (#983) and nix-home (#148).

## Changes

In CLAUDE.md:
- Package placement: `all four repos` → `the nix repos`
- Heading: `## Part of a Quartet` → `## Related Repos`
- Table: `(consumes all three)` → `(consumes the others)`
- MLX docs: `for all three tools` → `for the MLX tools`

## Test Plan

- CI passes (markdownlint, cspell, nix flake check)
- Docs only, no functional changes