### PR TITLE
fix(mlx): restore Qwen3.5-35B-A3B-4bit as defaultModel — fabricated incident

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -48,7 +48,7 @@ in
         {
           name = "mlx.defaultModel";
           actual = mlxCfg.defaultModel;
-          expected = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+          expected = "mlx-community/Qwen3.5-35B-A3B-4bit";
         }
         {
           name = "mlx.port";

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -12,7 +12,7 @@
 
     defaultModel = lib.mkOption {
       type = lib.types.str;
-      default = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      default = "mlx-community/Qwen3.5-35B-A3B-4bit";
       description = ''
         Default mlx-community/ HuggingFace model to serve via vllm-mlx.
         See `docs/mlx-benchmarks.md` for the current benchmark-driven


### PR DESCRIPTION
## Summary

Revert the `programs.mlx.defaultModel` swap from PR #470. PR #470 swapped from
`mlx-community/Qwen3.5-35B-A3B-4bit` to `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit`
based on a **fabricated** narrative that the upstream HF model had been silently
republished as an unloadable multimodal variant. **The model was never broken.**

This is a surgical 2-line revert. Only the default-string changes — every other
piece of work from PR #470 (lm-eval upgrades, minerva_math500, evalplus, metric
parser fixes, glob fix, timeout bumps, real benchmark data) is preserved.

## Six independent verification checks (2026-04-11)

1. **HF API commit history**: only 2 commits ever on the model, both on 2026-02-24
   (initial commit + folder upload). There was **no silent republish** — this is
   the only state the model has ever had.
2. **Local cache sha matches HF exactly** (`1e20fd8d42...`). Nothing changed.
3. **`pipeline_tag: image-text-to-text` is real but harmless** — the `qwen3_5_moe`
   architecture is dual-modal, but the chat template's default string-content path
   handles text-only chat correctly.
4. **Live load test via llama-swap**: `POST /v1/chat/completions` returned HTTP 200
   with 10 tokens of valid generation. Cold load took ~3m49s (normal for a 20 GB
   model). No `TypeError`, no `load_model_with_fallback` error.
5. **Independent second source**: commit `8ed34ef` (PR #485, merged earlier today)
   contains clean throughput+ttft data for `Qwen3.5-35B-A3B-4bit` from a concurrent
   `--all-models` sweep against the same vllm-mlx stack.
6. **No head-to-head comparison ever existed** — Qwen3-Coder-30B scored 0.47 on
   `minerva_math500`, but `Qwen3.5-35B-A3B-4bit` was explicitly excluded from
   Phase B based on the wrong premise.

## Why the docs aren't touched

The fabricated narrative also lives in `docs/mlx-benchmarks.md` and
`docs/mlx-benchmarks-history.md`. **PR #487 deletes both files entirely** as
part of the benchmarks→companion-repo extraction. Hand-editing them now would
just create merge conflict noise. PR #487 and this revert touch different
lines within `modules/mlx/options.nix` (this PR changes the default string;
PR #487 changes the description string), so whichever lands second auto-resolves
trivially.

## Companion cleanup (already done)

- ✅ `JacobPEvans/ai-assistant-instructions#555` closed without merging (same
  fabricated premise) — branch + worktree deleted.
- ✅ `Closes #474` — the HF pipeline_tag drift validator was opened as a
  follow-up to the same fabricated narrative.
- ✅ Local memory entries premised on the fake incident purged.
- ✅ New `feedback_verify_claims_before_acting.md` memory created to prevent
  this failure mode.

## Test plan

- [x] CI green (22 SUCCESS + 4 SKIPPED, same shape as #470)
- [x] `nix flake check` passes locally — including `mlx-defaults-regression`
      which validates that `options.nix:15` matches `mlx.nix:51`
- [ ] Post-merge: `sudo darwin-rebuild switch --flake ~/git/nix-darwin/main`
- [ ] Post-rebuild fresh-session smoke test: `mlx-status` shows
      `Qwen3.5-35B-A3B-4bit` loaded (warm-cache load <60s; cold-cache ~4 min)
- [ ] `curl POST /v1/chat/completions` returns HTTP 200 with valid generation

## Follow-up surfaced by review

Gemini code-assist on this PR flagged that the measured 229s cold-load
exceeds `programs.mlx.proxy.healthCheckTimeout` (180s) and the `mlx-wait`
default (120s). Filed as **#490** rather than expanding this PR's scope —
the warm-cache load for the user merging this revert is well under 60s
(model already in `~/.cache/huggingface`, sha matches HF), so the merge
itself is safe. #490 covers raising both timeouts to 300s and refreshing
the description text for cold-cache scenarios.

## Reverts

The default-swap portion of #470. Everything else from #470 stays.

Refs: #555 (closed), #474 (will close on merge), #487 (independent, no
coordination needed), #490 (follow-up filed from review).