### PR TITLE
fix(mcp): document Obsidian CLI integration, remove REST API port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,6 @@ new ports to avoid collisions (e.g., the 11434/11435/11436 fragmentation during 
 | 11434 | llama-swap proxy (routes to vllm-mlx) | HTTP (OpenAI-compatible) | `modules/mlx/` |
 | 11436 | vllm-mlx backend (internal, managed by llama-swap) | HTTP | `modules/mlx/` |
 | 8080 | Open WebUI | HTTP | `modules/open-webui.nix` |
-| 27124 | Obsidian Local REST API | HTTP | `modules/mcp/` (env only) |
 
 **Reserved/conflicting ports to avoid:**
 

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -161,7 +161,7 @@ in
   # ai-assistant-instructions permissions). No MCP server needed — the skill
   # provides equivalent structured access without an additional layer.
   #
-  # If MCP is desired later: bunx [ "mcp-obsidian-cli@latest" ] (stonematt)
+  # If MCP is desired later: bunx [ "mcp-obsidian-cli@1.2.0" ] (stonematt)
 
   # ================================================================
   # Database (disabled by default)

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -153,16 +153,15 @@ in
   };
 
   # ================================================================
-  # Obsidian - NOT IMPLEMENTED
+  # Obsidian - Integrated via Claude Code Plugin (not MCP)
   # ================================================================
-  # Decision: Not moving forward with REST API approach since official Obsidian CLI will be released soon.
-  # Using Claude Skills plugins for Obsidian integration instead (see plugins/community.nix).
+  # The official Obsidian CLI (v1.8+, ships in Obsidian.app) provides 80+
+  # commands. Integration uses the kepano/obsidian-skills Claude Code plugin
+  # which teaches Claude to invoke the CLI via Bash (auto-approved in
+  # ai-assistant-instructions permissions). No MCP server needed — the skill
+  # provides equivalent structured access without an additional layer.
   #
-  # If revisited in the future:
-  # - Use `uvx mcp-obsidian` (PyPI package)
-  # - Requires Obsidian REST API plugin: https://github.com/coddingtonbear/obsidian-local-rest-api
-  # - IMPORTANT: Inject OBSIDIAN_API_KEY via secrets manager at runtime (never in Nix store)
-  # - Non-secret defaults: OBSIDIAN_HOST=127.0.0.1, OBSIDIAN_PORT=27124
+  # If MCP is desired later: bunx [ "mcp-obsidian-cli@latest" ] (stonematt)
 
   # ================================================================
   # Database (disabled by default)


### PR DESCRIPTION
# PR #493: Obsidian Integration Finalization

## Summary

- Updates the Obsidian comment block in `modules/mcp/default.nix` — replaces "NOT
  IMPLEMENTED / waiting for CLI" with accurate status reflecting CLI integration via
  plugin
- Removes port 27124 from the port allocation table in `CLAUDE.md` — the REST API
  approach is abandoned; the official CLI uses IPC, no port needed

## Changes

**modules/mcp/default.nix:**

- Changed Obsidian integration from "NOT IMPLEMENTED — awaiting CLI" to "Integrated via
  Claude Code plugin"
- Documents that the official Obsidian CLI (v1.8+, ships in Obsidian.app) provides 80+
  commands
- Notes that the obsidian-skills plugin handles integration by teaching Claude to invoke
  the CLI via Bash (auto-approved permissions)
- Clarifies that no MCP server is needed — the skill provides equivalent structured
  access
- Adds reference comment for mcp-obsidian-cli@1.2.0 as a future option if MCP
  integration is desired later

**CLAUDE.md:**

- Removes port 27124 from port allocation table (was planned for Obsidian REST API, now obsolete)

## Test Plan

- [x] `nix flake check` — passes (17/17 checks)
- [x] Static Nix evaluation validates syntax
- After merging companion PR in ai-assistant-instructions (adds `obsidian` to permissions
  allow list): `darwin-rebuild switch` and verify `obsidian help` auto-approves in a
  fresh Claude Code session
- [x] Verified port 27124 no longer appears in CLAUDE.md
- [x] Verified modules/mcp/default.nix accurately documents CLI-via-plugin integration

Related: #4 (obsidian-skills plugin integration)
