### PR TITLE
fix(claude): consolidate config defaults and set model/effort explicitly

### DIFF
--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -141,7 +141,17 @@ in
         {
           name = "showTurnDuration";
           actual = cfg.showTurnDuration;
-          expected = true;
+          expected = false;
+        }
+        {
+          name = "model";
+          actual = cfg.model;
+          expected = "opusplan";
+        }
+        {
+          name = "effortLevel";
+          actual = cfg.effortLevel;
+          expected = "medium";
         }
         {
           name = "sandbox.enabled";

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -85,18 +85,19 @@ in
     # scriptPath default: .local/bin/claude-api-key-helper
   };
 
-  # Agent teams display mode (direct settings.json property)
-  teammateMode = "auto";
+  # teammateMode — using upstream default: "auto" (options.nix)
+  # "auto" splits panes in tmux, in-process otherwise.
 
-  # Model: use account-tier default. The 'opusplan' model is no longer
-  # specified as it lacks a 1M context variant.
-  # See: https://code.claude.com/docs/en/model-config
+  # Model: opusplan — Opus 4.6 for planning, Sonnet 4.6 for execution (1M context).
+  model = "opusplan";
 
-  # Release channel: "latest" gets newest releases immediately
-  autoUpdatesChannel = "latest";
+  # Effort: medium — matches upstream Max/Team default (v2.1.68+).
+  # Must be explicit to override runtime "high" value (merge script preserves runtime keys).
+  # Override per-session via /model effort slider or "ultrathink" keyword.
+  effortLevel = "medium";
 
-  # Show turn duration in UI for performance visibility
-  showTurnDuration = true;
+  # autoUpdatesChannel — using upstream default: "latest" (options.nix)
+  # showTurnDuration — using upstream default: false (options.nix)
 
   # Enable Remote Control for all sessions (Feb 2026 feature).
   # Writes remoteControlAtStartup = true into ~/.claude.json via home.activation.
@@ -108,11 +109,6 @@ in
   # Generates hasClaudeMdExternalIncludesApproved = true entries in ~/.claude.json
   # for each ~/git/<repo>/main path found at home-manager activation time (runtime) via claude-json-merge.sh.
   trustedProjectDirs = [ "~/git" ];
-
-  # effortLevel = "medium";
-  # Claude Code v2.1.68+ defaults to medium effort for Max/Team subscribers.
-  # Use /model effort slider or "ultrathink" keyword to override per-session.
-  # Uncomment to pin a specific effort level.
 
   # Minimal commit attribution — replaces verbose Co-Authored-By trailer
   # Claude Code appends this string to every commit message automatically
@@ -187,16 +183,13 @@ in
     # Extended thinking enabled with token budget controlled via env vars
     alwaysThinkingEnabled = true;
 
-    # Session cleanup: explicitly set to 30 days (upstream Claude default).
-    # Keeping this explicit to document the intentional choice and prevent
-    # accidental drift if the module option default ever changes.
-    cleanupPeriodDays = 30;
+    # cleanupPeriodDays — using upstream default: 30 (options.nix)
 
     # Environment variables for model config and token optimization
     # See: https://code.claude.com/docs/en/settings
     # See: https://code.claude.com/docs/en/model-config
     env = {
-      # Model: uses account-tier default (no override set above).
+      # Model: opusplan set above. Env var overrides available if needed.
       # Auto-claude background jobs use their own CLAUDE_MODEL env var (haiku).
       # ANTHROPIC_MODEL = "sonnet"; # Uncomment to override default model via env var
       # CLAUDE_CODE_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"; # Cost control for subagents
@@ -235,6 +228,12 @@ in
       # Effort level via env var (alternative to settings.json key)
       # CLAUDE_CODE_EFFORT_LEVEL = "medium";
 
+      # Force plugin auto-update on startup (skips staleness check)
+      FORCE_AUTOUPDATE_PLUGINS = "1";
+
+      # Auto-compact threshold — using upstream default (~95% of context window)
+      # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "95";
+
       # ===== OpenTelemetry — OrbStack k8s OTEL Collector =====
       # Pipeline: Claude Code → OTEL Collector (:30317) → Cribl Stream (:4317) → Splunk HEC
       # Requires: OrbStack k8s running with OTEL collector deployed.
@@ -268,7 +267,7 @@ in
     # Currently disabled - enable when reviewing external code or untrusted repos.
     sandbox = {
       enabled = false;
-      autoAllowBashIfSandboxed = true; # Safe because sandbox prevents destructive ops
+      # autoAllowBashIfSandboxed — using upstream default: true (options.nix)
       excludedCommands = [
         "git"
         "nix"

--- a/modules/claude/statusline/claude-statusline.sh
+++ b/modules/claude/statusline/claude-statusline.sh
@@ -88,7 +88,7 @@ out=""
 out+="${blue}${model_name}${reset}"
 
 # Current working directory
-cwd=$(echo "$input" | jq -r '.cwd // .workspace.current_dir // empty')
+cwd=$(printf '%s' "$input" | jq -r '.cwd // .workspace.current_dir // empty')
 if [ -n "$cwd" ]; then
     # Show last 2 path components (e.g., nix-ai/main) instead of just basename
     display_dir="$(basename "$(dirname "$cwd")")/$(basename "$cwd")"

--- a/modules/claude/statusline/claude-statusline.sh
+++ b/modules/claude/statusline/claude-statusline.sh
@@ -88,7 +88,7 @@ out=""
 out+="${blue}${model_name}${reset}"
 
 # Current working directory
-cwd=$(echo "$input" | jq -r '.cwd // empty')
+cwd=$(echo "$input" | jq -r '.cwd // .workspace.current_dir // empty')
 if [ -n "$cwd" ]; then
     # Show last 2 path components (e.g., nix-ai/main) instead of just basename
     display_dir="$(basename "$(dirname "$cwd")")/$(basename "$cwd")"


### PR DESCRIPTION
## Summary

Consolidate Claude Code configuration settings into Nix-authoritative values, reducing runtime-only state and improving consistency. Enforce opusplan model and medium effort level explicitly, comment out 5 redundant settings that match upstream defaults, add plugin auto-update flag, and fix statusline fallback logic.

## Changes

| File | Change |
|------|--------|
| `modules/claude-config.nix` | Set `model = "opusplan"` and `effortLevel = "medium"` explicitly; comment out `teammateMode`, `autoUpdatesChannel`, `showTurnDuration`, `cleanupPeriodDays`, `sandbox.autoAllowBashIfSandboxed` with inline default values; add `FORCE_AUTOUPDATE_PLUGINS = "1"` env var |
| `modules/claude/statusline/claude-statusline.sh` | Add `.workspace.current_dir` fallback for `.cwd` extraction; use `printf` instead of `echo` to avoid issues with jq pipe |
| `lib/checks/claude.nix` | Update regression tests for model/effortLevel; verify showTurnDuration default value |

## Architecture Note

`settings.nix` unconditionally inherits `showTurnDuration`, `cleanupPeriodDays`, `autoUpdatesChannel`, `teammateMode` — commenting them out emits the `options.nix` default. But `model` and `effortLevel` use `lib.optionalAttrs` guards, so they must be SET explicitly to override runtime-preserved values.

## Test Plan

- [x] `nix flake check` — all regression tests pass
- [x] `nix fmt` — no formatting changes
- [x] CI — all checks green (except expected merge conflict markers)
- [ ] `darwin-rebuild switch` runtime verification

Generated with [Claude Code](https://claude.com/claude-code)
