### PR TITLE
feat(claude): enable OTEL telemetry to OrbStack collector

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -212,6 +212,16 @@ in
 
       # Effort level via env var (alternative to settings.json key)
       # CLAUDE_CODE_EFFORT_LEVEL = "medium";
+
+      # ===== OpenTelemetry — OrbStack k8s OTEL Collector =====
+      # Pipeline: Claude Code → OTEL Collector (:30317) → Cribl Stream (:4317) → Splunk HEC
+      # Requires: OrbStack k8s running with OTEL collector deployed.
+      # Source: orbstack-kubernetes/k8s/monitoring/otel-collector/service-external.yaml
+      CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+      OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:30317";
+      OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
+      OTEL_METRICS_EXPORTER = "otlp";
+      OTEL_LOGS_EXPORTER = "otlp";
     };
 
     # Permissions from unified ai-assistant-instructions system

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -222,6 +222,7 @@ in
       OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
       OTEL_METRICS_EXPORTER = "otlp";
       OTEL_LOGS_EXPORTER = "otlp";
+      OTEL_TRACES_EXPORTER = "none"; # Only metrics + logs; no trace overhead
     };
 
     # Permissions from unified ai-assistant-instructions system


### PR DESCRIPTION
# PR #496: Enable OTEL Telemetry to OrbStack Collector

## Summary

- Enable OpenTelemetry export from Claude Code to the OrbStack k8s OTEL Collector
- gRPC transport on NodePort 30317
- Exports metrics and logs via OTLP; traces explicitly disabled
- Pipeline: Claude Code → OTEL Collector (:30317) → Cribl Stream (:4317) → Splunk HEC

## Changes

| File | Change |
|------|--------|
| `modules/claude-config.nix` | Add 6 OTEL env vars to `settings.env` block |

## Test Plan

- [x] `nix flake check` — all checks pass
- [x] CI — all green
- [ ] `darwin-rebuild switch` runtime verification
- [ ] Verify OTEL env vars in `~/.claude/settings.json`
- [ ] Confirm OTEL Collector receives data: `kubectl logs -n monitoring otel-collector-0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
