### PR TITLE
feat(codex): add official OpenAI Codex plugin + MCP server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,10 @@
       url = "github:kepano/obsidian-skills";
       flake = false;
     };
+    openai-codex = {
+      url = "github:openai/codex-plugin-cc";
+      flake = false;
+    };
     axton-obsidian-visual-skills = {
       url = "github:axtonliu/axton-obsidian-visual-skills";
       flake = false;
@@ -125,6 +129,7 @@
       jacobpevans-cc-plugins,
       lunar-claude,
       obsidian-skills,
+      openai-codex,
       axton-obsidian-visual-skills,
       superpowers-marketplace,
       visual-explainer-marketplace,
@@ -155,6 +160,7 @@
           jacobpevans-cc-plugins
           lunar-claude
           obsidian-skills
+          openai-codex
           axton-obsidian-visual-skills
           superpowers-marketplace
           visual-explainer-marketplace

--- a/modules/claude/plugins/experimental.nix
+++ b/modules/claude/plugins/experimental.nix
@@ -28,9 +28,16 @@ _:
     # ========================================================================
     # WARNING: These plugins invoke external AI models (OpenAI, Google)
 
-    # Codex: OpenAI GPT integration for high-reasoning coding tasks
+    # Codex (Community): OpenAI GPT integration for high-reasoning coding tasks
     # Auto-selects the latest available GPT model for coding or reasoning
     "codex@cc-dev-tools" = true;
+
+    # ========================================================================
+    # Official OpenAI Codex Plugin
+    # ========================================================================
+    # Codex (Official): code review, adversarial review, task delegation
+    # Provides: /codex:review, /codex:adversarial-review, /codex:rescue, /codex:setup
+    "codex@openai-codex" = true;
 
     # Gemini: Google Gemini integration for research and reasoning
     # Includes web search capabilities and session resumption

--- a/modules/claude/plugins/marketplaces.nix
+++ b/modules/claude/plugins/marketplaces.nix
@@ -201,6 +201,15 @@ let
       };
     };
 
+    # --- Official OpenAI ---
+    # OpenAI Codex plugin: code review, adversarial review, task delegation
+    "openai-codex" = {
+      source = {
+        type = "github";
+        url = "openai/codex-plugin-cc";
+      };
+    };
+
     # --- Enterprise / Well-Known ---
     # Bitwarden AI plugins: session retrospective, config validation, code review
     "bitwarden-marketplace" = {

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -164,6 +164,17 @@ in
   # If MCP is desired later: bunx [ "mcp-obsidian-cli@1.2.0" ] (stonematt)
 
   # ================================================================
+  # Codex CLI — OpenAI coding agent MCP server
+  # ================================================================
+  # Native `codex mcp-server` (stdio). Structured MCP tool access to Codex.
+  # The codex@openai-codex plugin provides skill-based /codex commands.
+  # Installed via Homebrew cask (see nix-darwin modules/darwin/homebrew.nix).
+  codex = {
+    command = "codex";
+    args = [ "mcp-server" ];
+  };
+
+  # ================================================================
   # Database (disabled by default)
   # ================================================================
 

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -168,7 +168,8 @@ in
   # ================================================================
   # Native `codex mcp-server` (stdio). Structured MCP tool access to Codex.
   # The codex@openai-codex plugin provides skill-based /codex commands.
-  # Installed via Homebrew cask (see nix-darwin modules/darwin/homebrew.nix).
+  # Auth: `codex login` stores credentials in ~/.codex/auth.json (no env var API keys needed).
+  # Installed via Homebrew cask in the nix-darwin repo (not managed here).
   codex = {
     command = "codex";
     args = [ "mcp-server" ];


### PR DESCRIPTION
# PR #497: Official OpenAI Codex Integration

## Summary

- Add official OpenAI Codex plugin (`openai/codex-plugin-cc`) as a flake input and marketplace
- Enable `codex@openai-codex` — provides `/codex:review`, `/codex:adversarial-review`, `/codex:rescue`, `/codex:setup`
- Add native `codex mcp-server` (stdio) for structured MCP tool access
- Existing community `codex@cc-dev-tools` plugin retained (different feature set)

## Changes

| File | Change |
|------|--------|
| `flake.nix` | Add `openai-codex` input + passthrough to `marketplaceInputs` |
| `modules/claude/plugins/marketplaces.nix` | Register `openai-codex` marketplace |
| `modules/claude/plugins/experimental.nix` | Enable `codex@openai-codex` plugin |
| `modules/mcp/default.nix` | Add Codex MCP server (`codex mcp-server` stdio) |

## Test Plan

- [x] `nix flake check` — all checks pass
- [x] `codex mcp-server --help` confirms subcommand exists
- [x] CI — all green
- [ ] `darwin-rebuild switch` runtime verification
- [ ] Verify marketplace in `~/.claude/settings.json`
- [ ] Verify MCP server in `~/.claude.json`
- [ ] Fresh Claude session: confirm Codex MCP connects and `/codex:review` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
