### PR TITLE
feat(fabric): add zsh completions and AI tool decision tree

### DIFF
--- a/docs/ai-tool-decision-tree.md
+++ b/docs/ai-tool-decision-tree.md
@@ -1,0 +1,102 @@
+# AI Tool Decision Tree
+
+When to use which tool for AI-assisted tasks in the nix-ai ecosystem.
+
+## Quick Reference
+
+| Situation | Use | Why |
+| --- | --- | --- |
+| One-shot text transformation in a shell pipeline | `fabric --pattern X` | Pipe-based, no Claude Code needed |
+| YouTube video processing | `fabric -y URL --pattern summarize` | Built-in yt-dlp + Jina extraction |
+| Want Claude Code to auto-invoke a pattern | Fabric skills (synthetic marketplace) | 32 curated patterns auto-loaded by description match |
+| Want to explicitly call a pattern from Claude Code | Fabric MCP server | Pattern appears as a callable MCP tool |
+| Multi-model consensus or routing | PAL MCP `clink` / `consensus` | Routes across providers |
+| Single external model call | Bifrost (`localhost:30080`) | OpenAI-compatible, multi-provider |
+| Writing Python/Go code that calls an LLM | Anthropic SDK / OpenAI SDK | Direct API, no middleware |
+
+## When to Use Fabric CLI
+
+Best for: **shell pipelines and one-shot transformations**
+
+```bash
+# Summarize an article
+cat article.md | fabric --pattern summarize
+
+# Extract wisdom from a YouTube video
+fabric -y "https://youtube.com/watch?v=..." --pattern extract_wisdom
+
+# Generate a commit message from a diff
+git diff --staged | fabric --pattern create_git_diff_commit
+
+# Review code
+cat src/main.go | fabric --pattern review_code
+```
+
+Use when:
+
+- You're in a terminal, not a Claude Code session
+- You want to pipe stdin through a pattern
+- You need YouTube/URL extraction (built-in yt-dlp + Jina)
+- You want local MLX inference for a quick task
+
+## When to Use Fabric Skills (Claude Code Auto-Discovery)
+
+Best for: **letting Claude Code pick the right pattern automatically**
+
+32 curated patterns are registered as Claude Code skills via the synthetic
+marketplace. Claude Code loads them based on description matching — you don't
+need to ask for a specific pattern.
+
+Use when:
+
+- You're in a Claude Code session
+- The task naturally matches a pattern (summarize, extract, analyze, review)
+- You want Claude to decide whether a fabric pattern is useful
+
+Not for:
+
+- Tasks that need a specific pattern — use the CLI or MCP server instead
+- Patterns not in the curated 32 — use CLI or expand the set (#446)
+
+## When to Use Fabric MCP Server
+
+Best for: **explicit pattern invocation from Claude Code**
+
+The MCP server (community-maintained `ksylvan/fabric-mcp`) exposes patterns
+as callable tools. Disabled by default.
+
+Use when:
+
+- You want to call a specific pattern by name from Claude Code
+- You need structured tool-call semantics (vs free-text skill matching)
+
+Not for:
+
+- Shell pipelines (use CLI — faster, no MCP overhead)
+- Auto-discovery (use skills — MCP requires explicit invocation)
+
+## When to Use Bifrost / PAL MCP
+
+Best for: **multi-model routing and external model calls**
+
+| Tool | Use Case |
+| --- | --- |
+| Bifrost (`localhost:30080`) | Single model call via OpenAI-compatible API |
+| PAL `clink` | Multi-model parallel (research, exploration) |
+| PAL `consensus` | Multi-model agreement (critical decisions) |
+
+Use when:
+
+- You need a non-Claude model (Gemini, OpenRouter, local MLX)
+- You need multi-model consensus for a decision
+- You're building a workflow that routes across providers
+
+## Anti-Patterns
+
+| Don't Do This | Do This Instead |
+| --- | --- |
+| Use MCP server for a quick shell pipeline | `echo "text" \| fabric --pattern X` |
+| Manually invoke fabric skills from Claude Code | Let auto-discovery match by description |
+| Use fabric for multi-step automated workflows | Use the orchestrator (when it has consumers) |
+| Route through Bifrost for a task fabric handles | Use fabric directly — it already talks to MLX |
+| Use PAL for single-model calls | Use Bifrost directly — lower overhead |

--- a/flake.lock
+++ b/flake.lock
@@ -326,6 +326,22 @@
         "type": "github"
       }
     },
+    "openai-codex": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775684930,
+        "narHash": "sha256-4kqtfdHlcg3YXWX1og9b5JuLgnB/3Nj5dFMe4Ryt7No=",
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "rev": "6a5c2ba53b734f3cdd8daacbd49f68f3e6c8c167",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "type": "github"
+      }
+    },
     "pal-mcp-server": {
       "flake": false,
       "locked": {
@@ -364,6 +380,7 @@
         "lunar-claude": "lunar-claude",
         "nixpkgs": "nixpkgs",
         "obsidian-skills": "obsidian-skills",
+        "openai-codex": "openai-codex",
         "pal-mcp-server": "pal-mcp-server",
         "superpowers-marketplace": "superpowers-marketplace",
         "visual-explainer-marketplace": "visual-explainer-marketplace",

--- a/modules/fabric/completions/_fabric
+++ b/modules/fabric/completions/_fabric
@@ -1,0 +1,63 @@
+#compdef fabric
+
+# Zsh completion for Daniel Miessler's Fabric CLI.
+# Dynamic completions use --shell-complete-list for patterns and models.
+
+_fabric_patterns() {
+  local -a patterns
+  patterns=("${(@f)$(fabric --listpatterns --shell-complete-list 2>/dev/null)}")
+  _describe 'pattern' patterns
+}
+
+_fabric_models() {
+  local -a models
+  models=("${(@f)$(fabric --listmodels --shell-complete-list 2>/dev/null)}")
+  _describe 'model' models
+}
+
+_fabric_contexts() {
+  local -a contexts
+  contexts=("${(@f)$(fabric --listcontexts --shell-complete-list 2>/dev/null)}")
+  _describe 'context' contexts
+}
+
+_fabric_sessions() {
+  local -a sessions
+  sessions=("${(@f)$(fabric --listsessions --shell-complete-list 2>/dev/null)}")
+  _describe 'session' sessions
+}
+
+_fabric() {
+  _arguments \
+    '(-p --pattern)'{-p,--pattern}'[Choose a pattern]:pattern:_fabric_patterns' \
+    '(-m --model)'{-m,--model}'[Choose model]:model:_fabric_models' \
+    '(-C --context)'{-C,--context}'[Choose context]:context:_fabric_contexts' \
+    '--session[Choose session]:session:_fabric_sessions' \
+    '(-a --attachment)'{-a,--attachment}'[Attachment path or URL]:file:_files' \
+    '(-s --stream)'{-s,--stream}'[Stream output]' \
+    '(-c --copy)'{-c,--copy}'[Copy to clipboard]' \
+    '(-o --output)'{-o,--output}'[Output to file]:file:_files' \
+    '(-l --listpatterns)'{-l,--listpatterns}'[List all patterns]' \
+    '(-L --listmodels)'{-L,--listmodels}'[List all models]' \
+    '(-x --listcontexts)'{-x,--listcontexts}'[List all contexts]' \
+    '(-X --listsessions)'{-X,--listsessions}'[List all sessions]' \
+    '(-U --updatepatterns)'{-U,--updatepatterns}'[Update patterns]' \
+    '(-y --youtube)'{-y,--youtube}'[YouTube URL]:url:' \
+    '(-u --scrape_url)'{-u,--scrape_url}'[Scrape URL to markdown]:url:' \
+    '(-t --temperature)'{-t,--temperature}'[Set temperature]:temp:' \
+    '(-T --topp)'{-T,--topp}'[Set top P]:topp:' \
+    '(-S --setup)'{-S,--setup}'[Run setup]' \
+    '(-d --changeDefaultModel)'{-d,--changeDefaultModel}'[Change default model]' \
+    '--serve[Start REST API server]' \
+    '--address[REST API bind address]:address:' \
+    '--version[Print version]' \
+    '--dry-run[Show what would be sent]' \
+    '--readability[Convert HTML to readable view]' \
+    '--search[Enable web search]' \
+    '(-r --raw)'{-r,--raw}'[Use model defaults]' \
+    '(-g --language)'{-g,--language}'[Language code]:lang:' \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '*:input:_files'
+}
+
+_fabric "$@"

--- a/modules/fabric/completions/_fabric
+++ b/modules/fabric/completions/_fabric
@@ -42,10 +42,10 @@ _fabric() {
     '(-x --listcontexts)'{-x,--listcontexts}'[List all contexts]' \
     '(-X --listsessions)'{-X,--listsessions}'[List all sessions]' \
     '(-U --updatepatterns)'{-U,--updatepatterns}'[Update patterns]' \
-    '(-y --youtube)'{-y,--youtube}'[YouTube URL]:url:' \
-    '(-u --scrape_url)'{-u,--scrape_url}'[Scrape URL to markdown]:url:' \
-    '(-t --temperature)'{-t,--temperature}'[Set temperature]:temp:' \
-    '(-T --topp)'{-T,--topp}'[Set top P]:topp:' \
+    '(-y --youtube)'{-y,--youtube}'[YouTube URL]:url:_urls' \
+    '(-u --scrape_url)'{-u,--scrape_url}'[Scrape URL to markdown]:url:_urls' \
+    '(-t --temperature)'{-t,--temperature}'[Set temperature (0.0-2.0)]:temp:' \
+    '(-T --topp)'{-T,--topp}'[Set top P (0.0-1.0)]:topp:' \
     '(-S --setup)'{-S,--setup}'[Run setup]' \
     '(-d --changeDefaultModel)'{-d,--changeDefaultModel}'[Change default model]' \
     '--serve[Start REST API server]' \

--- a/modules/fabric/package.nix
+++ b/modules/fabric/package.nix
@@ -19,6 +19,7 @@
 {
   lib,
   buildGoModule,
+  installShellFiles,
   fabric-src,
 }:
 
@@ -42,8 +43,16 @@ buildGoModule rec {
     "-w"
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   # Skip tests during build — they require network access to AI providers
   doCheck = false;
+
+  # Fabric uses go-flags (no built-in completion generator). Install a hand-
+  # written zsh completion that uses --shell-complete-list for dynamic values.
+  postInstall = ''
+    installShellCompletion --zsh --name _fabric ${./completions/_fabric}
+  '';
 
   # Prevent Go from downloading a different toolchain version
   env.GOTOOLCHAIN = "local";


### PR DESCRIPTION
# PR #503: Fabric Zsh Completions & AI Tool Decision Tree

## Summary

- Add zsh tab-completion for fabric CLI (patterns, models, contexts, sessions)
- Add decision tree doc explaining when to use fabric CLI vs skills vs MCP vs Bifrost

## Changes

**Zsh completions** (`modules/fabric/completions/_fabric`):

- Installed via `installShellFiles` in the package derivation
- Dynamic completion using `--shell-complete-list` for patterns and models
- Covers all major flags (`--pattern`, `--model`, `--context`, `--session`, etc.)

**Decision tree** (`docs/ai-tool-decision-tree.md`):

- Quick reference table: situation → recommended tool
- Detailed sections for each tool with examples
- Anti-patterns section

## Test Plan

- [ ] `nix flake check` passes
- [ ] `nix build .#fabric-ai` produces `share/zsh/site-functions/_fabric`
- [ ] `fabric <TAB>` completes flags in a fresh shell after `darwin-rebuild switch`
- [ ] `fabric --pattern <TAB>` lists available patterns

Closes #443, closes #452
