### PR TITLE
feat: extract Claude stack into nix-ai-claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ nix-ai exports [home-manager](https://github.com/nix-community/home-manager) mod
 | Export | What it includes |
 | ------ | --------------- |
 | `homeManagerModules.default` | Full AI stack — Claude, Gemini, Copilot, Codex, MCP, MLX, dev tools |
-| `homeManagerModules.claude` | Just Claude Code |
+| `homeManagerModules.claude` | Claude Code via the extracted `nix-ai-claude` module |
 | `homeManagerModules.maestro` | Just Maestro orchestration |
 | `lib.ci.claudeSettingsJson` | Pure JSON for CI validation (no derivations needed) |
 
@@ -111,6 +111,7 @@ nix fmt
 ## Repository structure
 
 ```text
+nix-ai-claude/        # Staged standalone Claude-only flake
 modules/
 ├── claude/          # Claude Code (settings, plugins, statusline, auto-claude)
 ├── maestro/         # Maestro agent orchestration

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "ai-assistant-instructions_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776008934,
+        "narHash": "sha256-R02sX+Dko7XHyFxQ4dgGz1uA8wjR+aBtJSFmjM9p4ek=",
+        "owner": "JacobPEvans",
+        "repo": "ai-assistant-instructions",
+        "rev": "253e4e2580faaaef9a9ed883e2d3489657c84532",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JacobPEvans",
+        "repo": "ai-assistant-instructions",
+        "type": "github"
+      }
+    },
     "anthropic-agent-skills": {
       "flake": false,
       "locked": {
@@ -32,7 +48,39 @@
         "type": "github"
       }
     },
+    "anthropic-agent-skills_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775755206,
+        "narHash": "sha256-H/oorOl5cch7bnziDz7gHNBv5Q0OAwFbk9w1WLku2kk=",
+        "owner": "anthropics",
+        "repo": "skills",
+        "rev": "12ab35c2eb5668c95810e6a6066f40f4218adc39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "axton-obsidian-visual-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770862721,
+        "narHash": "sha256-28hLlKPifZ0GT3vc3eYuIN0C2DQm6vtZhJIKEomRp0M=",
+        "owner": "axtonliu",
+        "repo": "axton-obsidian-visual-skills",
+        "rev": "1265976d9746a84858b4b7b42fb86a215aa93de9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "axtonliu",
+        "repo": "axton-obsidian-visual-skills",
+        "type": "github"
+      }
+    },
+    "axton-obsidian-visual-skills_2": {
       "flake": false,
       "locked": {
         "lastModified": 1770862721,
@@ -64,6 +112,22 @@
         "type": "github"
       }
     },
+    "bills-claude-skills_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772306604,
+        "narHash": "sha256-PyQSIuAzLXuah9qvfXSiiXedprtwvq/d7rzaAan7xTA=",
+        "owner": "BillChirico",
+        "repo": "bills-claude-skills",
+        "rev": "3a7e65e88949e3f98a75ea296b53e478e2b5995c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BillChirico",
+        "repo": "bills-claude-skills",
+        "type": "github"
+      }
+    },
     "bitwarden-marketplace": {
       "flake": false,
       "locked": {
@@ -72,6 +136,22 @@
         "owner": "bitwarden",
         "repo": "ai-plugins",
         "rev": "a54507e92c984d687d1e4d5ce1afa6466343b83f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitwarden",
+        "repo": "ai-plugins",
+        "type": "github"
+      }
+    },
+    "bitwarden-marketplace_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775576196,
+        "narHash": "sha256-/NW6DwIdZwt5UqQzuqIG3TE4qjQc9dtcm4ply92Jgsw=",
+        "owner": "bitwarden",
+        "repo": "ai-plugins",
+        "rev": "e6095fe6058d07f34ca32243b0dab19d556a3b2d",
         "type": "github"
       },
       "original": {
@@ -96,6 +176,22 @@
         "type": "github"
       }
     },
+    "browser-use-skills_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776008847,
+        "narHash": "sha256-prDfQao291H8fgClUwjyKyee5yAxW2HUKn9COmm9WNQ=",
+        "owner": "browser-use",
+        "repo": "browser-use",
+        "rev": "36438e409e70ab6018a222c931c887b4a4720a71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "browser-use",
+        "repo": "browser-use",
+        "type": "github"
+      }
+    },
     "cc-dev-tools": {
       "flake": false,
       "locked": {
@@ -112,7 +208,39 @@
         "type": "github"
       }
     },
+    "cc-dev-tools_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773368188,
+        "narHash": "sha256-HcICAqqI3kP0PWQhWvkaM2DOegINXamgox5u+LH2wYA=",
+        "owner": "Lucklyric",
+        "repo": "cc-dev-tools",
+        "rev": "f6414993a4c5047ab3c6f88866789d03f50bef7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Lucklyric",
+        "repo": "cc-dev-tools",
+        "type": "github"
+      }
+    },
     "cc-marketplace": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768758615,
+        "narHash": "sha256-BnH8+reZQRy4st+5zwA1EEDLIc2nVIp8CVBizUIkjXo=",
+        "owner": "ananddtyagi",
+        "repo": "cc-marketplace",
+        "rev": "b643305146890bda9b2e694d2c42206ae4d0a4df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ananddtyagi",
+        "repo": "cc-marketplace",
+        "type": "github"
+      }
+    },
+    "cc-marketplace_2": {
       "flake": false,
       "locked": {
         "lastModified": 1768758615,
@@ -160,6 +288,22 @@
         "type": "github"
       }
     },
+    "claude-code-plugins-plus_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775769794,
+        "narHash": "sha256-ksmRNoD5Vhki99/nndJnLzBMf6B0Y+5eMMUPFFHXYkI=",
+        "owner": "jeremylongshore",
+        "repo": "claude-code-plugins-plus",
+        "rev": "c8a915cb82a09594c12ee5b9aca351a50e28b831",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeremylongshore",
+        "repo": "claude-code-plugins-plus",
+        "type": "github"
+      }
+    },
     "claude-code-workflows": {
       "flake": false,
       "locked": {
@@ -168,6 +312,22 @@
         "owner": "wshobson",
         "repo": "agents",
         "rev": "70444e5b1fae2237f3cb087c70db043ab633fe11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wshobson",
+        "repo": "agents",
+        "type": "github"
+      }
+    },
+    "claude-code-workflows_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775684268,
+        "narHash": "sha256-LFApt/MSM5sp8KxNbghCNkVn3RF3986rhi3mamfsbhM=",
+        "owner": "wshobson",
+        "repo": "agents",
+        "rev": "03d0b4b9eb4d57bd961aa252a56025daa21543e6",
         "type": "github"
       },
       "original": {
@@ -192,6 +352,22 @@
         "type": "github"
       }
     },
+    "claude-cookbooks_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775867615,
+        "narHash": "sha256-sDC2q9iJcN+n/wPr1fItLf+vNxBW8euUJROb5cHc0xA=",
+        "owner": "anthropics",
+        "repo": "claude-cookbooks",
+        "rev": "753ddfe35fdc7e310a45cadcfe314ba6809672f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "claude-cookbooks",
+        "type": "github"
+      }
+    },
     "claude-plugins-official": {
       "flake": false,
       "locked": {
@@ -200,6 +376,22 @@
         "owner": "anthropics",
         "repo": "claude-plugins-official",
         "rev": "104d39be10b7b1380b2ae23a387a11a297b599c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "type": "github"
+      }
+    },
+    "claude-plugins-official_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775860746,
+        "narHash": "sha256-wt+D1LKRWQDPuLA0f4X2deV5LDL7+x0iz7+2BHkkAYs=",
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "rev": "7ed523140f506611c968a0ec32e1dfc40a1d5673",
         "type": "github"
       },
       "original": {
@@ -224,7 +416,40 @@
         "type": "github"
       }
     },
+    "claude-skills_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775668456,
+        "narHash": "sha256-AGvjE398hSve2gctkVodCdcmMsN8/7OdwMTx4gR8rOo=",
+        "owner": "secondsky",
+        "repo": "claude-skills",
+        "rev": "88da5ffe9767d2b75bd5a5545165ca4bcd868168",
+        "type": "github"
+      },
+      "original": {
+        "owner": "secondsky",
+        "repo": "claude-skills",
+        "type": "github"
+      }
+    },
     "fabric-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775769065,
+        "narHash": "sha256-986ny/DRchsu+MkZFnmGrWaCPaw+SFYJzY768ZEPtfQ=",
+        "owner": "danielmiessler",
+        "repo": "fabric",
+        "rev": "42311fe04b552f63503667b35f26b9b2ad537f95",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danielmiessler",
+        "ref": "v1.4.444",
+        "repo": "fabric",
+        "type": "github"
+      }
+    },
+    "fabric-src_2": {
       "flake": false,
       "locked": {
         "lastModified": 1775769065,
@@ -278,6 +503,22 @@
         "type": "github"
       }
     },
+    "jacobpevans-cc-plugins_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776009076,
+        "narHash": "sha256-ax0tWhq2lopf74Ct8uwRYHb9gfvSrb6VCyWvLlw7G0s=",
+        "owner": "JacobPEvans",
+        "repo": "claude-code-plugins",
+        "rev": "97b7db34db2b0f8388fcdf383929e799d3dd8890",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JacobPEvans",
+        "repo": "claude-code-plugins",
+        "type": "github"
+      }
+    },
     "lunar-claude": {
       "flake": false,
       "locked": {
@@ -293,6 +534,63 @@
         "repo": "lunar-claude",
         "type": "github"
       }
+    },
+    "lunar-claude_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775954149,
+        "narHash": "sha256-2uerJNB6LwsHLn+tbR0EV6dpnOHzrjzZa6gjWAzZcfM=",
+        "owner": "basher83",
+        "repo": "lunar-claude",
+        "rev": "095effbcad721d82fa245c5d0d00b478b76d8838",
+        "type": "github"
+      },
+      "original": {
+        "owner": "basher83",
+        "repo": "lunar-claude",
+        "type": "github"
+      }
+    },
+    "nix-ai-claude": {
+      "inputs": {
+        "ai-assistant-instructions": "ai-assistant-instructions_2",
+        "anthropic-agent-skills": "anthropic-agent-skills_2",
+        "axton-obsidian-visual-skills": "axton-obsidian-visual-skills_2",
+        "bills-claude-skills": "bills-claude-skills_2",
+        "bitwarden-marketplace": "bitwarden-marketplace_2",
+        "browser-use-skills": "browser-use-skills_2",
+        "cc-dev-tools": "cc-dev-tools_2",
+        "cc-marketplace": "cc-marketplace_2",
+        "claude-code-plugins-plus": "claude-code-plugins-plus_2",
+        "claude-code-workflows": "claude-code-workflows_2",
+        "claude-cookbooks": "claude-cookbooks_2",
+        "claude-plugins-official": "claude-plugins-official_2",
+        "claude-skills": "claude-skills_2",
+        "fabric-src": "fabric-src_2",
+        "home-manager": [
+          "home-manager"
+        ],
+        "jacobpevans-cc-plugins": "jacobpevans-cc-plugins_2",
+        "lunar-claude": "lunar-claude_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "obsidian-skills": "obsidian-skills",
+        "openai-codex": "openai-codex",
+        "pal-mcp-server": "pal-mcp-server",
+        "superpowers-marketplace": "superpowers-marketplace",
+        "visual-explainer-marketplace": "visual-explainer-marketplace",
+        "wakatime": "wakatime"
+      },
+      "locked": {
+        "path": "./nix-ai-claude",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix-ai-claude",
+        "type": "path"
+      },
+      "parent": []
     },
     "nixpkgs": {
       "locked": {
@@ -326,6 +624,22 @@
         "type": "github"
       }
     },
+    "obsidian-skills_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775150516,
+        "narHash": "sha256-/D5HKtLvVdBh7g7zCFDQmInL7/q8koiR6HL0ARmTCoE=",
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "rev": "fa1e131a014576ff8f8919f191a7ca8d8fded39b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "type": "github"
+      }
+    },
     "openai-codex": {
       "flake": false,
       "locked": {
@@ -342,7 +656,39 @@
         "type": "github"
       }
     },
+    "openai-codex_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775684930,
+        "narHash": "sha256-4kqtfdHlcg3YXWX1og9b5JuLgnB/3Nj5dFMe4Ryt7No=",
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "rev": "6a5c2ba53b734f3cdd8daacbd49f68f3e6c8c167",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "type": "github"
+      }
+    },
     "pal-mcp-server": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765818451,
+        "narHash": "sha256-N10TLndisNT48NVT8OZs7hZFf4D6j8ekPU7RfqwkqY0=",
+        "owner": "BeehiveInnovations",
+        "repo": "pal-mcp-server",
+        "rev": "7afc7c1cc96e23992c8f105f960132c657883bb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BeehiveInnovations",
+        "repo": "pal-mcp-server",
+        "type": "github"
+      }
+    },
+    "pal-mcp-server_2": {
       "flake": false,
       "locked": {
         "lastModified": 1765818451,
@@ -378,16 +724,33 @@
         "home-manager": "home-manager",
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "lunar-claude": "lunar-claude",
+        "nix-ai-claude": "nix-ai-claude",
         "nixpkgs": "nixpkgs",
-        "obsidian-skills": "obsidian-skills",
-        "openai-codex": "openai-codex",
-        "pal-mcp-server": "pal-mcp-server",
-        "superpowers-marketplace": "superpowers-marketplace",
-        "visual-explainer-marketplace": "visual-explainer-marketplace",
-        "wakatime": "wakatime"
+        "obsidian-skills": "obsidian-skills_2",
+        "openai-codex": "openai-codex_2",
+        "pal-mcp-server": "pal-mcp-server_2",
+        "superpowers-marketplace": "superpowers-marketplace_2",
+        "visual-explainer-marketplace": "visual-explainer-marketplace_2",
+        "wakatime": "wakatime_2"
       }
     },
     "superpowers-marketplace": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775805828,
+        "narHash": "sha256-OU3AnCrFesExZdIKF39j9Mu2pXzcm2qHtrC1oALKhtw=",
+        "owner": "obra",
+        "repo": "superpowers-marketplace",
+        "rev": "0b73e2556d4ecf4fe54dbb32b248b5e17ed0c0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "obra",
+        "repo": "superpowers-marketplace",
+        "type": "github"
+      }
+    },
+    "superpowers-marketplace_2": {
       "flake": false,
       "locked": {
         "lastModified": 1774985213,
@@ -419,7 +782,39 @@
         "type": "github"
       }
     },
+    "visual-explainer-marketplace_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774753729,
+        "narHash": "sha256-gaFtCysH6k5ogkb+6yvnwnAeuJqR4kK5OHbHdr64/hk=",
+        "owner": "nicobailon",
+        "repo": "visual-explainer",
+        "rev": "9a97a5818bebbcb61cccf8941d533b82a1ce958b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nicobailon",
+        "repo": "visual-explainer",
+        "type": "github"
+      }
+    },
     "wakatime": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775007070,
+        "narHash": "sha256-XiFVK4LtFvq19LEPK1vNcBO2FUaqiHuaApkI3ZqmYu8=",
+        "owner": "wakatime",
+        "repo": "claude-code-wakatime",
+        "rev": "ec4df00f98ab749171b8899e8be11c063332a35c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wakatime",
+        "repo": "claude-code-wakatime",
+        "type": "github"
+      }
+    },
+    "wakatime_2": {
       "flake": false,
       "locked": {
         "lastModified": 1775007070,

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -11,30 +11,11 @@
   pkgs,
   lib,
   ai-assistant-instructions,
-  marketplaceInputs,
-  claude-cookbooks,
-  claude-code-plugins,
   fabric-src,
-  userConfig ? {
-    ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
-  },
   ...
 }:
 
 let
-  # Claude Code configuration values
-  claudeConfig = import ./claude-config.nix {
-    inherit
-      config
-      pkgs
-      lib
-      ai-assistant-instructions
-      marketplaceInputs
-      claude-cookbooks
-      fabric-src
-      ;
-  };
-
   # AgentsMD symlinks from ai-assistant-instructions flake input
   agentsMdSymlinks = {
     "CLAUDE.md" = {
@@ -91,7 +72,6 @@ let
 in
 {
   imports = [
-    ./claude
     ./fabric
     ./maestro
     ./mlx
@@ -106,13 +86,6 @@ in
       file = geminiFiles.file // codexFiles // geminiCommands // copilotFiles // agentsMdSymlinks;
 
       activation = geminiFiles.activation // {
-        # Claude Code Settings Validation (post-rebuild)
-        validateClaudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-          $DRY_RUN_CMD ${./scripts/validate-claude-settings.sh} \
-            "${config.home.homeDirectory}/.claude/settings.json" \
-            "${userConfig.ai.claudeSchemaUrl}"
-        '';
-
         # open-webui: installed via uv (nixpkgs broken on darwin — see modules/open-webui.nix)
         installOpenWebui = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           if ! ${lib.getExe pkgs.uv} tool list 2>/dev/null | grep -q "^open-webui"; then
@@ -133,13 +106,6 @@ in
 
     # Programs configuration
     programs = {
-      # Claude Code declarative configuration
-      claude = claudeConfig;
-
-      # Claude Code statusline (switched from powerline to daniel3303)
-      claudeStatusline.enable = false; # Disabled (kept for easy re-enable)
-      claudeStatuslineDaniel3303.enable = true; # Active: ClaudeCodeStatusLine (2-line)
-
       # MLX inference server (vllm-mlx on port 11434)
       mlx.enable = true;
 

--- a/nix-ai-claude/.claude/rules-plugin-cache-architecture.md
+++ b/nix-ai-claude/.claude/rules-plugin-cache-architecture.md
@@ -1,0 +1,76 @@
+# Plugin Cache Architecture
+
+## Marketplace Symlinks
+
+Marketplace directories (`~/.claude/plugins/marketplaces/`) are single directory symlinks
+to the Nix store, NOT recursive per-file symlinks.
+
+**Never use `recursive = true` or `force = true` in `plugins.nix`:**
+
+- `recursive = true` creates per-file symlinks, which allows `.backup` file pollution
+- `force = true` causes home-manager to rename existing files to `.backup`, polluting
+  Claude Code's plugin cache when it re-indexes from marketplaces
+- Neither is needed because Claude Code only READS from marketplaces
+
+## Read/Write Separation
+
+- **Marketplaces** (`~/.claude/plugins/marketplaces/`): Read-only. Managed by Nix.
+  Claude Code reads plugin definitions from here but never writes.
+- **Cache** (`~/.claude/plugins/cache/`): Read-write. Owned by Claude Code.
+  Plugin state, indexes, and cached data live here.
+
+## Never Delete Plugin Cache Mid-Session
+
+Deleting `~/.claude/plugins/cache/` or `~/.claude/plugins/installed_plugins.json` during
+an active Claude Code session creates an unbreakable hook error loop. All registered hooks
+(PreToolUse, PostToolUse, Stop) reference files inside the cache directory. Deleting it
+causes every hook invocation to fail, including the Stop hook, creating an infinite error
+loop that requires force-killing the process.
+
+Cache staleness is handled automatically by `verify-cache-integrity.sh` on every
+`darwin-rebuild switch`. No manual cache deletion is ever needed.
+
+## Never Mutate Plugin Cache from Activation Scripts
+
+`home.activation` scripts MUST NOT run `claude plugins update`, `claude plugins marketplace update`,
+or any command that creates/deletes directories under `~/.claude/plugins/cache/`.
+
+These commands regenerate cache directories with new hashes, which breaks `${CLAUDE_PLUGIN_ROOT}`
+references in active Claude Code sessions. All registered hooks (PreToolUse, PostToolUse, Stop)
+resolve `${CLAUDE_PLUGIN_ROOT}` at session start — when the old hash path disappears, every hook
+call fails, including the Stop hook, creating an unbreakable error loop.
+
+The correct mechanism is:
+
+- **Nix-managed marketplace symlinks** update the store path on rebuild
+- **`verify-cache-integrity.sh`** (in `orphan-cleanup.nix`) detects stale caches via hash comparison
+  and purges only when the store path actually changed
+- **Claude Code detects marketplace changes on new session start** — no forced re-index needed
+
+Commit `edba1ad` (2026-03-19) introduced an `updateClaudePlugins` activation script that violated
+this rule, causing intermittent hook failures in active sessions. It was removed in the subsequent fix.
+
+## Synthetic Marketplaces
+
+Repos with skills but no native `.claude-plugin/` structure (e.g., `browser-use/browser-use`)
+need a synthetic marketplace wrapper. The derivation in `claude-config.nix` must create:
+
+1. **Marketplace manifest**: `.claude-plugin/marketplace.json` at the marketplace root
+2. **Per-plugin manifest**: `.claude-plugin/plugin.json` inside each plugin directory
+3. **Skills symlink**: linking to the upstream repo's skills
+
+Without the per-plugin `plugin.json`, Claude Code reports "Plugin X not found in marketplace Y"
+even when the marketplace.json correctly declares the plugin.
+
+Additionally, Claude Code discovers marketplaces via `~/.claude/plugins/known_marketplaces.json`
+(its actual registry), NOT directly from `extraKnownMarketplaces` in `settings.json`. Entries
+propagate from `extraKnownMarketplaces` only when Claude Code can successfully fetch the
+marketplace from the declared GitHub source. Synthetic marketplaces fail this fetch (no upstream
+structure), so the `knownMarketplacesMerge` activation in `settings.nix` ensures the local
+`installLocation` is registered directly.
+
+## Migration Path
+
+Phase 1 of `orphan-cleanup.nix` handles the one-time migration from `recursive = true`
+(real directories with per-file symlinks) to directory symlinks. After the first rebuild,
+marketplace paths are already symlinks and the migration code is a no-op.

--- a/nix-ai-claude/CLAUDE.md
+++ b/nix-ai-claude/CLAUDE.md
@@ -70,7 +70,6 @@ constraints and on-demand patterns.
 
 - `modules/default.nix` — Module entry point (imports all AI modules)
 - `modules/claude/` — Claude Code settings, plugins, statusline, auto-claude
-- `nix-ai-claude/` — staged standalone Claude-only flake extracted from this repo
 - `modules/mcp/` — MCP server definitions
 - `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools, perf tuning)
 - `modules/common/` — Shared permission engine and formatters

--- a/nix-ai-claude/CLAUDE.md
+++ b/nix-ai-claude/CLAUDE.md
@@ -1,6 +1,6 @@
-# nix-ai - AI Agent Instructions
+# nix-ai-claude - AI Agent Instructions
 
-AI CLI ecosystem for Claude, Gemini, Copilot, MCP servers via Nix home-manager modules.
+Standalone Claude-specific AI CLI ecosystem extracted from nix-ai.
 
 ## Critical Constraints
 
@@ -22,7 +22,7 @@ nix fmt            # Fix formatting
 
 ```bash
 sudo darwin-rebuild switch --flake "$HOME/git/nix-darwin/main" \
-  --override-input nix-ai "$HOME/git/nix-ai/<worktree>"
+  --override-input nix-ai-claude "$HOME/git/nix-ai-claude/<worktree>"
 ```
 
 Then verify in a live Claude Code session — static checks validate Nix
@@ -31,11 +31,10 @@ feature loads without errors before claiming done.
 
 ## Architecture
 
-This repo exports home-manager modules consumed by nix-darwin:
+This repo exports home-manager modules consumed by nix-darwin or by nix-ai:
 
-- `homeManagerModules.default` — Full AI stack
+- `homeManagerModules.default` — Claude module stack for standalone use
 - `homeManagerModules.claude` — Claude Code only
-- `homeManagerModules.maestro` — Maestro orchestration only
 - `lib.ci.claudeSettingsJson` — Pure JSON for CI validation
 
 ### Self-contained design
@@ -43,20 +42,17 @@ This repo exports home-manager modules consumed by nix-darwin:
 Modules inject their own dependencies via `_module.args`. Consumers only need:
 
 ```nix
-inputs.nix-ai.inputs.nixpkgs.follows = "nixpkgs";
-inputs.nix-ai.inputs.home-manager.follows = "home-manager";
+inputs.nix-ai-claude.inputs.nixpkgs.follows = "nixpkgs";
+inputs.nix-ai-claude.inputs.home-manager.follows = "home-manager";
 ```
 
 ## Separation Guidelines
 
-### What belongs here (nix-ai)
+### What belongs here (nix-ai-claude)
 
-- AI CLI tools (Claude Code, Gemini, Copilot, Codex, block-goose)
-- MCP servers and wrappers (github-mcp-server, terraform-mcp-server, doppler-mcp, etc.)
-- AI-specific GitHub CLI extensions (gh-aw)
-- AI tool configuration files (`.claude/`, `.gemini/`, `.copilot/`)
-- MLX inference server (vllm-mlx LaunchAgent + wrappers)
-- AI-specific shell utilities (sync-mlx-models, check-pal-mcp, hf CLI wrapper)
+- Claude Code settings, plugins, statusline, auto-claude
+- Supporting MCP/pal/fabric integration needed by Claude
+- Shared permissions/formatter helpers needed by Claude config
 
 ### Package placement
 
@@ -68,17 +64,14 @@ constraints and on-demand patterns.
 
 ## Key Files
 
-- `modules/default.nix` — Module entry point (imports all AI modules)
+- `modules/default.nix` — Standalone module entry point
+- `modules/embedded.nix` — Embedded entrypoint consumed by nix-ai
 - `modules/claude/` — Claude Code settings, plugins, statusline, auto-claude
-- `modules/mcp/` — MCP server definitions
-- `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools, perf tuning)
+- `modules/mcp/` — PAL / model sync support used by Claude
 - `modules/common/` — Shared permission engine and formatters
-- `lib/claude-settings.nix` — Pure settings generator (CI-only; deployment uses modules/claude/settings.nix)
+- `lib/claude-settings.nix` — Pure settings generator (CI-only)
 - `lib/claude-registry.nix` — Marketplace format functions
-- `lib/checks.nix` — Check aggregator (imports lib/checks/{lint,claude,mlx}.nix)
-- `lib/checks/lint.nix` — Formatting, statix, deadnix, shellcheck
-- `lib/checks/claude.nix` — Claude module regression tests, settings-json, maestro-script
-- `lib/checks/mlx.nix` — MLX option/defaults regression, LaunchAgent flag validation
+- `lib/checks/fabric.nix` — Fabric regression checks
 
 ## MLX Ecosystem Stack
 

--- a/nix-ai-claude/LICENSE
+++ b/nix-ai-claude/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jacob P. Evans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nix-ai-claude/README.md
+++ b/nix-ai-claude/README.md
@@ -1,0 +1,30 @@
+# nix-ai-claude
+
+Claude-specific Home Manager module stack extracted from `nix-ai`.
+
+It is designed to work in two modes:
+
+- standalone: import `nix-ai-claude.homeManagerModules.default` directly
+- embedded: let `nix-ai` re-export or import the Claude module as one part of a larger AI tool stack
+
+## Exports
+
+- `homeManagerModules.default`
+- `homeManagerModules.claude`
+- `lib.ci.claudeSettingsJson`
+- `lib.claude-settings`
+- `lib.claude-registry`
+
+## Usage
+
+```nix
+{
+  inputs.nix-ai-claude.url = "github:JacobPEvans/nix-ai-claude";
+}
+```
+
+```nix
+sharedModules = [ nix-ai-claude.homeManagerModules.default ];
+```
+
+This staged copy lives inside `nix-ai` so the extraction can be validated before it is moved to its own repository.

--- a/nix-ai-claude/flake.lock
+++ b/nix-ai-claude/flake.lock
@@ -1,0 +1,424 @@
+{
+  "nodes": {
+    "ai-assistant-instructions": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776008934,
+        "narHash": "sha256-R02sX+Dko7XHyFxQ4dgGz1uA8wjR+aBtJSFmjM9p4ek=",
+        "owner": "JacobPEvans",
+        "repo": "ai-assistant-instructions",
+        "rev": "253e4e2580faaaef9a9ed883e2d3489657c84532",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JacobPEvans",
+        "repo": "ai-assistant-instructions",
+        "type": "github"
+      }
+    },
+    "anthropic-agent-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775755206,
+        "narHash": "sha256-H/oorOl5cch7bnziDz7gHNBv5Q0OAwFbk9w1WLku2kk=",
+        "owner": "anthropics",
+        "repo": "skills",
+        "rev": "12ab35c2eb5668c95810e6a6066f40f4218adc39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
+    "axton-obsidian-visual-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770862721,
+        "narHash": "sha256-28hLlKPifZ0GT3vc3eYuIN0C2DQm6vtZhJIKEomRp0M=",
+        "owner": "axtonliu",
+        "repo": "axton-obsidian-visual-skills",
+        "rev": "1265976d9746a84858b4b7b42fb86a215aa93de9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "axtonliu",
+        "repo": "axton-obsidian-visual-skills",
+        "type": "github"
+      }
+    },
+    "bills-claude-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772306604,
+        "narHash": "sha256-PyQSIuAzLXuah9qvfXSiiXedprtwvq/d7rzaAan7xTA=",
+        "owner": "BillChirico",
+        "repo": "bills-claude-skills",
+        "rev": "3a7e65e88949e3f98a75ea296b53e478e2b5995c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BillChirico",
+        "repo": "bills-claude-skills",
+        "type": "github"
+      }
+    },
+    "bitwarden-marketplace": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775576196,
+        "narHash": "sha256-/NW6DwIdZwt5UqQzuqIG3TE4qjQc9dtcm4ply92Jgsw=",
+        "owner": "bitwarden",
+        "repo": "ai-plugins",
+        "rev": "e6095fe6058d07f34ca32243b0dab19d556a3b2d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitwarden",
+        "repo": "ai-plugins",
+        "type": "github"
+      }
+    },
+    "browser-use-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776008847,
+        "narHash": "sha256-prDfQao291H8fgClUwjyKyee5yAxW2HUKn9COmm9WNQ=",
+        "owner": "browser-use",
+        "repo": "browser-use",
+        "rev": "36438e409e70ab6018a222c931c887b4a4720a71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "browser-use",
+        "repo": "browser-use",
+        "type": "github"
+      }
+    },
+    "cc-dev-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773368188,
+        "narHash": "sha256-HcICAqqI3kP0PWQhWvkaM2DOegINXamgox5u+LH2wYA=",
+        "owner": "Lucklyric",
+        "repo": "cc-dev-tools",
+        "rev": "f6414993a4c5047ab3c6f88866789d03f50bef7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Lucklyric",
+        "repo": "cc-dev-tools",
+        "type": "github"
+      }
+    },
+    "cc-marketplace": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768758615,
+        "narHash": "sha256-BnH8+reZQRy4st+5zwA1EEDLIc2nVIp8CVBizUIkjXo=",
+        "owner": "ananddtyagi",
+        "repo": "cc-marketplace",
+        "rev": "b643305146890bda9b2e694d2c42206ae4d0a4df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ananddtyagi",
+        "repo": "cc-marketplace",
+        "type": "github"
+      }
+    },
+    "claude-code-plugins-plus": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775769794,
+        "narHash": "sha256-ksmRNoD5Vhki99/nndJnLzBMf6B0Y+5eMMUPFFHXYkI=",
+        "owner": "jeremylongshore",
+        "repo": "claude-code-plugins-plus",
+        "rev": "c8a915cb82a09594c12ee5b9aca351a50e28b831",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeremylongshore",
+        "repo": "claude-code-plugins-plus",
+        "type": "github"
+      }
+    },
+    "claude-code-workflows": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775684268,
+        "narHash": "sha256-LFApt/MSM5sp8KxNbghCNkVn3RF3986rhi3mamfsbhM=",
+        "owner": "wshobson",
+        "repo": "agents",
+        "rev": "03d0b4b9eb4d57bd961aa252a56025daa21543e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wshobson",
+        "repo": "agents",
+        "type": "github"
+      }
+    },
+    "claude-cookbooks": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775867615,
+        "narHash": "sha256-sDC2q9iJcN+n/wPr1fItLf+vNxBW8euUJROb5cHc0xA=",
+        "owner": "anthropics",
+        "repo": "claude-cookbooks",
+        "rev": "753ddfe35fdc7e310a45cadcfe314ba6809672f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "claude-cookbooks",
+        "type": "github"
+      }
+    },
+    "claude-plugins-official": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775860746,
+        "narHash": "sha256-wt+D1LKRWQDPuLA0f4X2deV5LDL7+x0iz7+2BHkkAYs=",
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "rev": "7ed523140f506611c968a0ec32e1dfc40a1d5673",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "type": "github"
+      }
+    },
+    "claude-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775668456,
+        "narHash": "sha256-AGvjE398hSve2gctkVodCdcmMsN8/7OdwMTx4gR8rOo=",
+        "owner": "secondsky",
+        "repo": "claude-skills",
+        "rev": "88da5ffe9767d2b75bd5a5545165ca4bcd868168",
+        "type": "github"
+      },
+      "original": {
+        "owner": "secondsky",
+        "repo": "claude-skills",
+        "type": "github"
+      }
+    },
+    "fabric-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775769065,
+        "narHash": "sha256-986ny/DRchsu+MkZFnmGrWaCPaw+SFYJzY768ZEPtfQ=",
+        "owner": "danielmiessler",
+        "repo": "fabric",
+        "rev": "42311fe04b552f63503667b35f26b9b2ad537f95",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danielmiessler",
+        "ref": "v1.4.444",
+        "repo": "fabric",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775425411,
+        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "jacobpevans-cc-plugins": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776009076,
+        "narHash": "sha256-ax0tWhq2lopf74Ct8uwRYHb9gfvSrb6VCyWvLlw7G0s=",
+        "owner": "JacobPEvans",
+        "repo": "claude-code-plugins",
+        "rev": "97b7db34db2b0f8388fcdf383929e799d3dd8890",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JacobPEvans",
+        "repo": "claude-code-plugins",
+        "type": "github"
+      }
+    },
+    "lunar-claude": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775954149,
+        "narHash": "sha256-2uerJNB6LwsHLn+tbR0EV6dpnOHzrjzZa6gjWAzZcfM=",
+        "owner": "basher83",
+        "repo": "lunar-claude",
+        "rev": "095effbcad721d82fa245c5d0d00b478b76d8838",
+        "type": "github"
+      },
+      "original": {
+        "owner": "basher83",
+        "repo": "lunar-claude",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "obsidian-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775150516,
+        "narHash": "sha256-/D5HKtLvVdBh7g7zCFDQmInL7/q8koiR6HL0ARmTCoE=",
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "rev": "fa1e131a014576ff8f8919f191a7ca8d8fded39b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "type": "github"
+      }
+    },
+    "openai-codex": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775684930,
+        "narHash": "sha256-4kqtfdHlcg3YXWX1og9b5JuLgnB/3Nj5dFMe4Ryt7No=",
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "rev": "6a5c2ba53b734f3cdd8daacbd49f68f3e6c8c167",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "type": "github"
+      }
+    },
+    "pal-mcp-server": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765818451,
+        "narHash": "sha256-N10TLndisNT48NVT8OZs7hZFf4D6j8ekPU7RfqwkqY0=",
+        "owner": "BeehiveInnovations",
+        "repo": "pal-mcp-server",
+        "rev": "7afc7c1cc96e23992c8f105f960132c657883bb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BeehiveInnovations",
+        "repo": "pal-mcp-server",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ai-assistant-instructions": "ai-assistant-instructions",
+        "anthropic-agent-skills": "anthropic-agent-skills",
+        "axton-obsidian-visual-skills": "axton-obsidian-visual-skills",
+        "bills-claude-skills": "bills-claude-skills",
+        "bitwarden-marketplace": "bitwarden-marketplace",
+        "browser-use-skills": "browser-use-skills",
+        "cc-dev-tools": "cc-dev-tools",
+        "cc-marketplace": "cc-marketplace",
+        "claude-code-plugins-plus": "claude-code-plugins-plus",
+        "claude-code-workflows": "claude-code-workflows",
+        "claude-cookbooks": "claude-cookbooks",
+        "claude-plugins-official": "claude-plugins-official",
+        "claude-skills": "claude-skills",
+        "fabric-src": "fabric-src",
+        "home-manager": "home-manager",
+        "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
+        "lunar-claude": "lunar-claude",
+        "nixpkgs": "nixpkgs",
+        "obsidian-skills": "obsidian-skills",
+        "openai-codex": "openai-codex",
+        "pal-mcp-server": "pal-mcp-server",
+        "superpowers-marketplace": "superpowers-marketplace",
+        "visual-explainer-marketplace": "visual-explainer-marketplace",
+        "wakatime": "wakatime"
+      }
+    },
+    "superpowers-marketplace": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775805828,
+        "narHash": "sha256-OU3AnCrFesExZdIKF39j9Mu2pXzcm2qHtrC1oALKhtw=",
+        "owner": "obra",
+        "repo": "superpowers-marketplace",
+        "rev": "0b73e2556d4ecf4fe54dbb32b248b5e17ed0c0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "obra",
+        "repo": "superpowers-marketplace",
+        "type": "github"
+      }
+    },
+    "visual-explainer-marketplace": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774753729,
+        "narHash": "sha256-gaFtCysH6k5ogkb+6yvnwnAeuJqR4kK5OHbHdr64/hk=",
+        "owner": "nicobailon",
+        "repo": "visual-explainer",
+        "rev": "9a97a5818bebbcb61cccf8941d533b82a1ce958b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nicobailon",
+        "repo": "visual-explainer",
+        "type": "github"
+      }
+    },
+    "wakatime": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775007070,
+        "narHash": "sha256-XiFVK4LtFvq19LEPK1vNcBO2FUaqiHuaApkI3ZqmYu8=",
+        "owner": "wakatime",
+        "repo": "claude-code-wakatime",
+        "rev": "ec4df00f98ab749171b8899e8be11c063332a35c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wakatime",
+        "repo": "claude-code-wakatime",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix-ai-claude/flake.nix
+++ b/nix-ai-claude/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "AI CLI ecosystem for Claude, Gemini, Copilot (Nix flake)";
+  description = "Claude Code module and automation stack extracted from nix-ai";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
@@ -9,30 +9,16 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    nix-ai-claude = {
-      url = "path:./nix-ai-claude";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.home-manager.follows = "home-manager";
-    };
-
-    # Official Anthropic repositories
-    claude-code-plugins = {
-      url = "github:anthropics/claude-code";
-      flake = false;
-    };
-
     claude-cookbooks = {
       url = "github:anthropics/claude-cookbooks";
       flake = false;
     };
 
-    # AI Assistant Instructions - source of truth for AI agent configuration
     ai-assistant-instructions = {
       url = "github:JacobPEvans/ai-assistant-instructions";
       flake = false;
     };
 
-    # Marketplace Inputs
     anthropic-agent-skills = {
       url = "github:anthropics/skills";
       flake = false;
@@ -43,6 +29,10 @@
     };
     bitwarden-marketplace = {
       url = "github:bitwarden/ai-plugins";
+      flake = false;
+    };
+    browser-use-skills = {
+      url = "github:browser-use/browser-use";
       flake = false;
     };
     cc-dev-tools = {
@@ -102,21 +92,11 @@
       flake = false;
     };
 
-    # Skill-only repos (no marketplace structure — wrapped via synthetic derivation)
-    browser-use-skills = {
-      url = "github:browser-use/browser-use";
-      flake = false;
-    };
-
-    # PAL MCP server - pinned for supply-chain safety; auto-bumped by deps-update-flake.yml
     pal-mcp-server = {
       url = "github:BeehiveInnovations/pal-mcp-server";
       flake = false;
     };
 
-    # Fabric - Daniel Miessler's 252+ AI prompt pattern framework (Go CLI).
-    # Source of both the fabric binary and the pattern library. Pinned to a
-    # release tag; Renovate bumps via the annotation in modules/fabric/package.nix.
     fabric-src = {
       url = "github:danielmiessler/fabric/v1.4.444";
       flake = false;
@@ -128,13 +108,12 @@
       self,
       nixpkgs,
       home-manager,
-      nix-ai-claude,
-      claude-code-plugins,
       claude-cookbooks,
       ai-assistant-instructions,
       anthropic-agent-skills,
       bills-claude-skills,
       bitwarden-marketplace,
+      browser-use-skills,
       cc-dev-tools,
       cc-marketplace,
       claude-code-plugins-plus,
@@ -149,7 +128,6 @@
       superpowers-marketplace,
       visual-explainer-marketplace,
       wakatime,
-      browser-use-skills,
       pal-mcp-server,
       fabric-src,
       ...
@@ -185,19 +163,13 @@
       };
     in
     {
-      # Home-manager modules
       homeManagerModules = {
-        # Full AI CLI module
         default = {
-          imports = [
-            "${nix-ai-claude}/modules/embedded.nix"
-            ./modules/default.nix
-          ];
+          imports = [ ./modules/default.nix ];
           _module.args = {
             inherit
               ai-assistant-instructions
               marketplaceInputs
-              claude-code-plugins
               claude-cookbooks
               pal-mcp-server
               fabric-src
@@ -205,57 +177,85 @@
           };
         };
 
-        # Individual modules for selective import
-        claude = nix-ai-claude.homeManagerModules.claude;
-
-        maestro = {
-          imports = [ ./modules/maestro ];
+        claude = {
+          imports = [ ./modules/embedded.nix ];
+          _module.args = {
+            inherit
+              ai-assistant-instructions
+              marketplaceInputs
+              claude-cookbooks
+              pal-mcp-server
+              fabric-src
+              ;
+          };
         };
       };
 
-      # CI-friendly outputs
       lib = {
         ci = {
-          inherit (nix-ai-claude.lib.ci) claudeSettingsJson;
+          claudeSettingsJson =
+            let
+              aiCommon = import ./modules/common {
+                inherit ai-assistant-instructions;
+                inherit (nixpkgs) lib;
+                config = {
+                  home.homeDirectory = "/home/user";
+                };
+              };
+              inherit (aiCommon) permissions formatters;
+            in
+            builtins.toJSON (
+              import ./lib/claude-settings.nix {
+                inherit (nixpkgs) lib;
+                homeDir = "/home/user";
+                schemaUrl = "https://json.schemastore.org/claude-code-settings.json";
+                permissions = {
+                  allow = formatters.claude.formatAllowed permissions;
+                  deny = formatters.claude.formatDenied permissions;
+                  ask = [ ];
+                };
+                plugins =
+                  (import ./modules/claude-plugins.nix {
+                    inherit (nixpkgs) lib;
+                    inherit marketplaceInputs claude-cookbooks;
+                  }).pluginConfig;
+              }
+            );
         };
 
-        # Expose lib functions
-        inherit (nix-ai-claude.lib) claude-settings claude-registry;
-        versions = import ./lib/versions.nix;
+        claude-settings = import ./lib/claude-settings.nix;
+        claude-registry = import ./lib/claude-registry.nix;
       };
 
-      # Quality checks (formatting, linting, dead code, shellcheck, module-eval)
       checks = forAllSystems (
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-        in
-        import ./lib/checks.nix {
-          inherit
-            pkgs
-            home-manager
-            pal-mcp-server
-            fabric-src
-            ;
-          src = ./.;
           aiModule = self.homeManagerModules.default;
-        }
-      );
-
-      # Expose custom packages for nix-update automation
-      packages = forAllSystems (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
+          hmConfig = home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+              aiModule
+              {
+                _module.args.userConfig = {
+                  ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
+                };
+                home = {
+                  username = "test-user";
+                  homeDirectory = "/home/test-user";
+                  stateVersion = "25.11";
+                };
+                programs.mlx = {
+                  enable = true;
+                  host = "127.0.0.1";
+                  port = 11434;
+                  defaultModel = "mlx-community/Qwen3.5-122B-A10B-4bit";
+                };
+              }
+            ];
+          };
         in
-        {
-          gh-aw = pkgs.callPackage ./modules/gh-extensions/gh-aw.nix { };
-          pal-mcp-server = pkgs.callPackage ./modules/mcp/pal-package.nix { inherit pal-mcp-server; };
-          fabric-ai = pkgs.callPackage ./modules/fabric/package.nix { inherit fabric-src; };
-        }
+        import ./lib/checks/claude.nix { inherit pkgs hmConfig; }
       );
-
-      # Formatter
-      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
     };
 }

--- a/nix-ai-claude/lib/checks/claude.nix
+++ b/nix-ai-claude/lib/checks/claude.nix
@@ -1,0 +1,316 @@
+# Claude module regression tests and pure generators
+{ pkgs, hmConfig }:
+let
+  cfg = hmConfig.config.programs.claude;
+in
+{
+  # Evaluate the real home-manager module with real inputs to catch import errors
+  module-eval = builtins.seq hmConfig.activationPackage (
+    pkgs.runCommand "check-module-eval" { } ''
+      touch $out
+    ''
+  );
+
+  # Verify all expected option paths exist in the evaluated module.
+  # Catches accidentally dropped options (e.g., from refactoring with lib;).
+  options-regression =
+    let
+      expectedClaudeOptions = [
+        "agents"
+        "apiKeyHelper"
+        "attribution"
+        "autoUpdatesChannel"
+        "commands"
+        "effortLevel"
+        "enable"
+        "features"
+        "hooks"
+        "mcpServers"
+        "model"
+        "plugins"
+        "remoteControlAtStartup"
+        "rules"
+        "settings"
+        "showTurnDuration"
+        "skills"
+        "statusLine"
+        "teammateMode"
+        "trustedProjectDirs"
+      ];
+      actualClaudeOptions = builtins.attrNames cfg;
+      missingClaudeOptions = builtins.filter (
+        o: !(builtins.elem o actualClaudeOptions)
+      ) expectedClaudeOptions;
+
+      expectedSettingsOptions = [
+        "additionalDirectories"
+        "alwaysThinkingEnabled"
+        "cleanupPeriodDays"
+        "env"
+        "permissions"
+        "sandbox"
+        "schemaUrl"
+      ];
+      actualSettingsOptions = builtins.attrNames cfg.settings;
+      missingSettingsOptions = builtins.filter (
+        s: !(builtins.elem s actualSettingsOptions)
+      ) expectedSettingsOptions;
+
+      expectedHookOptions = [
+        "postToolUse"
+        "preToolUse"
+        "sessionEnd"
+        "sessionStart"
+        "stop"
+        "subagentStop"
+        "userPromptSubmit"
+      ];
+      actualHookOptions = builtins.attrNames cfg.hooks;
+      missingHookOptions = builtins.filter (h: !(builtins.elem h actualHookOptions)) expectedHookOptions;
+
+      expectedPermissionOptions = [
+        "allow"
+        "ask"
+        "deny"
+      ];
+      actualPermissionOptions = builtins.attrNames cfg.settings.permissions;
+      missingPermissionOptions = builtins.filter (
+        p: !(builtins.elem p actualPermissionOptions)
+      ) expectedPermissionOptions;
+
+      expectedSandboxOptions = [
+        "autoAllowBashIfSandboxed"
+        "enabled"
+        "excludedCommands"
+      ];
+      actualSandboxOptions = builtins.attrNames cfg.settings.sandbox;
+      missingSandboxOptions = builtins.filter (
+        s: !(builtins.elem s actualSandboxOptions)
+      ) expectedSandboxOptions;
+    in
+    assert
+      missingClaudeOptions == [ ]
+      || throw "Missing Claude options: ${builtins.toJSON missingClaudeOptions}";
+    assert
+      missingSettingsOptions == [ ]
+      || throw "Missing settings options: ${builtins.toJSON missingSettingsOptions}";
+    assert
+      missingHookOptions == [ ] || throw "Missing hook options: ${builtins.toJSON missingHookOptions}";
+    assert
+      missingPermissionOptions == [ ]
+      || throw "Missing permission options: ${builtins.toJSON missingPermissionOptions}";
+    assert
+      missingSandboxOptions == [ ]
+      || throw "Missing sandbox options: ${builtins.toJSON missingSandboxOptions}";
+    pkgs.runCommand "check-options-regression" { } ''
+      echo "Option regression: ${toString (builtins.length expectedClaudeOptions)} Claude, ${toString (builtins.length expectedSettingsOptions)} settings, ${toString (builtins.length expectedHookOptions)} hooks, ${toString (builtins.length expectedPermissionOptions)} permissions, ${toString (builtins.length expectedSandboxOptions)} sandbox options verified"
+      touch $out
+    '';
+
+  # Verify evaluated config values match expected values.
+  # Tests the FULL module output (options.nix defaults + claude-config.nix overrides).
+  # Catches unintended changes to either file.
+  defaults-regression =
+    let
+      checks = [
+        {
+          name = "enable";
+          actual = cfg.enable;
+          expected = true;
+        }
+        {
+          name = "alwaysThinkingEnabled";
+          actual = cfg.settings.alwaysThinkingEnabled;
+          expected = true;
+        }
+        {
+          name = "cleanupPeriodDays";
+          actual = cfg.settings.cleanupPeriodDays;
+          expected = 30;
+        }
+        {
+          name = "autoUpdatesChannel";
+          actual = cfg.autoUpdatesChannel;
+          expected = "latest";
+        }
+        {
+          name = "teammateMode";
+          actual = cfg.teammateMode;
+          expected = "auto";
+        }
+        {
+          name = "showTurnDuration";
+          actual = cfg.showTurnDuration;
+          expected = true;
+        }
+        {
+          name = "sandbox.enabled";
+          actual = cfg.settings.sandbox.enabled;
+          expected = false;
+        }
+        {
+          name = "sandbox.autoAllowBashIfSandboxed";
+          actual = cfg.settings.sandbox.autoAllowBashIfSandboxed;
+          expected = true;
+        }
+        {
+          name = "statusLine.enable";
+          actual = cfg.statusLine.enable;
+          expected = true;
+        }
+        {
+          name = "schemaUrl";
+          actual = cfg.settings.schemaUrl;
+          expected = "https://json.schemastore.org/claude-code-settings.json";
+        }
+        {
+          name = "plugins.allowRuntimeInstall";
+          actual = cfg.plugins.allowRuntimeInstall;
+          expected = true;
+        }
+        {
+          name = "features.pluginSchemaVersion";
+          actual = cfg.features.pluginSchemaVersion;
+          expected = 1;
+        }
+        {
+          name = "remoteControlAtStartup";
+          actual = cfg.remoteControlAtStartup;
+          expected = true;
+        }
+        {
+          name = "apiKeyHelper.enable";
+          actual = cfg.apiKeyHelper.enable;
+          expected = true;
+        }
+      ];
+      failures = builtins.filter (c: c.actual != c.expected) checks;
+      failureMsg = builtins.concatStringsSep "\n" (
+        map (
+          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
+        ) failures
+      );
+    in
+    assert failures == [ ] || throw "Default value regression:\n${failureMsg}";
+    pkgs.runCommand "check-defaults-regression" { } ''
+      echo "Defaults regression: ${toString (builtins.length checks)} critical defaults verified"
+      touch $out
+    '';
+
+  # Validate the pure settings JSON generator (lib/claude-settings.nix).
+  # Verifies structure, required keys, types, and value correctness.
+  settings-json =
+    let
+      ciSettings = import ../claude-settings.nix {
+        inherit (pkgs) lib;
+        homeDir = "/home/test-user";
+        schemaUrl = "https://json.schemastore.org/claude-code-settings.json";
+        permissions = {
+          allow = [
+            "Read"
+            "Write"
+          ];
+          deny = [ "Bash(rm -rf /)" ];
+          ask = [ ];
+        };
+        plugins = {
+          marketplaces = { };
+          enabledPlugins = { };
+        };
+      };
+    in
+    pkgs.runCommand "check-settings-json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+        passAsFile = [ "json" ];
+        json = builtins.toJSON ciSettings;
+      }
+      ''
+        echo "Validating settings JSON structure..."
+
+        # Verify required keys exist
+        jq -e 'has("$schema")' "$jsonPath" > /dev/null || { echo "FAIL: missing \$schema"; exit 1; }
+        jq -e 'has("alwaysThinkingEnabled")' "$jsonPath" > /dev/null || { echo "FAIL: missing alwaysThinkingEnabled"; exit 1; }
+        jq -e 'has("permissions")' "$jsonPath" > /dev/null || { echo "FAIL: missing permissions"; exit 1; }
+        jq -e 'has("extraKnownMarketplaces")' "$jsonPath" > /dev/null || { echo "FAIL: missing extraKnownMarketplaces"; exit 1; }
+        jq -e 'has("enabledPlugins")' "$jsonPath" > /dev/null || { echo "FAIL: missing enabledPlugins"; exit 1; }
+        jq -e 'has("statusLine")' "$jsonPath" > /dev/null || { echo "FAIL: missing statusLine"; exit 1; }
+
+        # Verify permission structure
+        jq -e '.permissions | has("allow")' "$jsonPath" > /dev/null || { echo "FAIL: missing permissions.allow"; exit 1; }
+        jq -e '.permissions | has("deny")' "$jsonPath" > /dev/null || { echo "FAIL: missing permissions.deny"; exit 1; }
+        jq -e '.permissions | has("ask")' "$jsonPath" > /dev/null || { echo "FAIL: missing permissions.ask"; exit 1; }
+        jq -e '.permissions | has("additionalDirectories")' "$jsonPath" > /dev/null || { echo "FAIL: missing permissions.additionalDirectories"; exit 1; }
+
+        # Verify types
+        jq -e '.alwaysThinkingEnabled | type == "boolean"' "$jsonPath" > /dev/null || { echo "FAIL: alwaysThinkingEnabled not boolean"; exit 1; }
+        jq -e '.permissions.allow | type == "array"' "$jsonPath" > /dev/null || { echo "FAIL: permissions.allow not array"; exit 1; }
+        jq -e '.permissions.deny | type == "array"' "$jsonPath" > /dev/null || { echo "FAIL: permissions.deny not array"; exit 1; }
+        jq -e '.permissions.ask | type == "array"' "$jsonPath" > /dev/null || { echo "FAIL: permissions.ask not array"; exit 1; }
+        jq -e '.permissions.additionalDirectories | type == "array"' "$jsonPath" > /dev/null || { echo "FAIL: additionalDirectories not array"; exit 1; }
+        jq -e '.statusLine | type == "object"' "$jsonPath" > /dev/null || { echo "FAIL: statusLine not object"; exit 1; }
+        jq -e '.extraKnownMarketplaces | type == "object"' "$jsonPath" > /dev/null || { echo "FAIL: extraKnownMarketplaces not object"; exit 1; }
+
+        # Verify values
+        jq -e '."$schema" == "https://json.schemastore.org/claude-code-settings.json"' "$jsonPath" > /dev/null || { echo "FAIL: wrong schema URL"; exit 1; }
+        jq -e '.alwaysThinkingEnabled == true' "$jsonPath" > /dev/null || { echo "FAIL: alwaysThinkingEnabled should be true"; exit 1; }
+        jq -e '.permissions.allow | length == 2' "$jsonPath" > /dev/null || { echo "FAIL: expected 2 allow entries"; exit 1; }
+        jq -e '.permissions.deny | length == 1' "$jsonPath" > /dev/null || { echo "FAIL: expected 1 deny entry"; exit 1; }
+        jq -e '.permissions.ask | length == 0' "$jsonPath" > /dev/null || { echo "FAIL: expected 0 ask entries"; exit 1; }
+        jq -e '.statusLine.type == "command"' "$jsonPath" > /dev/null || { echo "FAIL: statusLine.type should be command"; exit 1; }
+
+        echo "Settings JSON: 6 keys, 5 permission fields, 6 type checks, 6 value checks passed"
+        touch $out
+      '';
+
+  # Validate the maestro-cli script extraction produces correct output.
+  # Builds the script via pkgs.substituteAll and verifies content integrity.
+  maestro-script =
+    let
+      testScript = pkgs.replaceVars ../../modules/maestro/scripts/maestro-cli.sh {
+        maestroApp = "/test/path/to/Maestro";
+      };
+    in
+    pkgs.runCommand "check-maestro-script" { } ''
+      echo "Validating maestro-cli script..."
+
+      # Verify @maestroApp@ placeholder was substituted
+      if grep -q "@maestroApp@" ${testScript}; then
+        echo "FAIL: @maestroApp@ placeholder was NOT substituted"
+        exit 1
+      fi
+
+      # Verify the test path appears in the script
+      if ! grep -q "/test/path/to/Maestro" ${testScript}; then
+        echo "FAIL: substituted path not found in script"
+        exit 1
+      fi
+
+      # Verify shebang
+      if ! head -1 ${testScript} | grep -q "#!/usr/bin/env bash"; then
+        echo "FAIL: missing or incorrect shebang"
+        exit 1
+      fi
+
+      # Verify strict mode
+      if ! grep -q "set -euo pipefail" ${testScript}; then
+        echo "FAIL: missing set -euo pipefail"
+        exit 1
+      fi
+
+      # Verify exec command is present
+      if ! grep -q 'exec.*MAESTRO_APP' ${testScript}; then
+        echo "FAIL: missing exec command"
+        exit 1
+      fi
+
+      # Verify error handling exists
+      if ! grep -q 'Maestro not found' ${testScript}; then
+        echo "FAIL: missing error message"
+        exit 1
+      fi
+
+      echo "Maestro script: substitution, shebang, strict mode, exec, error handling verified"
+      touch $out
+    '';
+}

--- a/nix-ai-claude/lib/checks/fabric.nix
+++ b/nix-ai-claude/lib/checks/fabric.nix
@@ -1,0 +1,179 @@
+# Fabric module regression tests
+#
+# Mirrors lib/checks/mlx.nix patterns. Catches silent option/default drift
+# and validates the synthetic fabric-patterns marketplace builds correctly.
+{
+  pkgs,
+  hmConfig,
+  hmConfigFabricServer,
+  fabric-src,
+  src,
+}:
+let
+  cfg = hmConfig.config.programs.fabric;
+in
+{
+  # Verify all expected fabric option paths exist. Note: patternsDir is NOT
+  # an option — it is a computed constant in packages.nix (see that file for
+  # rationale). This check also asserts patternsDir is NOT in the option set.
+  fabric-options-regression =
+    let
+      expectedOptions = [
+        "customPatternsDir"
+        "defaultModel"
+        "enable"
+        "enableServer"
+        "host"
+        "port"
+      ];
+      actualOptions = builtins.attrNames cfg;
+      missingOptions = builtins.filter (o: !(builtins.elem o actualOptions)) expectedOptions;
+      patternsDirIsOption = builtins.elem "patternsDir" actualOptions;
+    in
+    assert missingOptions == [ ] || throw "Missing fabric options: ${builtins.toJSON missingOptions}";
+    assert
+      !patternsDirIsOption
+      || throw "patternsDir must NOT be a configurable option (it is a computed constant — see modules/fabric/packages.nix)";
+    pkgs.runCommand "check-fabric-options-regression" { } ''
+      echo "Fabric option regression: ${toString (builtins.length expectedOptions)} options verified"
+      touch $out
+    '';
+
+  # Verify fabric evaluated config values match expected defaults.
+  # Pinning these so accidental drift breaks the build (port collisions, etc.).
+  fabric-defaults-regression =
+    let
+      checks = [
+        {
+          name = "fabric.enable";
+          actual = cfg.enable;
+          expected = true;
+        }
+        {
+          name = "fabric.enableServer";
+          actual = cfg.enableServer;
+          expected = false;
+        }
+        {
+          name = "fabric.host";
+          actual = cfg.host;
+          expected = "127.0.0.1";
+        }
+        {
+          name = "fabric.port";
+          actual = cfg.port;
+          expected = 8180;
+        }
+        {
+          name = "fabric.defaultModel";
+          actual = cfg.defaultModel;
+          expected = "mlx-community/Qwen3.5-122B-A10B-4bit";
+        }
+        # Environment variables — FABRIC_PATTERNS_DIR is computed from
+        # config.home.homeDirectory + the fixed ".config/fabric/patterns"
+        # relative path (see modules/fabric/packages.nix). This check asserts
+        # the env var stays in sync with the home.file symlink location.
+        {
+          name = "fabric.env.FABRIC_PATTERNS_DIR";
+          actual = hmConfig.config.home.sessionVariables.FABRIC_PATTERNS_DIR;
+          expected = "${hmConfig.config.home.homeDirectory}/.config/fabric/patterns";
+        }
+        {
+          name = "fabric.env.FABRIC_DEFAULT_MODEL";
+          actual = hmConfig.config.home.sessionVariables.FABRIC_DEFAULT_MODEL;
+          expected = cfg.defaultModel;
+        }
+      ];
+      failures = builtins.filter (c: c.actual != c.expected) checks;
+      failureMsg = builtins.concatStringsSep "\n" (
+        map (
+          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
+        ) failures
+      );
+    in
+    assert failures == [ ] || throw "Fabric default value regression:\n${failureMsg}";
+    pkgs.runCommand "check-fabric-defaults-regression" { } ''
+      echo "Fabric defaults regression: ${toString (builtins.length checks)} critical defaults verified"
+      touch $out
+    '';
+
+  # Validate the fabric LaunchAgent (positive case): when enableServer = true,
+  # ProgramArguments must contain --serve and the configured host:port.
+  fabric-launchd =
+    let
+      serverCfg = hmConfigFabricServer.config.programs.fabric;
+      agent = hmConfigFabricServer.config.launchd.agents.fabric.config;
+      args = agent.ProgramArguments;
+      argsStr = builtins.concatStringsSep " " args;
+      expectedAddress = "${serverCfg.host}:${toString serverCfg.port}";
+      hasServeFlag = builtins.elem "--serve" args;
+      hasAddressFlag = builtins.elem "--address" args;
+      hasAddress = builtins.elem expectedAddress args;
+      hasKeepAlive = agent.KeepAlive or false;
+      hasRunAtLoad = agent.RunAtLoad or false;
+      hasBackgroundType = (agent.ProcessType or "") == "Background";
+    in
+    assert
+      hasServeFlag || throw "Fabric LaunchAgent missing --serve flag in ProgramArguments: ${argsStr}";
+    assert
+      hasAddressFlag || throw "Fabric LaunchAgent missing --address flag in ProgramArguments: ${argsStr}";
+    assert
+      hasAddress
+      || throw "Fabric LaunchAgent missing expected address ${expectedAddress} in ProgramArguments: ${argsStr}";
+    assert hasKeepAlive || throw "Fabric LaunchAgent must have KeepAlive = true";
+    assert hasRunAtLoad || throw "Fabric LaunchAgent must have RunAtLoad = true";
+    assert hasBackgroundType || throw "Fabric LaunchAgent must have ProcessType = \"Background\"";
+    pkgs.runCommand "check-fabric-launchd" { } ''
+      echo "Fabric LaunchAgent (enableServer=true): --serve --address ${expectedAddress} verified"
+      touch $out
+    '';
+
+  # Validate the fabric LaunchAgent (negative case): when enableServer = false
+  # (the default), no launchd.agents.fabric entry should exist.
+  fabric-launchd-negative =
+    let
+      hasAgent = hmConfig.config.launchd.agents ? fabric;
+    in
+    assert
+      !hasAgent || throw "Fabric LaunchAgent must NOT be defined when enableServer = false (default)";
+    pkgs.runCommand "check-fabric-launchd-negative" { } ''
+      echo "Fabric LaunchAgent negative: launchd.agents.fabric correctly absent when enableServer = false"
+      touch $out
+    '';
+
+  # Build the synthetic fabric-patterns marketplace and assert the SKILL.md
+  # count matches the curated JSON entry count. Catches silent JSON edits.
+  fabric-marketplace-build =
+    let
+      curated = builtins.fromJSON (
+        builtins.readFile "${src}/modules/claude/fabric-curated-patterns.json"
+      );
+      expectedCount = builtins.length curated.patterns;
+      # Derive version from the package (same source of truth as claude-config.nix)
+      fabricVersion =
+        (pkgs.callPackage "${src}/modules/fabric/package.nix" {
+          inherit fabric-src;
+        }).version;
+      overrides = import "${src}/modules/claude/marketplace-overrides.nix" {
+        inherit pkgs fabric-src fabricVersion;
+        inherit (pkgs) lib;
+        # The browser-use and jacobpevans wrappers also live in this file but
+        # are unused by the fabric check — pass nulls to satisfy module args.
+        marketplaceInputs = {
+          browser-use-skills = null;
+          jacobpevans-cc-plugins = null;
+        };
+      };
+      mp = overrides.fabricMarketplace;
+    in
+    pkgs.runCommand "check-fabric-marketplace-build" { } ''
+      actual_count=$(find ${mp}/fabric-patterns/skills -name SKILL.md | wc -l | tr -d ' ')
+      expected_count=${toString expectedCount}
+      if [ "$actual_count" != "$expected_count" ]; then
+        echo "Fabric marketplace SKILL.md count mismatch: actual=$actual_count expected=$expected_count" >&2
+        exit 1
+      fi
+      echo "Fabric marketplace build: $actual_count SKILL.md files (matches curated JSON)"
+      touch $out
+    '';
+}

--- a/nix-ai-claude/lib/claude-registry.nix
+++ b/nix-ai-claude/lib/claude-registry.nix
@@ -1,0 +1,156 @@
+# Claude Registry Functions
+#
+# Generates known_marketplaces.json structure that Claude Code expects.
+#
+# CRITICAL FIELDS (must match Claude's expectations exactly):
+# ============================================================================
+# 1. Marketplace Keys: MUST match the `name` field from the marketplace's
+#    .claude-plugin/marketplace.json file (NOT the GitHub repo path)
+#    Example: anthropics/skills → manifest name is "anthropic-agent-skills"
+#
+# 2. source.source: Always "github" for GitHub repos (lowercase)
+# 3. source.repo: GitHub path "owner/repo" format
+# 4. installLocation: Full absolute path to cache directory
+# 5. lastUpdated: ISO 8601 timestamp with milliseconds
+#
+# How to find manifest names: See docs/TESTING-MARKETPLACES.md
+# ============================================================================
+#
+# Parameters:
+#   lib: nixpkgs lib (required)
+#   lastUpdated: ISO 8601 timestamp (default: epoch, caller should provide current time)
+{
+  lib,
+  lastUpdated ? "1970-01-01T00:00:00.000Z",
+}:
+
+let
+  # ==========================================================================
+  # SINGLE SOURCE OF TRUTH: Marketplace Format Transformation
+  # ==========================================================================
+  # This function converts Nix marketplace definitions into Claude Code format.
+  #
+  # INPUT SPECIFICATION (Nix definition):
+  #   {
+  #     source = {
+  #       type = "github";           # or "git" for full URLs
+  #       url = "owner/repo";        # GitHub short form: owner/repo
+  #                                   # OR full URL: https://github.com/owner/repo.git
+  #     };
+  #   }
+  #
+  # OUTPUT SPECIFICATION (Claude Code settings.json):
+  #   {
+  #     source = {
+  #       source = "github";         # Always "github" for GitHub repos
+  #       repo = "marketplace-key";  # The marketplace identifier
+  #     };
+  #   }
+  #
+  # TRANSFORMATION LOGIC:
+  #   - Both type="github" and type="git" become source="github" in output
+  #   - The URL field becomes the repo value (the actual GitHub path for fetching)
+  #   - The KEY can differ from URL for display purposes (e.g., "wakatime" vs "wakatime/claude-code-wakatime")
+  #   - Non-GitHub types keep their source type and url unchanged
+  #
+  # DOCUMENTATION LOCATION:
+  #   See modules/home-manager/ai-cli/claude-plugins.nix for detailed format docs
+  #   and examples of correct usage.
+  #
+  # Usage: Import this function in any module that needs to transform marketplaces:
+  #   claudeRegistry = import ../../lib/claude-registry.nix { inherit lib; };
+  #   transformed = claudeRegistry.toClaudeMarketplaceFormat name marketplace;
+  #
+  toClaudeMarketplaceFormat = _name: m: {
+    source =
+      if m.source.type == "github" || m.source.type == "git" then
+        {
+          source = "github";
+          repo = m.source.url; # Use URL for GitHub path (allows key to differ for display)
+        }
+      else
+        {
+          source = m.source.type;
+          inherit (m.source) url;
+        };
+  };
+in
+{
+  # Export the transformation function for use by other modules
+  inherit toClaudeMarketplaceFormat;
+  # Generate the full known_marketplaces.json structure
+  # Matches native Claude Code format exactly
+  mkKnownMarketplaces =
+    {
+      marketplaces,
+      homeDir ? "/home/user",
+      allowRuntimeInstall ? true,
+    }:
+    let
+      # Extract marketplace name from the identifier
+      # e.g., "anthropics/claude-plugins-official" -> "claude-plugins-official"
+      #       "org/team/repo" -> "repo"
+      getMarketplaceName = name: lib.last (lib.splitString "/" name);
+
+      # Convert marketplace config to native format
+      # Uses toClaudeMarketplaceFormat for consistent source formatting
+      toNativeFormat =
+        name: m:
+        let
+          marketplaceName = getMarketplaceName name;
+          # Native format uses local paths, not Nix store
+          localPath = "${homeDir}/.claude/plugins/marketplaces/${marketplaceName}";
+          # Reuse single source of truth for marketplace format
+          formatted = toClaudeMarketplaceFormat name m;
+        in
+        lib.nameValuePair marketplaceName {
+          # Field order matches native: source, installLocation, lastUpdated
+          inherit (formatted) source;
+          installLocation = localPath;
+          inherit lastUpdated;
+        };
+    in
+    # NOTE: "local" marketplace removed - Claude Code doesn't create one by default.
+    # See docs/CLAUDE-MARKETPLACE-ARCHITECTURE.md for details.
+    lib.listToAttrs (lib.mapAttrsToList toNativeFormat marketplaces);
+
+  # Generate installed_plugins.json structure
+  mkInstalledPlugins =
+    {
+      schemaVersion ? 1,
+    }:
+    {
+      version = schemaVersion;
+      plugins = { };
+    };
+
+  # Generate settings.json structure (pure, no derivations)
+  mkSettings =
+    {
+      schemaUrl ? "https://json.schemastore.org/claude-code-settings.json",
+      alwaysThinkingEnabled ? true,
+      permissions ? {
+        allow = [ ];
+        deny = [ ];
+        ask = [ ];
+      },
+      additionalDirectories ? [ ],
+      marketplaces ? { },
+      enabledPlugins ? { },
+      mcpServers ? { },
+    }:
+    {
+      "$schema" = schemaUrl;
+      inherit alwaysThinkingEnabled;
+      permissions = {
+        allow = permissions.allow or [ ];
+        deny = permissions.deny or [ ];
+        ask = permissions.ask or [ ];
+      };
+      inherit additionalDirectories;
+      # Uses toClaudeMarketplaceFormat (single source of truth)
+      extraKnownMarketplaces = lib.mapAttrs toClaudeMarketplaceFormat marketplaces;
+      inherit enabledPlugins;
+      mcpServers = lib.filterAttrs (_: s: !(s.disabled or false)) mcpServers;
+    };
+}

--- a/nix-ai-claude/lib/claude-settings.nix
+++ b/nix-ai-claude/lib/claude-settings.nix
@@ -1,0 +1,63 @@
+# Pure Claude Code Settings Generator
+#
+# Generates the settings attrset without any derivations or platform-specific code.
+# Used by:
+#   - modules/claude/settings.nix (for deployment with jq pretty-printing)
+#   - flake.nix CI output (for cross-platform schema validation)
+#
+# This separation enables pure Nix evaluation for CI while keeping
+# pretty-printed JSON for local deployment.
+#
+# NOTE: Uses toClaudeMarketplaceFormat from lib/claude-registry.nix as
+# SINGLE SOURCE OF TRUTH for marketplace format transformation.
+
+# NOTE: lib MUST be passed in explicitly - no default value.
+# This ensures pure evaluation (CI) works correctly without <nixpkgs> lookup.
+{
+  lib,
+  homeDir,
+  schemaUrl,
+  permissions, # { allow, deny, ask }
+  plugins, # { marketplaces, enabledPlugins }
+}:
+
+let
+  # Import the single source of truth for marketplace formatting
+  claudeRegistry = import ./claude-registry.nix { inherit lib; };
+  inherit (claudeRegistry) toClaudeMarketplaceFormat;
+in
+{
+  # JSON Schema for IDE IntelliSense and validation
+  "$schema" = schemaUrl;
+
+  # Enable extended thinking mode
+  alwaysThinkingEnabled = true;
+
+  # Plugin marketplace configuration - transformed to Claude's expected format
+  extraKnownMarketplaces = lib.mapAttrs toClaudeMarketplaceFormat plugins.marketplaces;
+
+  # Enabled plugins from marketplaces
+  inherit (plugins) enabledPlugins;
+
+  # Permissions from ai-assistant-instructions
+  permissions = {
+    inherit (permissions) allow deny ask;
+
+    # Directory-level read access
+    additionalDirectories = [
+      "~/" # Full home directory access
+      "~/.claude/" # Claude configuration
+      "~/.config/" # XDG config directory
+    ];
+  };
+
+  # Status line configuration
+  statusLine = {
+    type = "command";
+    command = "${homeDir}/.claude/statusline-command.sh";
+  };
+
+  # NOTE: MCP servers are NOT configured in settings.json
+  # Claude Code reads MCP servers from ~/.claude.json (user scope) or .mcp.json (project scope)
+  # Nix manages MCP servers in ~/.claude.json via the claudeJsonMerge activation script
+}

--- a/nix-ai-claude/lib/python.nix
+++ b/nix-ai-claude/lib/python.nix
@@ -1,0 +1,2 @@
+# Change this one line when upgrading (e.g., python314 -> python315).
+{ pkgs }: pkgs.python314

--- a/nix-ai-claude/modules/claude-config.nix
+++ b/nix-ai-claude/modules/claude-config.nix
@@ -1,0 +1,303 @@
+# Claude Code Configuration Values
+#
+# Centralized configuration for the programs.claude module.
+# Imported by common.nix to keep it clean and high-level.
+{
+  config,
+  pkgs,
+  lib,
+  ai-assistant-instructions,
+  marketplaceInputs,
+  claude-cookbooks,
+  fabric-src,
+  ...
+}:
+
+let
+  # Import unified permissions from common module
+  # This reads from ai-assistant-instructions agentsmd/permissions/
+  aiCommon = import ./common { inherit lib config ai-assistant-instructions; };
+  inherit (aiCommon) permissions;
+  inherit (aiCommon) formatters;
+
+  # Dynamic discovery helper - finds all .md files in a directory
+  discoverMarkdownFiles =
+    dir:
+    let
+      files = if builtins.pathExists dir then builtins.readDir dir else { };
+      mdFiles = lib.filterAttrs (name: type: type == "regular" && lib.hasSuffix ".md" name) files;
+    in
+    map (name: lib.removeSuffix ".md" name) (builtins.attrNames mdFiles);
+
+  # Discover commands and agents from configured sources
+  # Commands are discovered from claude-cookbooks; agents from both ai-assistant-instructions and claude-cookbooks
+  cbCommands = discoverMarkdownFiles "${claude-cookbooks}/.claude/commands";
+  aiAgents = discoverMarkdownFiles "${ai-assistant-instructions}/agentsmd/agents";
+  cbAgents = discoverMarkdownFiles "${claude-cookbooks}/.claude/agents";
+  aiRules = discoverMarkdownFiles "${ai-assistant-instructions}/agentsmd/rules";
+
+  # Import modular plugin configuration
+  # Plugin configuration moved to claude-plugins.nix and organized by category
+  # See: modules/home-manager/ai-cli/claude/plugins/*.nix
+  claudePlugins = import ./claude-plugins.nix {
+    inherit lib marketplaceInputs claude-cookbooks;
+  };
+
+  # Extract enabled plugins from modular configuration
+  inherit (claudePlugins.pluginConfig) enabledPlugins;
+
+  # Derive fabric version from the package (single source of truth — Renovate-managed)
+  fabricVersion = (pkgs.callPackage ./fabric/package.nix { inherit fabric-src; }).version;
+
+  # Marketplace derivation overrides (synthetic wrappers, auto-generated manifests)
+  marketplaceOverrides = import ./claude/marketplace-overrides.nix {
+    inherit
+      pkgs
+      lib
+      marketplaceInputs
+      fabric-src
+      fabricVersion
+      ;
+  };
+  inherit (marketplaceOverrides)
+    browserUseMarketplace
+    jacobpevansMarketplace
+    fabricMarketplace
+    ;
+
+  # Helper to build command/agent entries from discovered names
+  mkSourceEntries =
+    sourcePath: names:
+    map (name: {
+      inherit name;
+      source = "${sourcePath}/${name}.md";
+    }) names;
+
+in
+{
+  enable = true;
+
+  # API Key Helper for headless authentication (cron jobs, CI/CD)
+  # Uses Bitwarden Secrets Manager to securely fetch OAuth token
+  # Configuration: ~/.config/bws/.env (see bws-env.example)
+  apiKeyHelper = {
+    enable = true;
+    # scriptPath default: .local/bin/claude-api-key-helper
+  };
+
+  # Agent teams display mode (direct settings.json property)
+  teammateMode = "auto";
+
+  # Model: use account-tier default. The 'opusplan' model is no longer
+  # specified as it lacks a 1M context variant.
+  # See: https://code.claude.com/docs/en/model-config
+
+  # Release channel: "latest" gets newest releases immediately
+  autoUpdatesChannel = "latest";
+
+  # Show turn duration in UI for performance visibility
+  showTurnDuration = true;
+
+  # Enable Remote Control for all sessions (Feb 2026 feature).
+  # Writes remoteControlAtStartup = true into ~/.claude.json via home.activation.
+  # Allows monitoring/controlling sessions from claude.ai or the mobile app.
+  # Requires a Claude Max subscription; no-op if not logged in.
+  remoteControlAtStartup = true;
+
+  # Auto-approve CLAUDE.md external imports for all repos discovered under ~/git/.
+  # Generates hasClaudeMdExternalIncludesApproved = true entries in ~/.claude.json
+  # for each ~/git/<repo>/main path found at home-manager activation time (runtime) via claude-json-merge.sh.
+  trustedProjectDirs = [ "~/git" ];
+
+  # effortLevel = "medium";
+  # Claude Code v2.1.68+ defaults to medium effort for Max/Team subscribers.
+  # Use /model effort slider or "ultrathink" keyword to override per-session.
+  # Uncomment to pin a specific effort level.
+
+  # Minimal commit attribution — replaces verbose Co-Authored-By trailer
+  # Claude Code appends this string to every commit message automatically
+  attribution = {
+    commit = "(claude)";
+  };
+
+  # Auto-Claude: DISABLED - migrating to ai-workflows repo
+  # Module files preserved (guarded by mkIf), will be extracted later
+  autoClaude.enable = false;
+
+  # Menu bar: disabled (depends on auto-claude)
+  menubar.enable = false;
+
+  plugins = {
+    # Marketplaces from modular configuration with flakeInput for Nix symlinks
+    # See: modules/home-manager/ai-cli/claude/plugins/marketplaces.nix
+    # Adding flakeInput enables Nix to create immutable symlinks instead of runtime downloads
+    # Standard marketplaces use raw flake input; synthetic ones override with a derivation
+    marketplaces =
+      let
+        base = lib.mapAttrs (
+          name: marketplace: marketplace // { flakeInput = marketplaceInputs.${name}; }
+        ) claudePlugins.pluginConfig.marketplaces;
+      in
+      base
+      // {
+        # Override flakeInput for synthetic marketplace (source defined in marketplaces.nix)
+        "browser-use-skills" = base."browser-use-skills" // {
+          flakeInput = browserUseMarketplace;
+        };
+        # Override flakeInput with auto-generated marketplace manifest
+        "jacobpevans-cc-plugins" = base."jacobpevans-cc-plugins" // {
+          flakeInput = jacobpevansMarketplace;
+        };
+        # Override flakeInput for synthetic fabric marketplace.
+        # Wraps a curated subset of fabric patterns from data/patterns/ into
+        # the .claude-plugin/ structure so they appear as skills in Claude Code.
+        # Exact count is enforced by the fabric-marketplace-build check
+        # (lib/checks/fabric.nix) against modules/claude/fabric-curated-patterns.json.
+        "fabric-patterns" = base."fabric-patterns" // {
+          flakeInput = fabricMarketplace;
+        };
+      };
+
+    enabled = enabledPlugins;
+    # Enable runtime plugin installation from community marketplaces.
+    # Nix defines the baseline (official plugins via flake inputs).
+    # Claude can dynamically install additional plugins at runtime.
+    # Runtime state tracked in ~/.claude/plugins/installed_plugins.json (not Nix-managed).
+    allowRuntimeInstall = true;
+  };
+
+  commands = {
+    # All commands from Nix store (flake inputs) for reproducibility
+    fromFlakeInputs = mkSourceEntries "${claude-cookbooks}/.claude/commands" cbCommands;
+  };
+
+  agents.fromFlakeInputs =
+    (mkSourceEntries "${ai-assistant-instructions}/agentsmd/agents" aiAgents)
+    ++ (mkSourceEntries "${claude-cookbooks}/.claude/agents" cbAgents);
+
+  # Global rules (loaded every session regardless of project)
+  rules.fromFlakeInputs = mkSourceEntries "${ai-assistant-instructions}/agentsmd/rules" aiRules;
+
+  rules.local = {
+    "pal-mcp-policy" = ./claude/rules/pal-mcp-policy.md;
+    "retrospective-report-location" = ./claude/rules/retrospective-report-location.md;
+  };
+
+  settings = {
+    # Extended thinking enabled with token budget controlled via env vars
+    alwaysThinkingEnabled = true;
+
+    # Session cleanup: explicitly set to 30 days (upstream Claude default).
+    # Keeping this explicit to document the intentional choice and prevent
+    # accidental drift if the module option default ever changes.
+    cleanupPeriodDays = 30;
+
+    # Environment variables for model config and token optimization
+    # See: https://code.claude.com/docs/en/settings
+    # See: https://code.claude.com/docs/en/model-config
+    env = {
+      # Model: uses account-tier default (no override set above).
+      # Auto-claude background jobs use their own CLAUDE_MODEL env var (haiku).
+      # ANTHROPIC_MODEL = "sonnet"; # Uncomment to override default model via env var
+      # CLAUDE_CODE_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"; # Cost control for subagents
+
+      # Explicit model versions (Jan 2026) - pin to known working versions if customization needed
+      # ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-5-20251101";
+      # ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-5-20250929";
+      # ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
+
+      # MCP timeout settings (5 minutes) - required for PAL MCP
+      MCP_TIMEOUT = "300000";
+      MCP_TOOL_TIMEOUT = "300000";
+
+      # Experimental: Agent teams - coordinate multiple Claude Code instances
+      # See: https://code.claude.com/docs/en/agent-teams
+      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+
+      # Adaptive thinking for Opus 4.6/Sonnet 4.6 (explicitly enabled)
+      CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0";
+
+      # DEFAULT VALUES (upstream) - reference only, do not uncomment unless tuning
+      # MAX_THINKING_TOKENS = "31999";
+      # CLAUDE_CODE_MAX_OUTPUT_TOKENS = "32000";
+      # BASH_MAX_OUTPUT_LENGTH = "30000";
+      # MAX_MCP_OUTPUT_TOKENS = "25000";
+      # SLASH_COMMAND_TOOL_CHAR_BUDGET = "16000";
+      # BASH_DEFAULT_TIMEOUT_MS = "120000";  # 2 minutes
+      # BASH_MAX_TIMEOUT_MS = "600000";      # 10 minutes
+
+      # Claude.ai MCP servers (enabled by default for logged-in users)
+      # ENABLE_CLAUDEAI_MCP_SERVERS = "true";
+
+      # Plugin git operations timeout (default: 120000ms / 2 minutes)
+      # CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS = "120000";
+
+      # Effort level via env var (alternative to settings.json key)
+      # CLAUDE_CODE_EFFORT_LEVEL = "medium";
+
+      # ===== OpenTelemetry — OrbStack k8s OTEL Collector =====
+      # Pipeline: Claude Code → OTEL Collector (:30317) → Cribl Stream (:4317) → Splunk HEC
+      # Requires: OrbStack k8s running with OTEL collector deployed.
+      # Source: orbstack-kubernetes/k8s/monitoring/otel-collector/service-external.yaml
+      CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+      OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:30317";
+      OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
+      OTEL_METRICS_EXPORTER = "otlp";
+      OTEL_LOGS_EXPORTER = "otlp";
+      OTEL_TRACES_EXPORTER = "none"; # Only metrics + logs; no trace overhead
+    };
+
+    # Permissions from unified ai-assistant-instructions system
+    # Uses common/permissions.nix which reads from agentsmd/permissions/
+    # Formatted by common/formatters.nix to Claude Code format
+    permissions = {
+      allow = formatters.claude.formatAllowed permissions;
+      deny = formatters.claude.formatDenied permissions;
+      ask = formatters.claude.formatAsk permissions;
+    };
+
+    # Additional directories accessible to Claude Code without prompts
+    additionalDirectories = [
+      "~/"
+      "~/.claude/"
+      "~/.config/"
+    ];
+
+    # Sandbox configuration (Dec 2025 feature)
+    # Provides filesystem/network isolation when working in untrusted codebases.
+    # Currently disabled - enable when reviewing external code or untrusted repos.
+    sandbox = {
+      enabled = false;
+      autoAllowBashIfSandboxed = true; # Safe because sandbox prevents destructive ops
+      excludedCommands = [
+        "git"
+        "nix"
+        "darwin-rebuild"
+      ];
+    };
+  };
+
+  # MCP Servers - deployed to ~/.claude.json via home.activation (see claude/settings.nix).
+  # Nix is the sole manager of user-scoped MCP servers; manual `claude mcp add --scope user`
+  # entries will be overwritten on next darwin-rebuild switch.
+  mcpServers = import ./mcp;
+
+  statusLine = {
+    enable = true;
+  };
+
+  # Hooks: Event-driven automation for Claude Code
+  # See: https://code.claude.com/docs/en/hooks
+  hooks = {
+    # Notify on user input needed (Issue #455)
+    # Sends Slack notification when Claude needs input via AskUserQuestion
+    # Enables mobile/async workflows
+    preToolUse = ./claude/hooks/ask-user-notify.sh;
+
+    # Capture last output for statusline display (Issue #479)
+    # Writes compact summary of last tool execution to ~/.cache/claude-last-output.txt
+    # Can be read by statusline, tmux, or other display tools
+    postToolUse = ./claude/hooks/last-output.sh;
+
+  };
+}

--- a/nix-ai-claude/modules/claude-plugins.nix
+++ b/nix-ai-claude/modules/claude-plugins.nix
@@ -1,0 +1,73 @@
+# Claude Code Plugins Configuration
+#
+# Manages official Anthropic plugins and commands from:
+# - anthropics/claude-code (plugin marketplace)
+# - anthropics/claude-cookbooks (commands and agents)
+#
+# Strategy:
+# 1. Configure plugin marketplaces and enabled plugins (modular structure)
+# 2. Copy useful commands/agents from claude-cookbooks to ~/.claude/
+#
+# Plugin Configuration:
+# - Marketplaces and plugins are defined in modules/home-manager/ai-cli/claude/plugins/
+# - Organized by category: official, community, infrastructure, development, business
+# - See claude/plugins/default.nix for the complete structure
+#
+# Migration Notes:
+# - Removed: "review-pr-ci" - replaced by code-review plugin (/code-review)
+
+{
+  lib,
+  marketplaceInputs,
+  claude-cookbooks,
+  ...
+}:
+
+let
+  # Import modular plugin configuration
+  pluginModules = import ./claude/plugins/default.nix {
+    inherit lib marketplaceInputs;
+  };
+
+  # Commands from claude-cookbooks to install globally
+  # These are copied directly to ~/.claude/commands/
+  cookbookCommands = [
+    "review-issue" # GitHub issue review
+    "notebook-review" # Jupyter notebook review
+    "model-check" # Model validation
+    "link-review" # Link verification
+  ];
+
+  # Agents from claude-cookbooks to install globally
+  # These are copied to ~/.claude/agents/
+  cookbookAgents = [
+    "code-reviewer" # Senior code review agent
+  ];
+in
+{
+  # Plugin marketplace and enabled plugins configuration
+  # Merged into settings.json by claude.nix
+  pluginConfig = {
+    inherit (pluginModules) marketplaces enabledPlugins;
+  };
+
+  # Home-manager file entries for commands and agents
+  # These copy files from the claude-cookbooks repo to ~/.claude/
+  #
+  # Helper function to reduce duplication
+  # Creates file entries for a given type (command/agent) from a list of names
+  files =
+    let
+      mkCookbookFileEntries =
+        type: names:
+        builtins.listToAttrs (
+          map (name: {
+            name = ".claude/${type}s/${name}.md";
+            value = {
+              source = "${claude-cookbooks}/.claude/${type}s/${name}.md";
+            };
+          }) names
+        );
+    in
+    mkCookbookFileEntries "command" cookbookCommands // mkCookbookFileEntries "agent" cookbookAgents;
+}

--- a/nix-ai-claude/modules/claude/TESTING.md
+++ b/nix-ai-claude/modules/claude/TESTING.md
@@ -1,0 +1,305 @@
+# Auto-Claude Testing Documentation
+
+Testing procedures for the auto-claude.sh autonomous maintenance script.
+
+## Prerequisites
+
+- zsh shell available
+- Claude CLI installed (`claude` command in PATH)
+- jq installed for JSON processing
+- gh CLI installed for GitHub operations (optional but recommended)
+- Deployed scripts via home-manager (`darwin-rebuild switch`)
+
+## Basic Validation Tests
+
+### 1. Syntax Validation
+
+Verify the script has valid zsh syntax:
+
+```bash
+zsh -n modules/claude/auto-claude.sh && echo "Syntax OK"
+```
+
+Expected: `Syntax OK`
+
+### 2. Usage Message
+
+Run without arguments to verify usage message:
+
+```bash
+zsh modules/claude/auto-claude.sh
+```
+
+Expected output:
+
+```text
+Usage: /path/to/auto-claude.sh <target_dir> <max_budget_usd> [log_dir]
+```
+
+Exit code: 1
+
+### 3. Invalid Directory Error
+
+Test directory validation:
+
+```bash
+zsh modules/claude/auto-claude.sh /nonexistent 10
+```
+
+Expected output:
+
+```text
+Error: Directory /nonexistent does not exist.
+```
+
+Exit code: 1
+
+### 4. Invalid Budget Error (Negative)
+
+Test budget validation with negative number:
+
+```bash
+zsh modules/claude/auto-claude.sh /tmp -5
+```
+
+Expected output:
+
+```text
+Error: MAX_BUDGET_USD must be a positive number, got: -5
+```
+
+Exit code: 1
+
+### 5. Decimal Budget Validation
+
+Test that decimal budgets are accepted:
+
+```bash
+zsh modules/claude/auto-claude.sh /tmp 0.5 2>&1 | head -5
+```
+
+Expected: Script starts executing (shows Claude initialization output)
+
+## Deployed Script Tests
+
+After `darwin-rebuild switch`, verify deployment:
+
+### 1. Script Deployment
+
+```bash
+ls -la ~/.claude/scripts/auto-claude.sh ~/.claude/scripts/orchestrator-prompt.txt
+```
+
+Expected: Both files exist as symlinks to nix store paths
+
+### 2. Executable Permissions
+
+```bash
+test -x ~/.claude/scripts/auto-claude.sh && echo "Executable OK"
+```
+
+Expected: `Executable OK`
+
+### 3. LaunchAgent Registration
+
+```bash
+launchctl list | grep com.claude.auto-claude
+```
+
+Expected: One or more auto-claude agents listed (if autoClaude.enable = true)
+
+## Integration Test (Live Run)
+
+To test a live run with minimal budget:
+
+```bash
+~/.claude/scripts/auto-claude.sh ~/git/test-repo 0.10 /tmp/auto-claude-test
+```
+
+This will:
+
+1. Source shell configs for environment
+2. Load orchestrator prompt
+3. Start Claude with the specified budget
+4. Log output to /tmp/auto-claude-test/
+
+### Verify Log Output
+
+```bash
+ls -la /tmp/auto-claude-test/
+cat /tmp/auto-claude-test/summary.log
+```
+
+## Slack Notification Tests
+
+Auto-Claude uses the Python notifier with Slack SDK for rich notifications.
+Channels are stored per-repo in the macOS automation keychain.
+
+### Slack Prerequisites
+
+1. Slack bot token in Bitwarden Secrets Manager (secret: `SLACK_BOT_TOKEN`)
+2. Per-repo channel IDs in automation keychain:
+   - `SLACK_CHANNEL_ID_NIX`
+   - `SLACK_CHANNEL_ID_AI_ASSISTANT_INSTRUCTIONS`
+3. BWS config at `~/.config/bws/.env`
+
+### 1. Unlock Automation Keychain
+
+The automation keychain must be unlocked for headless operations:
+
+```bash
+security unlock-keychain ~/Library/Keychains/automation.keychain-db
+```
+
+### 2. Verify Channel IDs in Keychain
+
+Check that channels are retrievable (output suppressed for security):
+
+```bash
+security find-generic-password -s "SLACK_CHANNEL_ID_NIX" -a "ai-cli-coder" -w >/dev/null && echo "NIX: FOUND"
+security find-generic-password -s "SLACK_CHANNEL_ID_AI_ASSISTANT_INSTRUCTIONS" -a "ai-cli-coder" -w >/dev/null && echo "AI: FOUND"
+```
+
+### 3. Run Validation Test Script
+
+```bash
+PYTHONPATH=~/.claude/scripts /etc/profiles/per-user/$USER/bin/python3 \
+  ~/.claude/scripts/test-slack-notifications.py
+```
+
+### 4. Send Test Messages to Each Channel
+
+Define a helper function to avoid repetition:
+
+```bash
+send_test_notification() {
+  local repo_key="$1"
+  local repo_name="$2"
+  local channel
+  channel=$(security find-generic-password -s "SLACK_CHANNEL_ID_${repo_key}" -a "ai-cli-coder" -w)
+  if [[ -z "$channel" ]]; then
+    echo "Channel for ${repo_key} not found in keychain." >&2
+    return 1
+  fi
+
+  PYTHONPATH=~/.claude/scripts /etc/profiles/per-user/$USER/bin/python3 \
+    ~/.claude/scripts/auto-claude-notify.py run_started \
+    --repo "$repo_name" --budget "0.01" --run-id "test-$(date +%s)" \
+    --channel "$channel" && echo "✓ ${repo_key} channel test sent"
+}
+
+# Test NIX channel
+send_test_notification "NIX" "test-nix"
+
+# Test AI-ASSISTANT-INSTRUCTIONS channel
+send_test_notification "AI_ASSISTANT_INSTRUCTIONS" "test-ai"
+```
+
+### 5. End-to-End LaunchD Test
+
+This tests the full launchd-initiated flow:
+
+```bash
+# Ensure keychain is unlocked first
+security unlock-keychain ~/Library/Keychains/automation.keychain-db
+
+# Kickstart the launchd agent
+launchctl kickstart gui/$(id -u)/com.claude.auto-claude-nix
+
+# Monitor logs
+tail -f ~/.claude/logs/launchd-nix.log
+
+# Check for errors
+tail ~/.claude/logs/launchd-nix.err
+```
+
+**Success indicators:**
+
+- Log shows `slack_enabled: "true"` in run_started event
+- Slack channel receives "Run Started" notification
+- No `ModuleNotFoundError` in error log
+
+## Troubleshooting
+
+### Script Not Found
+
+If `claude` command not found after launchd execution:
+
+1. Check PATH in launchd agent:
+
+   ```bash
+   cat ~/Library/LaunchAgents/com.claude.auto-claude-*.plist | grep -A5 PATH
+   ```
+
+2. Verify PATH includes `/run/current-system/sw/bin`
+
+### Orchestrator Prompt Missing
+
+If prompt file not found:
+
+```bash
+ls -la ~/.claude/scripts/orchestrator-prompt.txt
+```
+
+If missing, run `darwin-rebuild switch` to deploy.
+
+### API Authentication Failures
+
+If headless auth fails:
+
+1. Verify apiKeyHelper is enabled
+2. Check BWS secret access:
+
+   ```bash
+   ~/.local/bin/claude-api-key-helper
+   ```
+
+3. Verify keychain token:
+
+   ```bash
+   security find-generic-password -s bws-claude-automation -w
+   ```
+
+### Slack Notifications Not Sending
+
+**Symptom**: `ModuleNotFoundError: No module named 'slack_sdk'`
+
+**Cause**: LaunchD uses wrong Python environment
+
+**Fix**: Rebuild to update launchd plist with per-user profile path:
+
+```bash
+darwin-rebuild switch --flake ~/.config/nix
+```
+
+Verify the plist PATH includes per-user profile:
+
+```bash
+grep PATH ~/Library/LaunchAgents/com.claude.auto-claude-nix.plist
+# Should show: /etc/profiles/per-user/<username>/bin at the start
+```
+
+**Symptom**: Keychain access denied (error -25308)
+
+**Cause**: Automation keychain is locked
+
+**Fix**: Unlock the keychain:
+
+```bash
+security unlock-keychain ~/Library/Keychains/automation.keychain-db
+```
+
+**Symptom**: Channel not found in keychain
+
+**Cause**: Missing per-repo channel entry
+
+**Fix**: Add the channel to automation keychain:
+
+```bash
+security add-generic-password -a "ai-cli-coder" \
+  -s "SLACK_CHANNEL_ID_<REPO_NAME>" \
+  -w "<channel_id>" \
+  ~/Library/Keychains/automation.keychain-db
+```
+
+Replace `<REPO_NAME>` with uppercase repo name (dashes/dots to underscores).

--- a/nix-ai-claude/modules/claude/auto-claude-ctl.sh
+++ b/nix-ai-claude/modules/claude/auto-claude-ctl.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env zsh
+
+# =============================================================================
+# auto-claude-ctl: Runtime Control for Auto-Claude Scheduler
+# =============================================================================
+# Provides runtime control over auto-claude scheduling without modifying Nix.
+# Uses a control file that auto-claude.sh checks before each run.
+#
+# Usage: auto-claude-ctl <command> [args...]
+#
+# Commands:
+#   run                   Actually run auto-claude immediately (bypasses scheduler)
+#   pause <hours>         Pause all runs for specified hours
+#   skip <count>          Skip the next N scheduled runs
+#   resume                Clear pause/skip, resume normal schedule
+#   status                Show current control state and schedule
+#   schedule [h:m ...]    Show or set override schedule (e.g., "9:30 14:00 18:30")
+#   clear-schedule        Clear override schedule, use Nix-defined times
+#
+# Control file: ~/.claude/auto-claude-control.json
+# =============================================================================
+
+set -euo pipefail
+
+# Check for required dependencies
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is not installed. Please install it to use this script." >&2
+  exit 1
+fi
+
+CONTROL_FILE="${HOME}/.claude/auto-claude-control.json"
+SCRIPT_DIR="${HOME}/.claude/scripts"
+AUTO_CLAUDE_SCRIPT="${SCRIPT_DIR}/auto-claude.sh"
+
+# Ensure control directory exists
+mkdir -p "$(dirname "$CONTROL_FILE")"
+
+# Initialize control file if missing
+init_control_file() {
+  if [[ ! -f "$CONTROL_FILE" ]]; then
+    cat > "$CONTROL_FILE" << 'EOF'
+{
+  "pause_until": null,
+  "skip_count": 0,
+  "override_schedule": null,
+  "last_run": null,
+  "last_run_repo": null,
+  "notes": "Control file for auto-claude scheduling. Edit with auto-claude-ctl."
+}
+EOF
+  fi
+}
+
+# Read JSON field (requires jq)
+read_field() {
+  local field="$1"
+  jq -r ".$field // empty" "$CONTROL_FILE" 2>/dev/null || echo ""
+}
+
+# Update JSON field
+update_field() {
+  local field="$1"
+  local value="$2"
+  local tmp
+  tmp=$(mktemp) || { echo "Error: could not create temporary file for updating control file." >&2; return 1; }
+  if [[ -z "$tmp" || ! -f "$tmp" ]]; then
+    echo "Error: invalid temporary file path: '$tmp'" >&2
+    return 1
+  fi
+  if jq ".$field = $value" "$CONTROL_FILE" > "$tmp"; then
+    mv "$tmp" "$CONTROL_FILE"
+  else
+    echo "Error: failed to update control file with jq." >&2
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+# Format timestamp for display
+# Supports both macOS (BSD date) and Linux (GNU date)
+format_time() {
+  local ts="$1"
+  if [[ -z "$ts" || "$ts" == "null" ]]; then
+    echo "never"
+  else
+    # Convert ISO to readable format (cross-platform)
+    if date --version >/dev/null 2>&1; then
+      # GNU date (Linux)
+      date -d "$ts" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || echo "$ts"
+    else
+      # BSD date (macOS)
+      date -j -f "%Y-%m-%dT%H:%M:%S" "${ts%%.*}" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || echo "$ts"
+    fi
+  fi
+}
+
+# Convert ISO8601 timestamp to epoch seconds for reliable comparison
+# Supports both macOS (BSD date) and Linux (GNU date)
+iso_to_epoch() {
+  local iso="$1"
+  if date --version >/dev/null 2>&1; then
+    # GNU date (Linux)
+    date -d "$iso" "+%s" 2>/dev/null
+  else
+    # BSD date (macOS)
+    date -j -f "%Y-%m-%dT%H:%M:%S" "${iso%%.*}" "+%s" 2>/dev/null
+  fi
+}
+
+# Command: run - actually run auto-claude now
+# Usage: auto-claude-ctl run [repo-name]
+# If repo-name is provided, runs that specific repo. Otherwise, lists available repos.
+cmd_run() {
+  init_control_file
+  local target_repo="${1:-}"
+
+  # Find configured repository paths from launchd plists
+  local plist_dir="${HOME}/Library/LaunchAgents"
+  local found_plists=()
+  local found_names=()
+
+  # Collect all auto-claude plists
+  # Enable nullglob so glob expands to nothing if no matches (instead of literal pattern)
+  setopt nullglob
+  for plist in "$plist_dir"/com.claude.auto-claude-*.plist; do
+    if [[ -f "$plist" ]]; then
+      local name=$(basename "$plist" | sed 's/com.claude.auto-claude-//; s/.plist//')
+      found_plists+=("$plist")
+      found_names+=("$name")
+    fi
+  done
+
+  if [[ ${#found_plists[@]} -eq 0 ]]; then
+    echo "Error: No auto-claude configurations found in LaunchAgents" >&2
+    echo "Looking for: $plist_dir/com.claude.auto-claude-*.plist" >&2
+    exit 1
+  fi
+
+  # If no target specified and multiple repos exist, show list
+  if [[ -z "$target_repo" && ${#found_plists[@]} -gt 1 ]]; then
+    echo "Multiple repositories configured. Please specify which one to run:"
+    echo ""
+    for name in "${found_names[@]}"; do
+      echo "  auto-claude-ctl run $name"
+    done
+    exit 0
+  fi
+
+  # Find the target plist
+  local selected_plist=""
+  if [[ -z "$target_repo" ]]; then
+    # Only one repo, use it
+    selected_plist="${found_plists[1]}"
+  else
+    # Find matching repo
+    for i in {1..${#found_names[@]}}; do
+      if [[ "${found_names[$i]}" == "$target_repo" ]]; then
+        selected_plist="${found_plists[$i]}"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "$selected_plist" ]]; then
+    echo "Error: Repository '$target_repo' not found. Available repositories:" >&2
+    for name in "${found_names[@]}"; do
+      echo "  - $name" >&2
+    done
+    exit 1
+  fi
+
+  # Extract arguments from selected plist
+  local repo_path=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:1" "$selected_plist" 2>/dev/null || true)
+  local max_budget=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:2" "$selected_plist" 2>/dev/null || true)
+  local log_dir=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:3" "$selected_plist" 2>/dev/null || true)
+  local slack_channel=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:4" "$selected_plist" 2>/dev/null || true)
+
+  if [[ -z "$repo_path" || -z "$max_budget" ]]; then
+    echo "Error: Could not read configuration from $selected_plist" >&2
+    exit 1
+  fi
+
+  echo "Running auto-claude immediately..."
+  echo "  Repository: $repo_path"
+  echo "  Budget: \$${max_budget}"
+  echo ""
+
+  # Run with FORCE_RUN=1 to bypass pause/skip checks
+  FORCE_RUN=1 "$AUTO_CLAUDE_SCRIPT" "$repo_path" "$max_budget" "$log_dir" "$slack_channel"
+}
+
+# Command: pause - pause for N hours
+cmd_pause() {
+  local hours="${1:-}"
+  if [[ -z "$hours" || ! "$hours" =~ ^[0-9]+$ ]]; then
+    echo "Usage: auto-claude-ctl pause <hours>" >&2
+    exit 1
+  fi
+
+  init_control_file
+
+  # Date arithmetic with cross-platform support (BSD/macOS and GNU/Linux)
+  local pause_until
+  if date -v +1H "+%Y-%m-%dT%H:%M:%S" >/dev/null 2>&1; then
+    # BSD/macOS date
+    pause_until=$(date -v "+${hours}H" "+%Y-%m-%dT%H:%M:%S")
+  else
+    # GNU/Linux date
+    pause_until=$(date -d "+${hours} hours" "+%Y-%m-%dT%H:%M:%S")
+  fi
+
+  update_field "pause_until" "\"$pause_until\""
+
+  echo "Auto-claude paused until $(format_time "$pause_until")"
+  echo "Run 'auto-claude-ctl resume' to resume earlier."
+}
+
+# Command: skip - skip next N runs
+cmd_skip() {
+  local count="${1:-}"
+  if [[ -z "$count" || ! "$count" =~ ^[0-9]+$ ]]; then
+    echo "Usage: auto-claude-ctl skip <count>" >&2
+    exit 1
+  fi
+
+  init_control_file
+  update_field "skip_count" "$count"
+
+  echo "Will skip the next $count scheduled run(s)."
+  echo "Run 'auto-claude-ctl resume' to clear."
+}
+
+# Command: resume - clear pause/skip
+cmd_resume() {
+  init_control_file
+  update_field "pause_until" "null"
+  update_field "skip_count" "0"
+
+  echo "Resumed normal scheduling. Pause and skip cleared."
+}
+
+# Command: status - show current state
+cmd_status() {
+  init_control_file
+
+  echo "Auto-Claude Control Status"
+  echo "=========================="
+  echo ""
+
+  local pause_until=$(read_field "pause_until")
+  local skip_count=$(jq -r '.skip_count // 0' "$CONTROL_FILE" 2>/dev/null || echo 0)
+  local override=$(jq -c '.override_schedule // empty' "$CONTROL_FILE" 2>/dev/null)
+  local last_run=$(read_field "last_run")
+  local last_repo=$(read_field "last_run_repo")
+
+  # Check pause status
+  if [[ -n "$pause_until" && "$pause_until" != "null" ]]; then
+    local now=$(date "+%Y-%m-%dT%H:%M:%S")
+    local now_epoch=$(iso_to_epoch "$now")
+    local pause_until_epoch=$(iso_to_epoch "$pause_until")
+    if [[ -z "$now_epoch" || -z "$pause_until_epoch" ]]; then
+      echo "Warning: Could not parse pause_until or current time. Displaying raw values." >&2
+      echo "Status: PAUSED until $(format_time "$pause_until") (parse error)"
+    elif [[ "$now_epoch" -lt "$pause_until_epoch" ]]; then
+      echo "Status: PAUSED until $(format_time "$pause_until")"
+    else
+      echo "Status: Active (pause expired)"
+    fi
+  elif [[ "$skip_count" -gt 0 ]]; then
+    echo "Status: SKIPPING next $skip_count run(s)"
+  else
+    echo "Status: Active"
+  fi
+
+  echo ""
+  echo "Skip count: ${skip_count:-0}"
+  echo ""
+
+  if [[ -n "$override" && "$override" != "null" ]]; then
+    echo "Override schedule: $override"
+  else
+    echo "Schedule: Using Nix-defined times"
+  fi
+
+  echo ""
+  echo "Last run: $(format_time "$last_run") (${last_repo:-unknown repo})"
+  echo ""
+  echo "Control file: $CONTROL_FILE"
+}
+
+# Command: schedule - show or set override schedule
+cmd_schedule() {
+  init_control_file
+
+  if [[ $# -eq 0 ]]; then
+    # Show current schedule
+    local override=$(jq -c '.override_schedule // empty' "$CONTROL_FILE" 2>/dev/null)
+    if [[ -n "$override" && "$override" != "null" ]]; then
+      echo "Override schedule active:"
+      echo "$override" | jq -r '.[] | "  \(.hour):\(if .minute < 10 then "0" else "" end)\(.minute)"'
+    else
+      echo "No override schedule. Using Nix-defined times."
+      echo ""
+      echo "To set override: auto-claude-ctl schedule 9:00 14:30 18:00"
+    fi
+  else
+    # Parse and set schedule
+    local schedule="["
+    local first=true
+    for time in "$@"; do
+      if [[ ! "$time" =~ ^([0-9]{1,2}):([0-9]{2})$ ]]; then
+        echo "Error: Invalid time format '$time'. Use H:MM or HH:MM (e.g., 9:30 or 14:00)" >&2
+        exit 1
+      fi
+      # Extract hour and minute using zsh's match array (populated by =~ operator)
+      # Note: zsh arrays are 1-indexed, and match[1] is first capture group
+      local hour="${match[1]}"
+      local minute="${match[2]}"
+
+      if [[ "$hour" -lt 0 || "$hour" -gt 23 ]]; then
+        echo "Error: Hour must be 0-23, got $hour" >&2
+        exit 1
+      fi
+      if [[ "$minute" -lt 0 || "$minute" -gt 59 ]]; then
+        echo "Error: Minute must be 0-59, got $minute" >&2
+        exit 1
+      fi
+
+      if [[ "$first" == "true" ]]; then
+        first=false
+      else
+        schedule+=","
+      fi
+      schedule+="{\"hour\":$hour,\"minute\":$minute}"
+    done
+    schedule+="]"
+
+    update_field "override_schedule" "$schedule"
+    echo "Override schedule set:"
+    echo "$schedule" | jq -r '.[] | "  \(.hour):\(if .minute < 10 then "0" else "" end)\(.minute)"'
+    echo ""
+    echo "Note: This overrides Nix-defined schedule until cleared."
+    echo "Run 'auto-claude-ctl clear-schedule' to restore Nix schedule."
+  fi
+}
+
+# Command: clear-schedule - clear override schedule
+cmd_clear_schedule() {
+  init_control_file
+  update_field "override_schedule" "null"
+  echo "Override schedule cleared. Using Nix-defined times."
+}
+
+# Main dispatch
+case "${1:-}" in
+  run)
+    shift
+    cmd_run "$@"
+    ;;
+  pause)
+    shift
+    cmd_pause "$@"
+    ;;
+  skip)
+    shift
+    cmd_skip "$@"
+    ;;
+  resume)
+    cmd_resume
+    ;;
+  status)
+    cmd_status
+    ;;
+  schedule)
+    shift
+    cmd_schedule "$@"
+    ;;
+  clear-schedule)
+    cmd_clear_schedule
+    ;;
+  -h|--help|help|"")
+    cat << 'EOF'
+auto-claude-ctl: Runtime control for auto-claude scheduler
+
+Usage: auto-claude-ctl <command> [args...]
+
+Commands:
+  run [repo-name]       Run auto-claude immediately (bypass scheduler)
+  pause <hours>         Pause all runs for specified hours
+  skip <count>          Skip the next N scheduled runs
+  resume                Clear pause/skip, resume normal schedule
+  status                Show current control state
+  schedule [h:m ...]    Show or set override schedule times
+  clear-schedule        Clear override, use Nix-defined times
+  help                  Show this help
+
+Examples:
+  auto-claude-ctl pause 4          # Pause for 4 hours
+  auto-claude-ctl skip 2           # Skip next 2 runs
+  auto-claude-ctl schedule 9:00 14:30 18:00  # Run at these times
+  auto-claude-ctl run              # Run right now
+
+Control file: ~/.claude/auto-claude-control.json
+EOF
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Run 'auto-claude-ctl help' for usage." >&2
+    exit 1
+    ;;
+esac

--- a/nix-ai-claude/modules/claude/auto-claude-digest.py
+++ b/nix-ai-claude/modules/claude/auto-claude-digest.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Auto-Claude Digest - Scheduled Report Generator
+
+Sends twice-daily utilization reports to Slack showing:
+- Runs since last report
+- Token usage vs work completed
+- Efficiency breakdown per work unit
+- Flags for inefficient runs
+
+Usage:
+    auto-claude-digest.py --channel C123456789
+    auto-claude-digest.py --channel C123456789 --dry-run
+    auto-claude-digest.py --channel C123456789 --since "2025-12-22T08:00:00"
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+# Import from sibling module (same directory when deployed)
+try:
+    from auto_claude_db import AutoClaudeDB
+except ImportError:
+    # Handle case where script is run directly
+    sys.path.insert(0, str(Path(__file__).parent))
+    from auto_claude_db import AutoClaudeDB
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+
+def get_slack_token() -> str:
+    """Retrieve Slack bot token via bws_helper."""
+    try:
+        from bws_helper import get_secret
+        return get_secret("SLACK_BOT_TOKEN")
+    except ImportError:
+        print("Error: bws_helper module not found. Ensure it's in the same directory.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error retrieving Slack token: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def format_number(n: Optional[int]) -> str:
+    """Format number with commas for readability."""
+    if n is None:
+        return "0"
+    return f"{n:,}"
+
+
+def get_efficiency_emoji(tokens_per_unit: float, avg_tokens: float) -> str:
+    """Get emoji indicator for efficiency."""
+    if tokens_per_unit is None or avg_tokens is None or avg_tokens == 0:
+        return ""
+
+    ratio = tokens_per_unit / avg_tokens
+    if ratio <= 0.75:
+        return " :white_check_mark:"  # Very efficient
+    elif ratio <= 1.25:
+        return " :ballot_box_with_check:"  # Average
+    elif ratio <= 2.0:
+        return " :warning:"  # Above average
+    else:
+        return " :rotating_light:"  # Inefficient
+
+
+def build_report_blocks(
+    runs: list[dict],
+    summary: dict,
+    efficiency: list[dict],
+    avg_tokens_per_unit: float,
+    report_time: str,
+    since_time: str,
+) -> tuple[list, str]:
+    """Build Slack Block Kit blocks for the report."""
+    # Parse since time for display
+    try:
+        since_dt = datetime.fromisoformat(since_time.replace("Z", "+00:00"))
+        since_display = since_dt.strftime("%I:%M %p")
+    except (ValueError, TypeError):
+        since_display = "last report"
+
+    # Header
+    now_display = datetime.now(timezone.utc).strftime("%b %d, %I:%M %p")
+    text = f"Auto-Claude Report - {now_display}"
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": f":chart_with_upwards_trend: Auto-Claude Report", "emoji": True},
+        },
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f"*{now_display}* | Since {since_display}"}],
+        },
+        {"type": "divider"},
+    ]
+
+    # Summary stats
+    total_tokens = (summary.get("total_input_tokens") or 0) + (summary.get("total_output_tokens") or 0)
+    cache_savings = summary.get("total_cache_read_tokens") or 0
+
+    blocks.append({
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": (
+                f"*Summary*\n"
+                f":runner: {summary.get('run_count', 0)} runs completed\n"
+                f":page_facing_up: {summary.get('total_prs_created', 0)} PRs created\n"
+                f":white_check_mark: {summary.get('total_tasks_completed', 0)} tasks completed\n"
+                f":coin: {format_number(total_tokens)} tokens used"
+            ),
+        },
+    })
+
+    if cache_savings > 0:
+        blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f":recycle: Cache read: {format_number(cache_savings)} tokens"}],
+        })
+
+    # Efficiency breakdown (show up to 8 runs)
+    if efficiency:
+        blocks.append({"type": "divider"})
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*Efficiency Breakdown*"},
+        })
+
+        efficiency_lines = []
+        flagged_runs = []
+
+        for run in efficiency[:8]:
+            repo = run.get("repo", "unknown")
+            total = run.get("total_tokens", 0)
+            work = run.get("work_units", 0)
+            tpu = run.get("tokens_per_unit", total)
+
+            emoji = get_efficiency_emoji(tpu, avg_tokens_per_unit)
+
+            # Format work description
+            if work > 0:
+                work_desc = f"{work} unit{'s' if work != 1 else ''}"
+            else:
+                work_desc = "no output"
+                if total > 10000:
+                    flagged_runs.append(run)
+
+            efficiency_lines.append(
+                f"• `{repo}` | {format_number(total)} tokens | {work_desc}{emoji}"
+            )
+
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "\n".join(efficiency_lines)},
+        })
+
+        # Flag inefficient runs
+        if flagged_runs:
+            blocks.append({"type": "divider"})
+            flag_lines = []
+            for run in flagged_runs:
+                total = run.get("total_tokens", 0)
+                repo = run.get("repo", "unknown")
+                run_id = run.get("run_id", "unknown")
+                context_pct = run.get("context_usage_pct", 0)
+
+                flag_lines.append(
+                    f":warning: *{repo}* (`{run_id}`) used {format_number(total)} tokens with no completed work"
+                )
+                if context_pct > 80:
+                    flag_lines.append(f"   Context usage: {context_pct}%")
+
+            blocks.append({
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "\n".join(flag_lines)},
+            })
+
+    # No runs case
+    if not runs:
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "_No runs since last report_"},
+        })
+
+    # Footer
+    blocks.append({
+        "type": "context",
+        "elements": [
+            {"type": "mrkdwn", "text": f"Avg tokens/unit (7d): {format_number(int(avg_tokens_per_unit))}"},
+        ],
+    })
+
+    return blocks, text
+
+
+def send_report(
+    channel: str,
+    runs: list[dict],
+    summary: dict,
+    efficiency: list[dict],
+    avg_tokens_per_unit: float,
+    since_time: str,
+    dry_run: bool = False,
+) -> bool:
+    """Send the report to Slack."""
+    report_time = datetime.now(timezone.utc).isoformat()
+
+    blocks, text = build_report_blocks(
+        runs=runs,
+        summary=summary,
+        efficiency=efficiency,
+        avg_tokens_per_unit=avg_tokens_per_unit,
+        report_time=report_time,
+        since_time=since_time,
+    )
+
+    if dry_run:
+        print("=== DRY RUN - Would send to Slack ===")
+        print(f"Channel: {channel}")
+        print(f"Text: {text}")
+        print("Blocks:")
+        print(json.dumps(blocks, indent=2))
+        return True
+
+    try:
+        token = get_slack_token()
+        client = WebClient(token=token)
+        response = client.chat_postMessage(
+            channel=channel,
+            blocks=blocks,
+            text=text,
+        )
+        print(f"Report sent: {response['ts']}")
+        return True
+
+    except SlackApiError as e:
+        print(f"Slack API error: {e.response['error']}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error sending report: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Auto-Claude Digest - Scheduled Reports")
+    parser.add_argument("--channel", required=True, help="Slack channel ID")
+    parser.add_argument("--since", help="ISO timestamp to report from (default: last report)")
+    parser.add_argument("--dry-run", action="store_true", help="Print report without sending")
+    parser.add_argument("--db-path", type=Path, help="Path to SQLite database")
+
+    args = parser.parse_args()
+
+    # Initialize database
+    db = AutoClaudeDB(args.db_path) if args.db_path else AutoClaudeDB()
+
+    # Determine report window
+    if args.since:
+        since_time = args.since
+    else:
+        last_report = db.get_last_report_time("scheduled")
+        if last_report:
+            since_time = last_report
+        else:
+            # Default to 12 hours ago if no previous report
+            since_time = (datetime.now(timezone.utc) - timedelta(hours=12)).isoformat()
+
+    # Get data
+    runs = db.get_runs_since(since_time)
+    summary = db.get_summary_since(since_time)
+    efficiency = db.get_efficiency_breakdown(since_time)
+    avg_tokens = db.get_average_tokens_per_unit(days=7)
+
+    # Send report
+    success = send_report(
+        channel=args.channel,
+        runs=runs,
+        summary=summary,
+        efficiency=efficiency,
+        avg_tokens_per_unit=avg_tokens,
+        since_time=since_time,
+        dry_run=args.dry_run,
+    )
+
+    if success and not args.dry_run:
+        # Record that we sent this report
+        run_ids = [r.get("run_id") for r in runs if r.get("run_id")]
+        db.record_report_sent("scheduled", run_ids)
+
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nix-ai-claude/modules/claude/auto-claude-monitor.py
+++ b/nix-ai-claude/modules/claude/auto-claude-monitor.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+Auto-Claude Monitor - Real-time Anomaly Detection
+
+Checks completed runs for anomalies and sends immediate Slack alerts:
+- Context exhaustion (>90% of 200k tokens)
+- High budget utilization (>50% of token budget per run)
+- Stuck/looping behavior (high tokens, no output)
+- Repeated failures in same repo
+
+Called after each auto-claude run to detect problems early.
+
+Usage:
+    auto-claude-monitor.py --run-id 20251222_150007 --repo nix-config --log-file path/to/log.jsonl --channel C123456789
+    auto-claude-monitor.py --run-id 20251222_150007 --repo nix-config --log-file path/to/log.jsonl --channel C123456789 --dry-run
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+# Import from sibling module
+try:
+    from auto_claude_db import AutoClaudeDB, parse_jsonl_log
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from auto_claude_db import AutoClaudeDB, parse_jsonl_log
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+
+# Default thresholds (can be overridden via env vars or config)
+DEFAULT_CONTEXT_THRESHOLD = 90  # Alert if >90% context used
+DEFAULT_BUDGET_THRESHOLD = 50  # Alert if >50% of budget used (implies loop)
+DEFAULT_TOKENS_NO_OUTPUT = 50000  # Flag if >50k tokens with no work units
+DEFAULT_CONSECUTIVE_FAILURES = 2  # Alert after N consecutive failures
+
+
+def get_slack_token() -> str:
+    """Retrieve Slack bot token via bws_helper."""
+    try:
+        from bws_helper import get_secret
+        return get_secret("SLACK_BOT_TOKEN")
+    except ImportError:
+        print("Error: bws_helper module not found. Ensure it's in the same directory.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error retrieving Slack token: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def format_number(n: Optional[int]) -> str:
+    """Format number with commas."""
+    if n is None:
+        return "0"
+    return f"{n:,}"
+
+
+class AnomalyChecker:
+    """Check for anomalies in auto-claude runs."""
+
+    def __init__(
+        self,
+        db: AutoClaudeDB,
+        context_threshold: int = DEFAULT_CONTEXT_THRESHOLD,
+        budget_threshold: int = DEFAULT_BUDGET_THRESHOLD,
+        tokens_no_output: int = DEFAULT_TOKENS_NO_OUTPUT,
+        consecutive_failures: int = DEFAULT_CONSECUTIVE_FAILURES,
+    ):
+        self.db = db
+        self.context_threshold = context_threshold
+        self.budget_threshold = budget_threshold
+        self.tokens_no_output = tokens_no_output
+        self.consecutive_failures = consecutive_failures
+
+    def check_run(self, run_data: dict) -> list[dict]:
+        """Check a run for anomalies. Returns list of anomaly dicts."""
+        anomalies = []
+
+        # Check context exhaustion
+        context_pct = run_data.get("context_usage_pct", 0)
+        if context_pct >= self.context_threshold:
+            anomalies.append({
+                "type": "context_exhaustion",
+                "severity": "high" if context_pct >= 95 else "medium",
+                "message": f"Context usage at {context_pct}% of 200k token window",
+                "value": context_pct,
+            })
+
+        # Check high token usage with no output (stuck/loop indicator)
+        total_tokens = run_data.get("input_tokens", 0) + run_data.get("output_tokens", 0)
+        work_units = (
+            run_data.get("tasks_completed", 0)
+            + run_data.get("prs_created", 0)
+            + run_data.get("issues_resolved", 0)
+        )
+
+        if total_tokens >= self.tokens_no_output and work_units == 0:
+            anomalies.append({
+                "type": "high_tokens_no_output",
+                "severity": "high",
+                "message": f"Used {format_number(total_tokens)} tokens with no completed work",
+                "value": total_tokens,
+                "suggestion": "Check for loops or stuck behavior in logs",
+            })
+
+        # Check for failed run
+        exit_code = run_data.get("exit_code")
+        if exit_code is not None and exit_code != 0:
+            # Check for consecutive failures
+            recent_runs = self._get_recent_runs_for_repo(run_data.get("repo"))
+            consecutive = self._count_consecutive_failures(recent_runs)
+
+            if consecutive >= self.consecutive_failures:
+                anomalies.append({
+                    "type": "consecutive_failures",
+                    "severity": "high",
+                    "message": f"{consecutive} consecutive failures in {run_data.get('repo')}",
+                    "value": consecutive,
+                    "suggestion": "Investigate recurring issue",
+                })
+            else:
+                anomalies.append({
+                    "type": "run_failed",
+                    "severity": "low",
+                    "message": f"Run exited with code {exit_code}",
+                    "value": exit_code,
+                })
+
+        # Check high budget utilization, if a per-run token budget is provided
+        token_budget = run_data.get("token_budget")
+        if token_budget and token_budget > 0:
+            budget_pct = (total_tokens / token_budget) * 100
+            if budget_pct >= self.budget_threshold:
+                anomalies.append({
+                    "type": "high_budget_utilization",
+                    "severity": "high" if budget_pct >= 90 else "medium",
+                    "message": (
+                        f"Used {format_number(total_tokens)} tokens, "
+                        f"{budget_pct:.1f}% of the configured token budget "
+                        f"({format_number(token_budget)} tokens)"
+                    ),
+                    "value": budget_pct,
+                })
+
+        # Check for efficiency anomaly (tokens per unit way above average)
+        if work_units > 0:
+            tokens_per_unit = total_tokens / work_units
+            avg_tpu = self.db.get_average_tokens_per_unit(days=7)
+
+            if avg_tpu > 0 and tokens_per_unit > avg_tpu * 3:
+                anomalies.append({
+                    "type": "inefficient_run",
+                    "severity": "medium",
+                    "message": f"Tokens per unit ({format_number(int(tokens_per_unit))}) is 3x+ above average ({format_number(int(avg_tpu))})",
+                    "value": tokens_per_unit,
+                })
+
+        return anomalies
+
+    def _get_recent_runs_for_repo(self, repo: str, hours: int = 24) -> list[dict]:
+        """Get recent runs for a repo."""
+        if not repo:
+            return []
+        since = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+        return self.db.get_runs_since(since, repo=repo)
+
+    def _count_consecutive_failures(self, runs: list[dict]) -> int:
+        """Count consecutive failures from most recent."""
+        count = 0
+        # Sort by started_at descending
+        sorted_runs = sorted(runs, key=lambda r: r.get("started_at", ""), reverse=True)
+        for run in sorted_runs:
+            if run.get("exit_code", 0) != 0:
+                count += 1
+            else:
+                break
+        return count
+
+
+def build_alert_blocks(
+    run_id: str,
+    repo: str,
+    anomalies: list[dict],
+    run_data: dict,
+) -> tuple[list, str]:
+    """Build Slack Block Kit blocks for anomaly alert."""
+    # Determine overall severity
+    severities = [a.get("severity", "low") for a in anomalies]
+    if "high" in severities:
+        header_emoji = ":rotating_light:"
+        header_text = "Anomaly Detected"
+    elif "medium" in severities:
+        header_emoji = ":warning:"
+        header_text = "Warning"
+    else:
+        header_emoji = ":information_source:"
+        header_text = "Notice"
+
+    text = f"Auto-Claude Alert: {repo} @ {run_id}"
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": f"{header_emoji} {header_text}", "emoji": True},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Repository*\n{repo}"},
+                {"type": "mrkdwn", "text": f"*Run ID*\n`{run_id}`"},
+            ],
+        },
+        {"type": "divider"},
+    ]
+
+    # Add anomaly details
+    for anomaly in anomalies:
+        severity_emoji = {
+            "high": ":red_circle:",
+            "medium": ":large_orange_circle:",
+            "low": ":large_yellow_circle:",
+        }.get(anomaly.get("severity", "low"), ":white_circle:")
+
+        anomaly_text = f"{severity_emoji} *{anomaly.get('type', 'unknown').replace('_', ' ').title()}*\n{anomaly.get('message', '')}"
+
+        if anomaly.get("suggestion"):
+            anomaly_text += f"\n_Suggestion: {anomaly['suggestion']}_"
+
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": anomaly_text},
+        })
+
+    # Add run stats context
+    total_tokens = run_data.get("input_tokens", 0) + run_data.get("output_tokens", 0)
+    work_units = (
+        run_data.get("tasks_completed", 0)
+        + run_data.get("prs_created", 0)
+        + run_data.get("issues_resolved", 0)
+    )
+
+    blocks.append({
+        "type": "context",
+        "elements": [
+            {
+                "type": "mrkdwn",
+                "text": f"Tokens: {format_number(total_tokens)} | Work units: {work_units} | Duration: {run_data.get('duration_sec', 0) // 60}min",
+            },
+        ],
+    })
+
+    return blocks, text
+
+
+def send_alert(
+    channel: str,
+    run_id: str,
+    repo: str,
+    anomalies: list[dict],
+    run_data: dict,
+    dry_run: bool = False,
+) -> bool:
+    """Send anomaly alert to Slack."""
+    blocks, text = build_alert_blocks(run_id, repo, anomalies, run_data)
+
+    if dry_run:
+        print("=== DRY RUN - Would send alert to Slack ===")
+        print(f"Channel: {channel}")
+        print(f"Text: {text}")
+        print("Blocks:")
+        print(json.dumps(blocks, indent=2))
+        return True
+
+    try:
+        token = get_slack_token()
+        client = WebClient(token=token)
+        response = client.chat_postMessage(
+            channel=channel,
+            blocks=blocks,
+            text=text,
+        )
+        print(f"Alert sent: {response['ts']}")
+        return True
+
+    except SlackApiError as e:
+        print(f"Slack API error: {e.response['error']}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error sending alert: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Auto-Claude Monitor - Anomaly Detection")
+    parser.add_argument("--run-id", required=True, help="Run ID to check")
+    parser.add_argument("--repo", required=True, help="Repository name")
+    parser.add_argument("--log-file", type=Path, required=True, help="Path to JSONL log file")
+    parser.add_argument("--channel", required=True, help="Slack channel ID for alerts")
+    parser.add_argument("--dry-run", action="store_true", help="Print alert without sending")
+    parser.add_argument("--db-path", type=Path, help="Path to SQLite database")
+
+    # Threshold overrides
+    parser.add_argument("--context-threshold", type=int, default=DEFAULT_CONTEXT_THRESHOLD)
+    parser.add_argument("--budget-threshold", type=int, default=DEFAULT_BUDGET_THRESHOLD)
+    parser.add_argument("--tokens-no-output", type=int, default=DEFAULT_TOKENS_NO_OUTPUT)
+    parser.add_argument("--consecutive-failures", type=int, default=DEFAULT_CONSECUTIVE_FAILURES)
+
+    args = parser.parse_args()
+
+    # Initialize database
+    db = AutoClaudeDB(args.db_path) if args.db_path else AutoClaudeDB()
+
+    # Parse log file
+    run_data = parse_jsonl_log(args.log_file)
+    run_data["run_id"] = args.run_id
+    run_data["repo"] = args.repo
+
+    # Store run in database for historical tracking
+    db.insert_run(run_data)
+    for wu in run_data.get("work_units", []):
+        wu["run_id"] = args.run_id
+        db.insert_work_unit(wu)
+
+    # Check for anomalies
+    checker = AnomalyChecker(
+        db=db,
+        context_threshold=args.context_threshold,
+        budget_threshold=args.budget_threshold,
+        tokens_no_output=args.tokens_no_output,
+        consecutive_failures=args.consecutive_failures,
+    )
+
+    anomalies = checker.check_run(run_data)
+
+    if not anomalies:
+        print(f"No anomalies detected for run {args.run_id}")
+        return 0
+
+    # Filter to only high/medium severity for alerts
+    alertable = [a for a in anomalies if a.get("severity") in ("high", "medium")]
+
+    if not alertable:
+        print(f"Low-severity anomalies only, not alerting: {anomalies}")
+        return 0
+
+    # Send alert
+    success = send_alert(
+        channel=args.channel,
+        run_id=args.run_id,
+        repo=args.repo,
+        anomalies=alertable,
+        run_data=run_data,
+        dry_run=args.dry_run,
+    )
+
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nix-ai-claude/modules/claude/auto-claude-notify.py
+++ b/nix-ai-claude/modules/claude/auto-claude-notify.py
@@ -1,0 +1,829 @@
+#!/usr/bin/env python3
+"""
+Auto-Claude Slack Notifier
+
+Rich Slack notifications for auto-claude runs using Block Kit formatting.
+Supports threading for organized per-run notifications.
+
+Usage:
+    auto-claude-notify.py run_started --repo NAME --budget AMOUNT --run-id ID --channel CHANNEL_ID
+    auto-claude-notify.py task_started --repo NAME --thread-ts TS --task DESC --agent TYPE
+    auto-claude-notify.py task_completed --repo NAME --thread-ts TS --task DESC [--pr PR] [--cost COST] [--duration MIN]
+    auto-claude-notify.py task_blocked --repo NAME --thread-ts TS --task DESC --reason REASON
+    auto-claude-notify.py run_completed --repo NAME --thread-ts TS --log-file PATH --budget AMOUNT
+
+Secrets:
+    All secrets retrieved via bws_helper from ~/.config/bws/.env
+    - Slack bot token: BWS_SECRET_SLACK_BOT_TOKEN in config
+    - Slack channels: Retrieved from keychain (SLACK_CHANNEL_<REPO>)
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+# Import bws_helper from same directory
+sys.path.insert(0, str(Path(__file__).parent))
+import bws_helper
+
+# Display limits for Slack messages (prevents overly long messages)
+MAX_DISPLAY_ITEMS = 10
+
+
+def validate_slack_channel_id(channel: str) -> bool:
+    """
+    Validate Slack channel ID format.
+
+    Valid Slack channel IDs:
+    - Public channels: Start with 'C' followed by alphanumeric characters (8+ chars total)
+    - Private channels/groups: Start with 'G' followed by alphanumeric characters (8+ chars total)
+    - Direct messages: Start with 'D' followed by alphanumeric characters (8+ chars total)
+    - User groups: Start with 'S' followed by alphanumeric characters (8+ chars total)
+
+    Args:
+        channel: The channel ID to validate
+
+    Returns:
+        True if valid, False otherwise
+    """
+    # Slack channel IDs must start with C, D, G, or S and contain only alphanumeric characters
+    # Minimum 8 characters total (1 prefix + 7+ alphanumeric)
+    # Supports both uppercase and mixed case IDs
+    pattern = r'^[CDGS][A-Za-z0-9]{7,}$'
+    return bool(re.match(pattern, channel))
+
+
+def check_channel_and_handle_error(channel: str) -> Optional[int]:
+    """
+    Validate Slack channel ID and print error message if invalid.
+
+    Args:
+        channel: The channel ID to validate
+
+    Returns:
+        1 if invalid (with error message printed), None if valid
+    """
+    if not validate_slack_channel_id(channel):
+        print(f"Error: Invalid Slack channel ID format: {channel}", file=sys.stderr)
+        print("Channel ID must start with C, D, G, or S followed by alphanumeric characters", file=sys.stderr)
+        return 1
+    return None
+
+
+def escape_slack_markdown(text: str) -> str:
+    """Escape special Slack markdown characters to prevent formatting issues."""
+    # Escape characters that have special meaning in Slack markdown
+    for char in ["*", "_", "`", "~"]:
+        text = text.replace(char, f"\\{char}")
+    return text
+
+
+def get_slack_token() -> str:
+    """Retrieve Slack bot token from Bitwarden Secrets Manager via bws_helper."""
+    try:
+        return bws_helper.get_secret("SLACK_BOT_TOKEN")
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        print(f"Error retrieving Slack token: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def post_message(token: str, channel: str, blocks: list, text: str, thread_ts: Optional[str] = None) -> Optional[str]:
+    """Post a message to Slack and return the message ts."""
+    try:
+        client = WebClient(token=token)
+
+        kwargs = {
+            "channel": channel,
+            "blocks": blocks,
+            "text": text,  # Fallback for notifications
+        }
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+
+        response = client.chat_postMessage(**kwargs)
+        return response["ts"]
+
+    except SlackApiError as e:
+        print(f"Slack API error: {e.response['error']}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Error posting to Slack: {e}", file=sys.stderr)
+        return None
+
+
+def update_message(token: str, channel: str, ts: str, blocks: list, text: str) -> bool:
+    """Update an existing Slack message."""
+    try:
+        client = WebClient(token=token)
+        client.chat_update(channel=channel, ts=ts, blocks=blocks, text=text)
+        return True
+
+    except SlackApiError as e:
+        print(f"Slack API error: {e.response['error']}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"Error updating Slack message: {e}", file=sys.stderr)
+        return False
+
+
+# =============================================================================
+# Block Kit Templates
+# =============================================================================
+
+
+def blocks_run_started(repo: str, budget: float, run_id: str) -> tuple[list, str]:
+    """Block Kit for run started notification."""
+    now = datetime.now().strftime("%b %d, %I:%M %p")
+    safe_repo = escape_slack_markdown(repo)
+    safe_run_id = escape_slack_markdown(run_id)
+    text = f"Auto-Claude run started: {safe_repo}"
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "🤖 Auto-Claude Run Started", "emoji": True},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Repository*\n{safe_repo}"},
+                {"type": "mrkdwn", "text": f"*Budget*\n${budget:.2f}"},
+                {"type": "mrkdwn", "text": f"*Started*\n{now}"},
+                {"type": "mrkdwn", "text": f"*Run ID*\n`{safe_run_id}`"},
+            ],
+        },
+        {"type": "divider"},
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": "Task updates will appear in this thread..."}],
+        },
+    ]
+
+    return blocks, text
+
+
+def blocks_task_started(task: str, agent: str) -> tuple[list, str]:
+    """Block Kit for task started notification."""
+    safe_task = escape_slack_markdown(task)
+    safe_agent = escape_slack_markdown(agent)
+    text = f"Task started: {safe_task}"
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"🔧 *Dispatched*: {safe_agent}"},
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"```{safe_task}```"},
+        },
+    ]
+
+    return blocks, text
+
+
+def blocks_task_completed(task: str, pr: Optional[str], cost: Optional[float], duration: Optional[int]) -> tuple[list, str]:
+    """Block Kit for task completed notification."""
+    safe_task = escape_slack_markdown(task)
+    text = f"Task completed: {safe_task}"
+
+    fields = []
+    if pr:
+        safe_pr = escape_slack_markdown(pr)
+        fields.append({"type": "mrkdwn", "text": f"*PR Created*\n{safe_pr}"})
+    if cost is not None:
+        fields.append({"type": "mrkdwn", "text": f"*Cost*\n${cost:.2f}"})
+    if duration is not None:
+        fields.append({"type": "mrkdwn", "text": f"*Duration*\n{duration} min"})
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"✅ *Completed*: {safe_task}"},
+        },
+    ]
+
+    if fields:
+        blocks.append({"type": "section", "fields": fields})
+
+    return blocks, text
+
+
+def blocks_task_blocked(task: str, reason: str) -> tuple[list, str]:
+    """Block Kit for task blocked notification."""
+    safe_task = escape_slack_markdown(task)
+    safe_reason = escape_slack_markdown(reason)
+    text = f"Task blocked: {safe_task}"
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"⚠️ *Blocked*: {safe_task}"},
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"_Reason: {safe_reason}_"},
+        },
+    ]
+
+    return blocks, text
+
+
+def blocks_run_completed(
+    repo: str,
+    duration_minutes: int,
+    cost: float,
+    budget: float,
+    completed: list[str],
+    blocked: list[dict],
+    prs: list[str],
+) -> tuple[list, str]:
+    """Block Kit for run completed notification."""
+    pct = (cost / budget * 100) if budget > 0 else 0
+    text = f"Auto-Claude run completed: {repo}"
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "📊 Auto-Claude Run Complete", "emoji": True},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Duration*\n{duration_minutes} minutes"},
+                {"type": "mrkdwn", "text": f"*Cost*\n${cost:.2f} / ${budget:.2f} ({pct:.0f}%)"},
+                {"type": "mrkdwn", "text": f"*Tasks*\n{len(completed)} completed, {len(blocked)} blocked"},
+            ],
+        },
+        {"type": "divider"},
+    ]
+
+    # Completed tasks
+    if completed:
+        completed_text = "\n".join(f"• {t}" for t in completed[:MAX_DISPLAY_ITEMS])
+        if len(completed) > MAX_DISPLAY_ITEMS:
+            completed_text += f"\n_...and {len(completed) - MAX_DISPLAY_ITEMS} more_"
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*✅ Completed*\n{completed_text}"},
+            }
+        )
+
+    # PRs created
+    if prs:
+        prs_text = "\n".join(f"• {pr}" for pr in prs[:MAX_DISPLAY_ITEMS])
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*📝 PRs Created*\n{prs_text}"},
+            }
+        )
+
+    # Blocked tasks
+    if blocked:
+        blocked_text = "\n".join(f"• {b.get('task', 'Unknown')}: _{b.get('reason', 'No reason')}_" for b in blocked[:MAX_DISPLAY_ITEMS])
+        if len(blocked) > MAX_DISPLAY_ITEMS:
+            blocked_text += f"\n_...and {len(blocked) - MAX_DISPLAY_ITEMS} more_"
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*⚠️ Blocked*\n{blocked_text}"},
+            }
+        )
+
+    return blocks, text
+
+
+def parse_log_file(log_path: str) -> dict:
+    """Parse JSONL log file for task events and summary data."""
+    completed = []
+    blocked = []
+    prs = []
+    total_cost = 0.0
+    start_time = None
+    end_time = None
+
+    # Validate that the resolved path is within an allowed directory before opening.
+    # This prevents path traversal attacks where an attacker controls the log_file argument.
+    resolved = Path(log_path).resolve()
+    allowed_prefixes = [
+        Path.home() / ".claude" / "logs",
+        Path("/tmp"),
+    ]
+    if not any(str(resolved).startswith(str(p) + "/") or str(resolved) == str(p) for p in allowed_prefixes):
+        print(f"Error: Log file path not in an allowed directory: {log_path}", file=sys.stderr)
+        return {
+            "completed": [],
+            "blocked": [],
+            "prs": [],
+            "total_cost": 0.0,
+            "duration_minutes": 0,
+        }
+
+    try:
+        with open(resolved, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+
+                    # Track timestamps for duration
+                    if "timestamp" in data:
+                        ts = data["timestamp"]
+                        if start_time is None:
+                            start_time = ts
+                        end_time = ts
+
+                    event = data.get("event")
+                    if event == "task_completed":
+                        completed.append(data.get("task", "Unknown task"))
+                        if data.get("pr"):
+                            prs.append(data["pr"])
+                        if data.get("cost"):
+                            total_cost += float(data["cost"])
+
+                    elif event == "task_blocked":
+                        blocked.append(
+                            {
+                                "task": data.get("task", "Unknown"),
+                                "reason": data.get("reason", "No reason given"),
+                            }
+                        )
+
+                except json.JSONDecodeError:
+                    continue
+
+    except FileNotFoundError:
+        print(f"Warning: Log file not found: {log_path}", file=sys.stderr)
+
+    # Calculate duration
+    duration_minutes = 0
+    if start_time and end_time:
+        try:
+            start = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+            end = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
+            duration_minutes = int(abs((end - start).total_seconds()) / 60)
+        except (ValueError, TypeError):
+            # If timestamps are malformed or missing, leave duration as 0.
+            pass
+
+    return {
+        "completed": completed,
+        "blocked": blocked,
+        "prs": prs,
+        "total_cost": total_cost,
+        "duration_minutes": duration_minutes,
+    }
+
+
+# =============================================================================
+# CLI Commands
+# =============================================================================
+
+
+def cmd_run_started(args):
+    """Handle run_started event."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    blocks, text = blocks_run_started(args.repo, args.budget, args.run_id)
+    ts = post_message(token, args.channel, blocks, text)
+    if ts:
+        print(ts)  # Output ts for shell script to capture
+        return 0
+    return 1
+
+
+def cmd_task_started(args):
+    """Handle task_started event."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    blocks, text = blocks_task_started(args.task, args.agent)
+    result = post_message(token, args.channel, blocks, text, thread_ts=args.thread_ts)
+    return 0 if result else 1
+
+
+def cmd_task_completed(args):
+    """Handle task_completed event."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    blocks, text = blocks_task_completed(args.task, args.pr, args.cost, args.duration)
+    result = post_message(token, args.channel, blocks, text, thread_ts=args.thread_ts)
+    return 0 if result else 1
+
+
+def cmd_task_blocked(args):
+    """Handle task_blocked event."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    blocks, text = blocks_task_blocked(args.task, args.reason)
+    result = post_message(token, args.channel, blocks, text, thread_ts=args.thread_ts)
+    return 0 if result else 1
+
+
+def cmd_run_completed(args):
+    """Handle run_completed event."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+
+    # Parse log file for summary data
+    log_data = parse_log_file(args.log_file) if args.log_file else {}
+
+    blocks, text = blocks_run_completed(
+        repo=args.repo,
+        duration_minutes=log_data.get("duration_minutes", 0),
+        cost=log_data.get("total_cost", 0.0),
+        budget=args.budget,
+        completed=log_data.get("completed", []),
+        blocked=log_data.get("blocked", []),
+        prs=log_data.get("prs", []),
+    )
+
+    # Post summary as thread reply
+    post_message(token, args.channel, blocks, text, thread_ts=args.thread_ts)
+
+    # Update parent message with completion status
+    parent_blocks, parent_text = blocks_run_started(args.repo, args.budget, args.run_id or "unknown")
+    # Modify header to show completed
+    parent_blocks[0]["text"]["text"] = "✅ Auto-Claude Run Completed"
+    update_message(token, args.channel, args.thread_ts, parent_blocks, parent_text)
+
+    return 0
+
+
+def blocks_run_skipped(repo: str, reason: str) -> tuple[list, str]:
+    """Create blocks for run skipped notification."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "⏭️ Auto-Claude Run Skipped", "emoji": True},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Repository:*\n{escape_slack_markdown(repo)}"},
+                {"type": "mrkdwn", "text": f"*Time:*\n{timestamp}"},
+            ],
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Reason:*\n{escape_slack_markdown(reason)}"},
+        },
+    ]
+    return blocks, f"Auto-Claude run skipped for {repo}: {reason}"
+
+
+def blocks_session_summary(
+    findings: list[str],
+    recommendations: list[str],
+    mode: str,
+    stats: Optional[dict] = None,
+) -> tuple[list, str]:
+    """Block Kit for session summary - goes to Slack thread, NOT GitHub.
+
+    This is for meta-information about auto-claude runs that should NOT
+    be created as GitHub issues. Examples:
+    - "Orchestrator Session Summary"
+    - "Consolidated findings from analysis"
+    - Mode transition notifications
+    """
+    text = "Session Summary"
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "📋 Session Summary", "emoji": True},
+        },
+    ]
+
+    # Add mode info if provided
+    if mode:
+        mode_emoji = {
+            "NORMAL": "🟢",
+            "CONSOLIDATION": "🟡",
+            "PR_CREATION": "🟠",
+            "PR_FOCUS": "🔴",
+            "PAUSED": "⛔",
+        }.get(mode, "⚪")
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Mode:* {mode_emoji} {escape_slack_markdown(mode)}"},
+        })
+
+    # Add stats if provided
+    if stats:
+        stat_fields = []
+        if "total_issues" in stats:
+            stat_fields.append({"type": "mrkdwn", "text": f"*Issues:* {stats['total_issues']}"})
+        if "ai_created" in stats:
+            stat_fields.append({"type": "mrkdwn", "text": f"*AI-Created:* {stats['ai_created']}"})
+        if "pr_count" in stats:
+            stat_fields.append({"type": "mrkdwn", "text": f"*Open PRs:* {stats['pr_count']}"})
+        if "ratio" in stats:
+            stat_fields.append({"type": "mrkdwn", "text": f"*Ratio:* {stats['ratio']}:1"})
+        if stat_fields:
+            blocks.append({"type": "section", "fields": stat_fields})
+
+    # Add findings
+    if findings:
+        findings_text = "\n".join(f"• {escape_slack_markdown(f)}" for f in findings[:MAX_DISPLAY_ITEMS])
+        if len(findings) > MAX_DISPLAY_ITEMS:
+            findings_text += f"\n_...and {len(findings) - MAX_DISPLAY_ITEMS} more_"
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Findings:*\n{findings_text}"},
+        })
+
+    # Add recommendations
+    if recommendations:
+        rec_text = "\n".join(f"• {escape_slack_markdown(r)}" for r in recommendations[:MAX_DISPLAY_ITEMS])
+        if len(recommendations) > MAX_DISPLAY_ITEMS:
+            rec_text += f"\n_...and {len(recommendations) - MAX_DISPLAY_ITEMS} more_"
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Recommendations:*\n{rec_text}"},
+        })
+
+    blocks.append({"type": "divider"})
+    blocks.append({
+        "type": "context",
+        "elements": [{"type": "mrkdwn", "text": "_This summary is for Slack only - not a GitHub issue._"}],
+    })
+
+    return blocks, text
+
+
+def blocks_user_input_needed(session: str, question: str) -> tuple[list, str]:
+    """Block Kit for user input needed notification."""
+    safe_session = escape_slack_markdown(session)
+    safe_question = escape_slack_markdown(question)
+    text = f"Claude needs input: {safe_question}"
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "🤔 Claude needs your input", "emoji": True},
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Session*\n{safe_session}"},
+                {"type": "mrkdwn", "text": f"*Time*\n{datetime.now().strftime('%I:%M %p')}"},
+            ],
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Question:*\n{safe_question}"},
+        },
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": "Return to your terminal to respond"}],
+        },
+    ]
+
+    return blocks, text
+
+
+def blocks_cross_issue_update(
+    issues: list[str],
+    prs: list[str],
+    action: str,
+    details: Optional[str] = None,
+) -> tuple[list, str]:
+    """Block Kit for cross-issue/PR updates - goes to Slack thread, NOT GitHub.
+
+    Use this for updates that span multiple issues or PRs. Examples:
+    - "Linked issues #1, #2, #3 as related"
+    - "Closed 5 issues resolved by merged PRs"
+    - "Consolidated 3 duplicate issues into #45"
+    """
+    text = f"Cross-Issue Update: {action}"
+
+    action_emoji = {
+        "linked": "🔗",
+        "closed": "✅",
+        "consolidated": "📦",
+        "deduplicated": "🔄",
+        "labeled": "🏷️",
+    }.get(action.lower(), "📝")
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"{action_emoji} *{escape_slack_markdown(action)}*"},
+        },
+    ]
+
+    # Add issues if provided
+    if issues:
+        issues_text = ", ".join(f"#{escape_slack_markdown(str(i))}" for i in issues[:MAX_DISPLAY_ITEMS])
+        if len(issues) > MAX_DISPLAY_ITEMS:
+            issues_text += f" _...and {len(issues) - MAX_DISPLAY_ITEMS} more_"
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Issues:* {issues_text}"},
+        })
+
+    # Add PRs if provided
+    if prs:
+        prs_text = ", ".join(f"#{escape_slack_markdown(str(p))}" for p in prs[:MAX_DISPLAY_ITEMS])
+        if len(prs) > MAX_DISPLAY_ITEMS:
+            prs_text += f" _...and {len(prs) - MAX_DISPLAY_ITEMS} more_"
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*PRs:* {prs_text}"},
+        })
+
+    # Add details if provided
+    if details:
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"_{escape_slack_markdown(details)}_"},
+        })
+
+    return blocks, text
+
+
+def cmd_run_skipped(args):
+    """Handle run_skipped event."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    blocks, text = blocks_run_skipped(args.repo, args.reason)
+    result = post_message(token, args.channel, blocks, text)
+    return 0 if result else 1
+
+
+def cmd_session_summary(args):
+    """Handle session_summary event - posts to Slack thread, NOT GitHub."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    findings = [f.strip() for f in args.findings.split("|")] if args.findings else []
+    recommendations = [r.strip() for r in args.recommendations.split("|")] if args.recommendations else []
+    stats = {}
+    if args.total_issues is not None:
+        stats["total_issues"] = args.total_issues
+    if args.ai_created is not None:
+        stats["ai_created"] = args.ai_created
+    if args.pr_count is not None:
+        stats["pr_count"] = args.pr_count
+    if args.ratio is not None:
+        stats["ratio"] = args.ratio
+
+    blocks, text = blocks_session_summary(findings, recommendations, args.mode, stats if stats else None)
+    result = post_message(token, args.channel, blocks, text, thread_ts=args.thread_ts)
+    return 0 if result else 1
+
+
+def cmd_user_input_needed(args):
+    """Handle user_input_needed event - sends push notification."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    blocks, text = blocks_user_input_needed(args.session, args.question)
+    result = post_message(token, args.channel, blocks, text)
+    return 0 if result else 1
+
+
+def cmd_cross_issue_update(args):
+    """Handle cross_issue_update event - posts to Slack thread, NOT GitHub."""
+    error = check_channel_and_handle_error(args.channel)
+    if error is not None:
+        return error
+
+    token = get_slack_token()
+    issues = args.issues.split(",") if args.issues else []
+    prs = args.prs.split(",") if args.prs else []
+    blocks, text = blocks_cross_issue_update(issues, prs, args.action, args.details)
+    result = post_message(token, args.channel, blocks, text, thread_ts=args.thread_ts)
+    return 0 if result else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auto-Claude Slack Notifier")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # run_started
+    p_start = subparsers.add_parser("run_started", help="Notify run started")
+    p_start.add_argument("--repo", required=True, help="Repository name")
+    p_start.add_argument("--budget", type=float, required=True, help="Budget in USD")
+    p_start.add_argument("--run-id", required=True, help="Run ID")
+    p_start.add_argument("--channel", required=True, help="Slack channel ID")
+    p_start.set_defaults(func=cmd_run_started)
+
+    # task_started
+    p_task_start = subparsers.add_parser("task_started", help="Notify task started")
+    p_task_start.add_argument("--repo", required=True)
+    p_task_start.add_argument("--channel", required=True)
+    p_task_start.add_argument("--thread-ts", required=True, help="Parent message ts")
+    p_task_start.add_argument("--task", required=True, help="Task description")
+    p_task_start.add_argument("--agent", required=True, help="Agent type")
+    p_task_start.set_defaults(func=cmd_task_started)
+
+    # task_completed
+    p_task_done = subparsers.add_parser("task_completed", help="Notify task completed")
+    p_task_done.add_argument("--repo", required=True)
+    p_task_done.add_argument("--channel", required=True)
+    p_task_done.add_argument("--thread-ts", required=True)
+    p_task_done.add_argument("--task", required=True)
+    p_task_done.add_argument("--pr", help="PR number/link if created")
+    p_task_done.add_argument("--cost", type=float, help="Cost in USD")
+    p_task_done.add_argument("--duration", type=int, help="Duration in minutes")
+    p_task_done.set_defaults(func=cmd_task_completed)
+
+    # task_blocked
+    p_blocked = subparsers.add_parser("task_blocked", help="Notify task blocked")
+    p_blocked.add_argument("--repo", required=True)
+    p_blocked.add_argument("--channel", required=True)
+    p_blocked.add_argument("--thread-ts", required=True)
+    p_blocked.add_argument("--task", required=True)
+    p_blocked.add_argument("--reason", required=True, help="Block reason")
+    p_blocked.set_defaults(func=cmd_task_blocked)
+
+    # run_completed
+    p_complete = subparsers.add_parser("run_completed", help="Notify run completed")
+    p_complete.add_argument("--repo", required=True)
+    p_complete.add_argument("--channel", required=True)
+    p_complete.add_argument("--thread-ts", required=True)
+    p_complete.add_argument("--budget", type=float, required=True)
+    p_complete.add_argument("--run-id", help="Run ID for parent update")
+    p_complete.add_argument("--log-file", help="Path to JSONL log file")
+    p_complete.set_defaults(func=cmd_run_completed)
+
+    # run_skipped
+    p_skipped = subparsers.add_parser("run_skipped", help="Notify run skipped")
+    p_skipped.add_argument("--repo", required=True, help="Repository name")
+    p_skipped.add_argument("--reason", required=True, help="Skip reason")
+    p_skipped.add_argument("--channel", required=True, help="Slack channel ID")
+    p_skipped.set_defaults(func=cmd_run_skipped)
+
+    # session_summary - goes to Slack thread, NOT GitHub
+    p_summary = subparsers.add_parser("session_summary", help="Post session summary to Slack (not GitHub)")
+    p_summary.add_argument("--repo", required=True)
+    p_summary.add_argument("--channel", required=True)
+    p_summary.add_argument("--thread-ts", required=True)
+    p_summary.add_argument("--mode", required=True, help="Current mode (NORMAL, CONSOLIDATION, etc.)")
+    p_summary.add_argument("--findings", help="Pipe-separated list of findings")
+    p_summary.add_argument("--recommendations", help="Pipe-separated list of recommendations")
+    p_summary.add_argument("--total-issues", type=int, help="Total open issues")
+    p_summary.add_argument("--ai-created", type=int, help="AI-created issues count")
+    p_summary.add_argument("--pr-count", type=int, help="Open PR count")
+    p_summary.add_argument("--ratio", type=float, help="Issue:PR ratio")
+    p_summary.set_defaults(func=cmd_session_summary)
+
+    # user_input_needed - push notification for AskUserQuestion
+    p_input = subparsers.add_parser("user_input_needed", help="Notify when Claude needs user input")
+    p_input.add_argument("--session", required=True, help="Session context (repo @ branch)")
+    p_input.add_argument("--question", required=True, help="Question text from AskUserQuestion")
+    p_input.add_argument("--channel", required=True, help="Slack channel ID")
+    p_input.set_defaults(func=cmd_user_input_needed)
+
+    # cross_issue_update - goes to Slack thread, NOT GitHub
+    p_cross = subparsers.add_parser("cross_issue_update", help="Post cross-issue update to Slack (not GitHub)")
+    p_cross.add_argument("--repo", required=True)
+    p_cross.add_argument("--channel", required=True)
+    p_cross.add_argument("--thread-ts", required=True)
+    p_cross.add_argument("--action", required=True, help="Action taken (linked, closed, consolidated, etc.)")
+    p_cross.add_argument("--issues", help="Comma-separated issue numbers")
+    p_cross.add_argument("--prs", help="Comma-separated PR numbers")
+    p_cross.add_argument("--details", help="Additional details")
+    p_cross.set_defaults(func=cmd_cross_issue_update)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nix-ai-claude/modules/claude/auto-claude-reporting.nix
+++ b/nix-ai-claude/modules/claude/auto-claude-reporting.nix
@@ -1,0 +1,180 @@
+# Auto-Claude Reporting: Twice-Daily Digest and Real-Time Monitoring
+#
+# Scheduled reports and anomaly detection for auto-claude runs.
+# Sends 8am and 5pm EST Slack reports with efficiency metrics.
+# Alerts on anomalies: context exhaustion, stuck loops, failures.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+  homeDir = config.home.homeDirectory;
+  scriptDir = "${homeDir}/.claude/scripts";
+  logDir = "${homeDir}/.claude/logs";
+
+  python = import ../../lib/python.nix { inherit pkgs; };
+
+  # Python with required packages
+  pythonWithDeps = python.withPackages (ps: [
+    (ps.slack-sdk.overridePythonAttrs (_: {
+      doCheck = false;
+    }))
+    ps.cryptography # Cryptographic recipes and primitives (system-wide requirement)
+    ps.keyring
+  ]);
+
+  # Check if reporting is enabled
+  reportingEnabled = cfg.autoClaude.reporting.enable;
+
+  # Convert EST report times from config to UTC for launchd StartCalendarInterval
+  # NOTE: This assumes EST is always UTC-5 and does NOT account for Daylight Saving Time (EDT).
+  # During EDT (March-November), EST is actually UTC-4, so reports will be 1 hour off.
+  # If you need DST-aware scheduling, consider using fixed UTC times or a more complex conversion.
+  utcReportTimes = map (
+    timeStr:
+    let
+      # Parse time string with regex to extract hour and minute
+      match = builtins.match "0*([0-9]+):0*([0-9]+)" timeStr;
+      hour = lib.toInt (builtins.elemAt match 0);
+      minute = lib.toInt (builtins.elemAt match 1);
+      # Assume EST = UTC-5 (not accounting for EDT which is UTC-4)
+      utcHour = lib.mod (hour + 5) 24;
+    in
+    {
+      Hour = utcHour;
+      Minute = minute;
+    }
+  ) cfg.autoClaude.reporting.scheduledReports.times;
+
+in
+{
+  options.programs.claude.autoClaude.reporting = {
+    enable = lib.mkEnableOption "Auto-Claude reporting and monitoring" // {
+      default = false;
+    };
+
+    scheduledReports = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          times = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [
+              "08:00"
+              "17:00"
+            ];
+            description = "Times for scheduled reports in EST (HH:MM format). Default: 8am and 5pm EST.";
+            example = [
+              "08:00"
+              "17:00"
+            ];
+          };
+
+          slackChannel = lib.mkOption {
+            type = lib.types.str;
+            description = "Slack channel ID for scheduled reports (retrieved from BWS at runtime)";
+            example = "C0AXXXXXXXX";
+          };
+        };
+      };
+      default = { };
+      description = "Configuration for twice-daily digest reports";
+    };
+
+    alerts = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "Real-time anomaly alerts" // {
+            default = true;
+          };
+
+          contextThreshold = lib.mkOption {
+            type = lib.types.ints.between 0 100;
+            default = 90;
+            description = "Alert if context usage exceeds this percentage";
+          };
+
+          budgetThreshold = lib.mkOption {
+            type = lib.types.ints.between 0 100;
+            default = 50;
+            description = "Alert if run uses more than this percentage of token budget";
+          };
+
+          tokensNoOutput = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 50000;
+            description = "Flag if tokens used exceeds this with no completed work units";
+          };
+
+          consecutiveFailures = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 2;
+            description = "Alert after this many consecutive failures in same repo";
+          };
+        };
+      };
+      default = { };
+      description = "Configuration for real-time anomaly detection and alerts";
+    };
+  };
+
+  config = lib.mkIf reportingEnabled {
+    home = {
+      # Note: Python scripts (auto-claude-db.py, auto-claude-digest.py, auto-claude-monitor.py)
+      # are now deployed unconditionally by auto-claude.nix, not here.
+      # This prevents deployment conflicts when reporting is enabled.
+      file = {
+        "${logDir}/.gitkeep".text = "";
+      };
+
+      # Reminder to user: alert integration happens in auto-claude.sh
+      # The monitor script is called after each run completes
+      sessionVariables = {
+        CLAUDE_MONITORING_ENABLED = lib.mkIf cfg.autoClaude.reporting.alerts.enable "1";
+        CLAUDE_ALERT_CONTEXT_THRESHOLD = builtins.toString cfg.autoClaude.reporting.alerts.contextThreshold;
+        CLAUDE_ALERT_BUDGET_THRESHOLD = builtins.toString cfg.autoClaude.reporting.alerts.budgetThreshold;
+        CLAUDE_ALERT_TOKENS_NO_OUTPUT = builtins.toString cfg.autoClaude.reporting.alerts.tokensNoOutput;
+        CLAUDE_ALERT_CONSECUTIVE_FAILURES = builtins.toString cfg.autoClaude.reporting.alerts.consecutiveFailures;
+      };
+    };
+
+    # Launchd agent for scheduled digest reports
+    # Runs at specified times each day (default: 8am and 5pm EST)
+    launchd.agents."com.claude.auto-claude-digest" = {
+      enable = true;
+      config = {
+        Label = "com.claude.auto-claude-digest";
+        Program = "${pythonWithDeps}/bin/python3";
+        ProgramArguments = [
+          "${pythonWithDeps}/bin/python3"
+          "${scriptDir}/auto-claude-digest.py"
+          "--channel"
+          cfg.autoClaude.reporting.scheduledReports.slackChannel
+        ];
+
+        # Run at configured times (UTC)
+        StartCalendarInterval = utcReportTimes;
+
+        # Standard launchd settings
+        StandardOutPath = "${logDir}/launchd-digest.log";
+        StandardErrorPath = "${logDir}/launchd-digest.err";
+
+        # Inherit environment from shell
+        EnvironmentVariables = {
+          PATH = lib.concatStringsSep ":" [
+            "${pythonWithDeps}/bin"
+            "${pkgs.coreutils}/bin"
+          ];
+          HOME = homeDir;
+        };
+
+        # Run with reasonable settings
+        ProcessType = "Standard";
+        RunAtLoad = false;
+      };
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/auto-claude-reporting.nix
+++ b/nix-ai-claude/modules/claude/auto-claude-reporting.nix
@@ -1,7 +1,7 @@
 # Auto-Claude Reporting: Twice-Daily Digest and Real-Time Monitoring
 #
 # Scheduled reports and anomaly detection for auto-claude runs.
-# Sends 8am and 5pm EST Slack reports with efficiency metrics.
+# Sends 8am and 5pm local-time Slack reports with efficiency metrics.
 # Alerts on anomalies: context exhaustion, stuck loops, failures.
 {
   config,
@@ -30,22 +30,18 @@ let
   # Check if reporting is enabled
   reportingEnabled = cfg.autoClaude.reporting.enable;
 
-  # Convert EST report times from config to UTC for launchd StartCalendarInterval
-  # NOTE: This assumes EST is always UTC-5 and does NOT account for Daylight Saving Time (EDT).
-  # During EDT (March-November), EST is actually UTC-4, so reports will be 1 hour off.
-  # If you need DST-aware scheduling, consider using fixed UTC times or a more complex conversion.
-  utcReportTimes = map (
+  # launchd interprets StartCalendarInterval in the local timezone, so keep
+  # the configured times in local time instead of converting them.
+  reportTimes = map (
     timeStr:
     let
       # Parse time string with regex to extract hour and minute
       match = builtins.match "0*([0-9]+):0*([0-9]+)" timeStr;
       hour = lib.toInt (builtins.elemAt match 0);
       minute = lib.toInt (builtins.elemAt match 1);
-      # Assume EST = UTC-5 (not accounting for EDT which is UTC-4)
-      utcHour = lib.mod (hour + 5) 24;
     in
     {
-      Hour = utcHour;
+      Hour = hour;
       Minute = minute;
     }
   ) cfg.autoClaude.reporting.scheduledReports.times;
@@ -66,7 +62,7 @@ in
               "08:00"
               "17:00"
             ];
-            description = "Times for scheduled reports in EST (HH:MM format). Default: 8am and 5pm EST.";
+            description = "Times for scheduled reports in local time (HH:MM format). Default: 8am and 5pm.";
             example = [
               "08:00"
               "17:00"
@@ -142,7 +138,7 @@ in
     };
 
     # Launchd agent for scheduled digest reports
-    # Runs at specified times each day (default: 8am and 5pm EST)
+    # Runs at specified times each day (default: 8am and 5pm local time)
     launchd.agents."com.claude.auto-claude-digest" = {
       enable = true;
       config = {
@@ -155,8 +151,8 @@ in
           cfg.autoClaude.reporting.scheduledReports.slackChannel
         ];
 
-        # Run at configured times (UTC)
-        StartCalendarInterval = utcReportTimes;
+        # Run at configured local times
+        StartCalendarInterval = reportTimes;
 
         # Standard launchd settings
         StandardOutPath = "${logDir}/launchd-digest.log";

--- a/nix-ai-claude/modules/claude/auto-claude-status.py
+++ b/nix-ai-claude/modules/claude/auto-claude-status.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""SwiftBar Auto-Claude Status Plugin."""
+
+import json
+import shlex
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+HOME = Path.home()
+CONTROL_FILE = HOME / ".claude" / "auto-claude-control.json"
+LOG_DIR = HOME / ".claude" / "logs"
+CTL_SCRIPT = HOME / ".claude" / "scripts" / "auto-claude-ctl.sh"
+
+
+def get_active_sessions() -> int:
+    """Count running auto-claude sessions.
+
+    Auto-claude runs: claude -p <prompt> --output-format stream-json ...
+    We look for the specific --output-format flag used by auto-claude.
+    """
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "claude.*--output-format stream-json"],
+            capture_output=True,
+            text=True,
+        )
+        return len(result.stdout.strip().split("\n")) if result.stdout.strip() else 0
+    except Exception:
+        return 0
+
+
+def parse_iso_time(iso_str: str) -> Optional[datetime]:
+    """Parse ISO timestamp."""
+    try:
+        return datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def get_status() -> tuple[str, str, str]:
+    """Return (icon, status_text, color)."""
+    if not CONTROL_FILE.exists():
+        return "🤖", "No control file", "gray"
+
+    try:
+        with open(CONTROL_FILE) as f:
+            data = json.load(f)
+    except Exception:
+        return "⚠️", "Error reading control file", "red"
+
+    active = get_active_sessions()
+    if active > 0:
+        return "🔄", f"Running ({active} sessions)", "blue"
+
+    pause_until = data.get("pause_until")
+    if pause_until:
+        pause_time = parse_iso_time(pause_until)
+        if pause_time:
+            # Ensure `now` and `pause_time` are comparable (both naive or both aware)
+            try:
+                if pause_time.tzinfo is not None:
+                    now = datetime.now(pause_time.tzinfo)
+                else:
+                    now = datetime.now()
+                if now < pause_time:
+                    return "⏸️", f"Paused until {pause_time.strftime('%H:%M')}", "orange"
+            except Exception:
+                # If anything goes wrong comparing times (e.g. unexpected tzinfo),
+                # ignore the pause and fall through to the normal status logic.
+                pass
+
+    skip_count = data.get("skip_count", 0)
+    if skip_count > 0:
+        return "⏭️", f"Skipping {skip_count} runs", "yellow"
+
+    return "🤖", "Active", "green"
+
+
+def get_recent_logs(limit: int = 5) -> list[tuple[str, str, str]]:
+    """Return [(name, size, path), ...] for recent logs."""
+    if not LOG_DIR.exists():
+        return []
+
+    logs = sorted(LOG_DIR.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    result = []
+    for log in logs[:limit]:
+        size = log.stat().st_size
+        if size > 1024 * 1024:
+            size_str = f"{size / (1024 * 1024):.1f}MB"
+        elif size > 1024:
+            size_str = f"{size / 1024:.1f}KB"
+        else:
+            size_str = f"{size}B"
+        result.append((log.stem, size_str, str(log)))
+    return result
+
+
+def get_last_run_info() -> Optional[dict]:
+    """Extract last run info from most recent log file."""
+    if not LOG_DIR.exists():
+        return None
+
+    # Find most recent .jsonl log file (exclude events.jsonl and any summary files)
+    logs = sorted(
+        [
+            l for l in LOG_DIR.glob("*.jsonl")
+            if l.name not in ["events.jsonl", "summary.log"]
+            and not l.name.startswith("summary")
+        ],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True
+    )
+
+    if not logs:
+        return None
+
+    log_file = logs[0]
+    try:
+        # Extract repo name and run_id from filename
+        # Format: "{repo}_{YYYYMMDD}_{HHMMSS}.jsonl"
+        # Use rsplit to handle repo names with underscores (e.g., "my_repo_20251228_150002")
+        parts = log_file.stem.rsplit("_", 2)  # Split from right, max 2 splits
+        if len(parts) >= 3:
+            repo_name = parts[0]
+            run_id = f"{parts[1]}_{parts[2]}"  # Reconstruct run_id from date_time
+        else:
+            # Fallback for unexpected format
+            repo_name = log_file.stem
+            run_id = None
+
+        # Get file modification time
+        mtime = datetime.fromtimestamp(log_file.stat().st_mtime)
+        time_str = mtime.strftime("%H:%M")
+
+        # Find exit_code from events.jsonl (where run_completed events are written)
+        exit_status = None
+        events_file = LOG_DIR / "events.jsonl"
+        if run_id and events_file.exists():
+            with open(events_file, "rb") as f:
+                # Read last ~10KB to find recent run_completed events
+                try:
+                    f.seek(-10240, 2)  # Seek 10KB from end
+                except OSError:
+                    # File smaller than 10KB, read from start
+                    f.seek(0)
+                lines = f.read().decode("utf-8", errors="ignore").splitlines()
+
+            # Search for run_completed event matching this run_id
+            for line in reversed(lines):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                    if event.get("event") == "run_completed" and event.get("run_id") == run_id:
+                        exit_status = event.get("exit_code")
+                        break
+                except json.JSONDecodeError:
+                    continue
+
+        return {
+            "repo": repo_name,
+            "time": time_str,
+            "exit_status": exit_status
+        }
+    except (IOError, IndexError):
+        return None
+
+
+def main():
+    icon, status, color = get_status()
+    ctl = shlex.quote(str(CTL_SCRIPT))
+    log_dir = shlex.quote(str(LOG_DIR))
+
+    # Menu bar: show icon only (no status text)
+    print(f"{icon} | color={color}")
+    print("---")
+
+    # Auto-Claude Status section
+    print(f"Auto-Claude Status: {status} | color={color} disabled=true")
+    print("---")
+
+    # Last run info section
+    last_run = get_last_run_info()
+    if last_run:
+        # Handle None exit_status (unknown) vs 0 (success) vs non-zero (failure)
+        exit_status = last_run["exit_status"]
+        if exit_status is None:
+            status_icon = "?"
+            status_text = "unknown"
+        elif exit_status == 0:
+            status_icon = "✓"
+            status_text = f"exit {exit_status}"
+        else:
+            status_icon = "✗"
+            status_text = f"exit {exit_status}"
+
+        print(f"Last run: {last_run['time']} | disabled=true")
+        print(f"  Repo: {last_run['repo']} | disabled=true")
+        print(f"  Status: {status_icon} ({status_text}) | disabled=true")
+    else:
+        print("Last run: No runs yet | disabled=true")
+    print("---")
+
+    # Control actions
+    print(f"Run Now | bash={ctl} param1='run' terminal=false refresh=true")
+    print(f"Resume | bash={ctl} param1='resume' terminal=false refresh=true")
+    print(f"Skip next run | bash={ctl} param1='skip' param2='1' terminal=false refresh=true")
+
+    # Pause submenu with all options
+    print("--Pause for:")
+    for hours in [1, 2, 4, 6, 8, 12]:
+        label = f"{hours} hour" if hours == 1 else f"{hours} hours"
+        print(f"----{label} | bash={ctl} param1='pause' param2='{hours}' terminal=false refresh=true")
+
+    # Calculate hours until midnight for "pause until midnight" option
+    now = datetime.now()
+    midnight = now.replace(hour=23, minute=59, second=59, microsecond=0)
+    hours_until_midnight = max(1, int((midnight - now).total_seconds() / 3600) + 1)
+    print(f"----Until midnight | bash={ctl} param1='pause' param2='{hours_until_midnight}' terminal=false refresh=true")
+
+    # Add 1 day and 2 days options
+    print(f"----1 day | bash={ctl} param1='pause' param2='24' terminal=false refresh=true")
+    print(f"----2 days | bash={ctl} param1='pause' param2='48' terminal=false refresh=true")
+
+    print("---")
+
+    # Recent logs section
+    print("Recent Logs | size=12")
+    logs = get_recent_logs()
+    if logs:
+        for name, size, path in logs:
+            # Properly escape path for shell safety - use 'open' to open with default app
+            escaped_path = shlex.quote(path)
+            print(f"  {name} ({size}) | bash='open {escaped_path}' terminal=false")
+    else:
+        print("  No logs found | color=gray")
+
+    print("---")
+
+    # Bottom actions
+    print(f"Open Logs Folder | bash='open {log_dir}' terminal=false")
+    print(f"View Status | bash={ctl} param1='status' terminal=true")
+    print("---")
+    print("Refresh | refresh=true")
+
+
+if __name__ == "__main__":
+    main()

--- a/nix-ai-claude/modules/claude/auto-claude.nix
+++ b/nix-ai-claude/modules/claude/auto-claude.nix
@@ -1,0 +1,228 @@
+# Auto-Claude: Scheduled Autonomous Maintenance
+#
+# Configures launchd agents to run Claude autonomously on git repositories
+# at scheduled times. Uses the apiKeyHelper for headless authentication.
+# Sends rich Slack notifications via Python notifier.
+#
+# Options defined in: auto-claude/options.nix
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+  homeDir = config.home.homeDirectory;
+  scriptPath = "${homeDir}/.claude/scripts/auto-claude.sh";
+  logDir = "${homeDir}/.claude/logs";
+
+  python = import ../../lib/python.nix { inherit pkgs; };
+
+  # Python environment for auto-claude scripts
+  pythonEnv = python.withPackages (ps: [
+    (ps.slack-sdk.overridePythonAttrs (_: {
+      doCheck = false; # Disable tests - they fail in CI with connection/signal errors
+    }))
+    ps.cryptography # Cryptographic recipes and primitives (system-wide requirement)
+    ps.keyring # macOS Keychain access
+    ps.pyyaml
+  ]);
+
+  # Convert time spec to launchd calendar interval
+  # Supports both simple hour (int) and {hour, minute} attrset
+  mkCalendarInterval =
+    time:
+    if builtins.isInt time then
+      {
+        Hour = time;
+        Minute = 0;
+      }
+    else
+      {
+        Hour = time.hour;
+        Minute = time.minute or 0;
+      };
+
+  # Normalize schedule settings (supports single hour, list of hours, or list of times)
+  getScheduleTimes =
+    schedule:
+    let
+      timesList = schedule.times;
+      hoursList = schedule.hours;
+      hourOpt = schedule.hour;
+    in
+    if timesList != [ ] then
+      timesList
+    else if hoursList != [ ] then
+      hoursList
+    else if hourOpt != null then
+      [ hourOpt ]
+    else
+      [ ];
+
+  # Filter to only enabled repositories
+  enabledRepos = lib.filterAttrs (_: r: r.enabled) cfg.autoClaude.repositories;
+
+in
+{
+  imports = [ ./auto-claude/options.nix ];
+
+  config = lib.mkIf (cfg.enable && cfg.autoClaude.enable) {
+    # Ensure each enabled repository has at least one scheduled time
+    assertions = lib.mapAttrsToList (
+      name: repoCfg:
+      let
+        timesList = getScheduleTimes repoCfg.schedule;
+      in
+      {
+        assertion = (!repoCfg.enabled) || (timesList != [ ]);
+        message = "programs.claude.autoClaude.repositories.${name} must set schedule.times when enabled";
+      }
+    ) enabledRepos;
+
+    # Warn if apiKeyHelper is not enabled (required for headless auth)
+    warnings = lib.optional (!cfg.apiKeyHelper.enable) ''
+      programs.claude.autoClaude is enabled but programs.claude.apiKeyHelper is not.
+      Auto-Claude requires apiKeyHelper for headless authentication.
+      Enable it with: programs.claude.apiKeyHelper.enable = true;
+    '';
+
+    # Add Python with slack-sdk to path and deploy scripts
+    home = {
+      packages = [ pythonEnv ];
+
+      file = {
+        # Deploy shell script
+        ".claude/scripts/auto-claude.sh" = {
+          source = ./auto-claude.sh;
+          executable = true;
+        };
+
+        # Deploy control script for runtime pause/resume/status
+        ".claude/scripts/auto-claude-ctl.sh" = {
+          source = ./auto-claude-ctl.sh;
+          executable = true;
+        };
+
+        # Deploy orchestrator prompt
+        ".claude/scripts/orchestrator-prompt.txt" = {
+          source = ./orchestrator-prompt.txt;
+        };
+
+        # Deploy Python notifier
+        ".claude/scripts/auto-claude-notify.py" = {
+          source = ./auto-claude-notify.py;
+          executable = true;
+        };
+
+        # Deploy BWS helper (shared by notifier and API key helper)
+        ".claude/scripts/bws_helper.py" = {
+          source = ./bws_helper.py;
+          executable = true;
+        };
+
+        # Deploy Python modules for auto-claude
+        ".claude/scripts/auto_claude_utils.py" = {
+          source = ./auto_claude_utils.py;
+          executable = true;
+        };
+        ".claude/scripts/auto_claude_preflight.py" = {
+          source = ./auto_claude_preflight.py;
+          executable = true;
+        };
+        ".claude/scripts/auto_claude_postrun.py" = {
+          source = ./auto_claude_postrun.py;
+          executable = true;
+        };
+
+        # Deploy Slack notification test script
+        ".claude/scripts/test-slack-notifications.py" = {
+          source = ./test-slack-notifications.py;
+          executable = true;
+        };
+
+        # Deploy monitoring and reporting modules (always deployed, not gated by reporting.enable)
+        # These are dependencies of auto-claude-monitor.py which runs after each auto-claude run
+        ".claude/scripts/auto_claude_db.py" = {
+          source = ./auto_claude_db.py;
+          executable = true;
+        };
+        ".claude/scripts/auto-claude-monitor.py" = {
+          source = ./auto-claude-monitor.py;
+          executable = true;
+        };
+        ".claude/scripts/auto-claude-digest.py" = {
+          source = ./auto-claude-digest.py;
+          executable = true;
+        };
+
+        # Deploy BWS config template (user copies to .env and fills in values)
+        ".config/bws/.env.example" = {
+          source = ./bws-env.example;
+        };
+      };
+
+      # Shell alias for convenient access to control script
+      shellAliases = {
+        auto-claude-ctl = "${homeDir}/.claude/scripts/auto-claude-ctl.sh";
+      };
+    };
+
+    # Add shell alias for convenience
+    programs.zsh.shellAliases = {
+      auto-claude-ctl = "${homeDir}/.claude/scripts/auto-claude-ctl.sh";
+    };
+
+    # Create launchd agents for each repository (Darwin only)
+    # Each agent calls the same script with repository-specific arguments
+    launchd.agents = lib.mapAttrs' (
+      name: repoCfg:
+      let
+        timesList = getScheduleTimes repoCfg.schedule;
+        slackArg = if repoCfg.slackChannel != null then repoCfg.slackChannel else "";
+      in
+      lib.nameValuePair "com.claude.auto-claude-${name}" {
+        enable = repoCfg.enabled;
+        config = {
+          Label = "com.claude.auto-claude-${name}";
+          # Link to Ghostty for TCC permission inheritance
+          # Agents associated with an app can inherit its Full Disk Access
+          AssociatedBundleIdentifiers = [ "com.mitchellh.ghostty" ];
+          # Pass arguments at runtime instead of baking them into the script
+          ProgramArguments = [
+            scriptPath
+            repoCfg.path
+            (toString repoCfg.maxBudget)
+            logDir
+            slackArg
+          ];
+          StartCalendarInterval = map mkCalendarInterval timesList;
+          StandardOutPath = "${logDir}/launchd-${name}.log";
+          StandardErrorPath = "${logDir}/launchd-${name}.err";
+          EnvironmentVariables = {
+            HOME = homeDir;
+            # Claude model selection (defense-in-depth: env var + settings.json + --model flag)
+            CLAUDE_MODEL = repoCfg.model;
+            # Use per-user profile path and pythonEnv for proper package resolution
+            # pythonEnv contains slack-sdk and other required packages
+            PATH = "${pythonEnv}/bin:/etc/profiles/per-user/${config.home.username}/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+            # Explicitly set PYTHONPATH for launchd's clean environment
+            # Nix python wrappers may not resolve properly without this
+            # Include scripts directory for auto_claude_db, auto_claude_utils, etc.
+            PYTHONPATH = "${pythonEnv}/${python.sitePackages}:${homeDir}/.claude/scripts";
+            # GitHub CLI config directory for headless authentication
+            # gh will use the token from ~/.config/gh/hosts.yml
+            GH_CONFIG_DIR = "${homeDir}/.config/gh";
+          }
+          # API key helper for headless Claude authentication
+          # Must be passed to launchd environment, not just settings.json
+          // lib.optionalAttrs cfg.apiKeyHelper.enable {
+            API_KEY_HELPER = "${homeDir}/${cfg.apiKeyHelper.scriptPath}";
+          };
+        };
+      }
+    ) enabledRepos;
+  };
+}

--- a/nix-ai-claude/modules/claude/auto-claude.sh
+++ b/nix-ai-claude/modules/claude/auto-claude.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env zsh
+# =============================================================================
+# Auto-Claude: Autonomous AI Maintenance Daemon
+# =============================================================================
+# Runs Claude autonomously via launchd to perform maintenance tasks on git repos.
+# Uses Python modules for complex logic (preflight checks, postrun processing).
+#
+# Usage: auto-claude.sh <target_dir> <max_budget_usd> [log_dir] [slack_channel]
+#
+# Environment:
+# - FORCE_RUN=1 : Bypass pause/skip checks (used by auto-claude-ctl run)
+# =============================================================================
+
+set -euo pipefail
+
+# --- ARGUMENT PARSING ---
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <target_dir> <max_budget_usd> [log_dir] [slack_channel]" >&2
+  exit 1
+fi
+
+TARGET_DIR="$1"
+MAX_BUDGET_USD="$2"
+LOG_DIR="${3:-$HOME/.claude/logs}"
+SLACK_CHANNEL="${4:-}"
+
+# --- PATHS ---
+SCRIPT_DIR="${HOME}/.claude/scripts"
+NOTIFIER="${SCRIPT_DIR}/auto-claude-notify.py"
+PROMPT_FILE="${SCRIPT_DIR}/orchestrator-prompt.txt"
+
+# --- KEYCHAIN SECRETS ---
+# Retrieve secrets from macOS automation keychain for headless operation
+# This provides early fallback before Python preflight runs
+AUTOMATION_KEYCHAIN="${HOME}/Library/Keychains/automation.keychain-db"
+KEYCHAIN_ACCOUNT="ai-cli-coder"
+
+# Function to get a secret from the automation keychain
+get_keychain_secret() {
+  local service_name="$1"
+  if ! command -v security >/dev/null 2>&1; then
+    echo "Warning: 'security' command not found. Cannot retrieve secrets from keychain." >&2
+    return 1
+  fi
+
+  # Capture both stdout and stderr to detect actual errors
+  local output exit_code
+  output=$(security find-generic-password -a "$KEYCHAIN_ACCOUNT" -s "$service_name" -w "$AUTOMATION_KEYCHAIN" 2>&1) || {
+    exit_code=$?
+    # Only log if it's a real error (not just "item not found" which is expected for optional secrets)
+    if [[ $exit_code -ne 44 ]]; then  # 44 is "item not found" error code
+      echo "Error: Failed to retrieve keychain secret for service '$service_name' (exit code: $exit_code)" >&2
+    fi
+    return $exit_code
+  }
+  echo "$output"
+}
+
+# Get BWS access token (required for Slack notifier to authenticate with Bitwarden)
+if [[ -z "${BWS_ACCESS_TOKEN:-}" ]] && [[ -f "$AUTOMATION_KEYCHAIN" ]]; then
+  _token=$(get_keychain_secret "bws-access-token") || true
+  if [[ -n "$_token" ]]; then
+    export BWS_ACCESS_TOKEN="$_token"
+  fi
+fi
+
+# Get Slack channel from keychain if not provided as argument
+# Channels are stored as SLACK_CHANNEL_ID_<REPO_NAME> (uppercase, dashes/dots to underscores)
+if [[ -z "$SLACK_CHANNEL" ]] && [[ -f "$AUTOMATION_KEYCHAIN" ]]; then
+  # Normalize repo name: basename, uppercase, replace dashes/dots with underscores
+  REPO_BASENAME=$(basename "${TARGET_DIR%/}")
+  REPO_KEY=${${(U)REPO_BASENAME}//[-.]/_}
+  KEYCHAIN_SERVICE="SLACK_CHANNEL_ID_${REPO_KEY}"
+  SLACK_CHANNEL=$(get_keychain_secret "$KEYCHAIN_SERVICE") || true
+fi
+
+# --- SSH AGENT SETUP FOR GIT OPERATIONS ---
+# LaunchD agents don't inherit the user's SSH agent
+# Start a new agent and add keys from macOS Keychain if available
+if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
+  eval "$(ssh-agent -s 2>/dev/null)" || true
+  # Add keys from Keychain (requires AddKeysToAgent and UseKeychain in SSH config)
+  ssh-add --apple-use-keychain 2>/dev/null || true
+fi
+
+# --- GIT SSH BATCH MODE ---
+# If SSH agent has no identities, configure git to fail fast on SSH by forcing
+# SSH BatchMode (this only affects git's SSH operations, not gh CLI auth).
+# gh CLI authentication is handled separately via its config directory
+# (controlled by GH_CONFIG_DIR in the Nix configuration).
+if ! ssh-add -l >/dev/null 2>&1; then
+  export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=yes"
+fi
+
+# --- INPUT VALIDATION ---
+if [[ ! -d "$TARGET_DIR" ]]; then
+  echo "Error: Directory $TARGET_DIR does not exist." >&2
+  exit 1
+fi
+
+if ! [[ "$MAX_BUDGET_USD" =~ ^[0-9]+\.?[0-9]*$ ]] || ! awk -v val="$MAX_BUDGET_USD" 'BEGIN { exit !(val > 0) }'; then
+  echo "Error: MAX_BUDGET_USD must be a positive number, got: $MAX_BUDGET_USD" >&2
+  exit 1
+fi
+
+# --- LOGGING SETUP ---
+if ! mkdir -p "$LOG_DIR"; then
+  echo "Error: Cannot create log directory $LOG_DIR" >&2
+  exit 1
+fi
+
+RUN_ID=$(date "+%Y%m%d_%H%M%S")
+REPO_NAME=$(basename "${TARGET_DIR%/}")
+LOG_FILE="$LOG_DIR/${REPO_NAME}_${RUN_ID}.jsonl"
+SUMMARY_LOG="$LOG_DIR/summary.log"
+FAILURES_LOG="$LOG_DIR/failures.log"
+
+# --- ENVIRONMENT SETUP ---
+# NOTE: We intentionally do NOT source .zshrc or .profile here.
+# LaunchD agents should run in a controlled environment defined by the plist.
+# The launchd plist sets PATH to include /etc/profiles/per-user/<user>/bin
+# which provides home-manager packages (python3 with slack_sdk, etc.)
+# Sourcing interactive shell configs would override PATH and cause issues.
+
+# --- PYTHON PREFLIGHT CHECKS ---
+FORCE_FLAG=""
+[[ "${FORCE_RUN:-}" == "1" ]] && FORCE_FLAG="--force"
+
+# Run all preflight checks via Python
+PREFLIGHT_RESULT=$(python3 "${SCRIPT_DIR}/auto_claude_preflight.py" all "$TARGET_DIR" $FORCE_FLAG --json) || {
+  PREFLIGHT_EXIT=$?
+  if [[ $PREFLIGHT_EXIT -eq 2 ]]; then
+    # Skip requested (paused or skip_count)
+    SKIP_REASON=$(echo "$PREFLIGHT_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+    echo "[$RUN_ID] SKIPPED: $SKIP_REASON" >> "$SUMMARY_LOG"
+
+    # Send skip notification if Slack is available
+    if [[ -n "$SLACK_CHANNEL" ]] && [[ -x "$NOTIFIER" ]]; then
+      python3 "$NOTIFIER" run_skipped --repo "$REPO_NAME" --reason "$SKIP_REASON" --channel "$SLACK_CHANNEL" 2>/dev/null || true
+    fi
+    exit 0
+  fi
+  # Extract failure reason if available
+  PREFLIGHT_REASON=$(echo "$PREFLIGHT_RESULT" | python3 -c "import sys, json; data=sys.stdin.read(); obj=json.loads(data) if data else {}; print(obj.get('reason') or obj.get('error') or obj.get('message') or '')" 2>/dev/null || echo "")
+  if [[ -n "$PREFLIGHT_REASON" ]]; then
+    echo "[$RUN_ID] ERROR: Preflight checks failed (exit=$PREFLIGHT_EXIT, reason=$PREFLIGHT_REASON)" >> "$FAILURES_LOG"
+  else
+    echo "[$RUN_ID] ERROR: Preflight checks failed (exit=$PREFLIGHT_EXIT)" >> "$FAILURES_LOG"
+  fi
+  exit 1
+}
+
+# Extract channel from preflight if not provided
+if [[ -z "$SLACK_CHANNEL" ]]; then
+  SLACK_CHANNEL=$(echo "$PREFLIGHT_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('channel',{}).get('channel',''))" 2>/dev/null || true)
+fi
+
+# Extract repo name from preflight (more accurate for worktrees)
+DETECTED_REPO=$(echo "$PREFLIGHT_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('channel',{}).get('repo_name',''))" 2>/dev/null || true)
+[[ -n "$DETECTED_REPO" ]] && REPO_NAME="$DETECTED_REPO"
+
+# --- WORKTREE SETUP ---
+# Determine repository structure and set up isolated worktree for this run
+if [[ ! -e "$TARGET_DIR/.git" ]]; then
+  echo "[$RUN_ID] ERROR: $TARGET_DIR is not a git repository" >> "$FAILURES_LOG"
+  exit 1
+fi
+
+# Determine the bare repo location
+pushd "$TARGET_DIR" >/dev/null || {
+  echo "[$RUN_ID] ERROR: Cannot access $TARGET_DIR" >> "$FAILURES_LOG"
+  exit 1
+}
+BARE_REPO=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+popd >/dev/null
+
+if [[ -n "$BARE_REPO" ]] && [[ "$BARE_REPO" != ".git" ]]; then
+  # This is a worktree - find the parent (bare repo)
+  BARE_REPO=$(dirname "$BARE_REPO")
+else
+  # This is a regular repo - use its parent for worktree creation
+  BARE_REPO=$(dirname "$TARGET_DIR")
+fi
+
+# Sync main worktree with origin
+echo "[$RUN_ID] INFO: Syncing main worktree..." >> "$SUMMARY_LOG"
+pushd "$TARGET_DIR" >/dev/null || {
+  echo "[$RUN_ID] ERROR: Cannot cd to $TARGET_DIR" >> "$FAILURES_LOG"
+  exit 1
+}
+# Determine default branch dynamically
+DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH="main"
+# Validate branch name before use in subprocess calls to prevent flag/argument injection
+if ! [[ "$DEFAULT_BRANCH" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
+  echo "[$RUN_ID] ERROR: Unsafe branch name detected: $DEFAULT_BRANCH" >> "$FAILURES_LOG"
+  exit 1
+fi
+
+git fetch origin 2>&1 | tee -a "$FAILURES_LOG" || {
+  popd >/dev/null
+  echo "[$RUN_ID] ERROR: git fetch failed" >> "$FAILURES_LOG"
+  exit 1
+}
+git pull --ff-only origin "$DEFAULT_BRANCH" 2>&1 | tee -a "$FAILURES_LOG" || {
+  popd >/dev/null
+  echo "[$RUN_ID] ERROR: Fast-forward pull failed in main worktree" >> "$FAILURES_LOG"
+  exit 1
+}
+popd >/dev/null
+
+# Create worktree for this run
+TIMESTAMP=$(date "+%Y-%m-%d-%H%M")
+WORKTREE_NAME="auto-claude-${TIMESTAMP}"
+WORKTREE_DIR="${BARE_REPO}/worktrees/${WORKTREE_NAME}"
+BRANCH_NAME="${WORKTREE_NAME}"
+
+# Ensure worktrees directory exists
+mkdir -p "${BARE_REPO}/worktrees" || {
+  echo "[$RUN_ID] ERROR: Cannot create worktrees directory" >> "$FAILURES_LOG"
+  exit 1
+}
+
+# Create worktree branching from origin/main
+echo "[$RUN_ID] INFO: Creating worktree at $WORKTREE_DIR" >> "$SUMMARY_LOG"
+ORIGINAL_TARGET_DIR="$TARGET_DIR"
+pushd "$ORIGINAL_TARGET_DIR" >/dev/null || {
+  echo "[$RUN_ID] ERROR: Cannot cd to $ORIGINAL_TARGET_DIR" >> "$FAILURES_LOG"
+  exit 1
+}
+git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" origin/main 2>/dev/null || {
+  popd >/dev/null
+  echo "[$RUN_ID] ERROR: git worktree add failed" >> "$FAILURES_LOG"
+  exit 1
+}
+popd >/dev/null
+
+# Update TARGET_DIR to point to the new worktree
+TARGET_DIR="$WORKTREE_DIR"
+
+# --- PRE-FLIGHT DEPENDENCY CHECKS ---
+cd "$TARGET_DIR" || {
+  echo "[$RUN_ID] ERROR: Cannot cd to worktree $TARGET_DIR" >> "$FAILURES_LOG"
+  # Clean up worktree on cd failure
+  if [[ -n "$WORKTREE_DIR" ]]; then
+    pushd "$ORIGINAL_TARGET_DIR" >/dev/null && git worktree remove "$WORKTREE_DIR" --force 2>/dev/null && popd >/dev/null || true
+  fi
+  exit 1
+}
+
+if ! command -v claude &>/dev/null; then
+  echo "[$RUN_ID] ERROR: Claude CLI not found in PATH" >> "$FAILURES_LOG"
+  exit 1
+fi
+
+if [[ ! -r "$PROMPT_FILE" ]]; then
+  echo "[$RUN_ID] ERROR: Orchestrator prompt not found at $PROMPT_FILE" >> "$FAILURES_LOG"
+  exit 1
+fi
+
+# --- SLACK SETUP ---
+SLACK_ENABLED=false
+if [[ -n "$SLACK_CHANNEL" ]] && [[ -x "$NOTIFIER" ]] && command -v python3 &>/dev/null; then
+  SLACK_ENABLED=true
+fi
+
+# --- EMIT PREFLIGHT PASSED EVENT ---
+python3 "${SCRIPT_DIR}/auto_claude_postrun.py" emit-event preflight_passed \
+  --run-id "$RUN_ID" --repo "$REPO_NAME" \
+  --extra "target_dir=$TARGET_DIR" "budget=$MAX_BUDGET_USD" || true
+
+# --- SLACK: RUN STARTED ---
+PARENT_TS=""
+if [[ "$SLACK_ENABLED" == "true" ]]; then
+  PARENT_TS=$(python3 "$NOTIFIER" run_started \
+    --repo "$REPO_NAME" \
+    --budget "$MAX_BUDGET_USD" \
+    --run-id "$RUN_ID" \
+    --channel "$SLACK_CHANNEL") || true
+fi
+
+# --- EXECUTION ---
+echo "" >> "$SUMMARY_LOG"
+echo "=== [$RUN_ID] Starting: $REPO_NAME ===" >> "$SUMMARY_LOG"
+echo "    Target: $TARGET_DIR" >> "$SUMMARY_LOG"
+echo "    Budget: \$${MAX_BUDGET_USD}" >> "$SUMMARY_LOG"
+[[ -n "$PARENT_TS" ]] && echo "    Slack thread: $PARENT_TS" >> "$SUMMARY_LOG"
+
+# Emit run_started event
+python3 "${SCRIPT_DIR}/auto_claude_postrun.py" emit-event run_started \
+  --run-id "$RUN_ID" --repo "$REPO_NAME" --budget "$MAX_BUDGET_USD" \
+  --extra "slack_enabled=$SLACK_ENABLED" || true
+
+START_TIME=$(date +%s)
+ORCHESTRATOR_PROMPT=$(<"$PROMPT_FILE")
+
+set +e
+# Use gtimeout (macOS via coreutils) or timeout (Linux), fallback to no timeout
+TIMEOUT_CMD=""
+command -v gtimeout &>/dev/null && TIMEOUT_CMD="gtimeout 3600"
+command -v timeout &>/dev/null && [[ -z "$TIMEOUT_CMD" ]] && TIMEOUT_CMD="timeout 3600"
+
+# Determine model from environment variable (set by launchd via nix config)
+# Defaults to haiku if not set, with explicit --model flag for defense-in-depth
+CLAUDE_MODEL_TO_USE="${CLAUDE_MODEL:-haiku}"
+
+$TIMEOUT_CMD claude -p "$ORCHESTRATOR_PROMPT" \
+  --model "$CLAUDE_MODEL_TO_USE" \
+  --output-format stream-json \
+  --verbose \
+  --max-budget-usd "$MAX_BUDGET_USD" \
+  --no-session-persistence \
+  2>&1 | tee "$LOG_FILE"
+
+EXIT_CODE=${pipestatus[1]}
+set -e
+
+# --- POST-RUN PROCESSING ---
+END_TIME=$(date +%s)
+DURATION_SEC=$((END_TIME - START_TIME))
+TIMESTAMP=$(date "+%Y-%m-%d %H:%M:%S")
+
+# Check context usage via Python
+python3 "${SCRIPT_DIR}/auto_claude_postrun.py" check-context "$LOG_FILE" \
+  --run-id "$RUN_ID" --repo "$REPO_NAME" || true
+
+# Emit run_completed event
+if [[ $EXIT_CODE -eq 0 ]]; then
+  echo "=== [$TIMESTAMP] Completed: $REPO_NAME (exit 0) ===" >> "$SUMMARY_LOG"
+  python3 "${SCRIPT_DIR}/auto_claude_postrun.py" emit-event run_completed \
+    --run-id "$RUN_ID" --repo "$REPO_NAME" --exit-code 0 --duration "$DURATION_SEC" || true
+else
+  echo "=== [$TIMESTAMP] Failed: $REPO_NAME (exit $EXIT_CODE) ===" >> "$SUMMARY_LOG"
+  echo "[$RUN_ID] $REPO_NAME: Exit code $EXIT_CODE" >> "$FAILURES_LOG"
+  python3 "${SCRIPT_DIR}/auto_claude_postrun.py" emit-event run_completed \
+    --run-id "$RUN_ID" --repo "$REPO_NAME" --exit-code "$EXIT_CODE" --duration "$DURATION_SEC" || true
+fi
+
+# --- SLACK: RUN COMPLETED ---
+if [[ "$SLACK_ENABLED" == "true" ]] && [[ -n "$PARENT_TS" ]]; then
+  python3 "$NOTIFIER" run_completed \
+    --repo "$REPO_NAME" \
+    --channel "$SLACK_CHANNEL" \
+    --thread-ts "$PARENT_TS" \
+    --budget "$MAX_BUDGET_USD" \
+    --run-id "$RUN_ID" \
+    --log-file "$LOG_FILE" || true
+fi
+
+# --- MONITORING: CHECK FOR ANOMALIES ---
+MONITOR_SCRIPT="${SCRIPT_DIR}/auto-claude-monitor.py"
+if [[ -x "$MONITOR_SCRIPT" ]] && [[ "${CLAUDE_MONITORING_ENABLED:-0}" == "1" ]] && [[ "$SLACK_ENABLED" == "true" ]]; then
+  declare -a monitor_args=(--run-id "$RUN_ID" --repo "$REPO_NAME" --log-file "$LOG_FILE" --channel "$SLACK_CHANNEL")
+  [[ -n "${CLAUDE_ALERT_CONTEXT_THRESHOLD:-}" ]] && monitor_args+=(--context-threshold "$CLAUDE_ALERT_CONTEXT_THRESHOLD")
+  [[ -n "${CLAUDE_ALERT_BUDGET_THRESHOLD:-}" ]] && monitor_args+=(--budget-threshold "$CLAUDE_ALERT_BUDGET_THRESHOLD")
+  [[ -n "${CLAUDE_ALERT_TOKENS_NO_OUTPUT:-}" ]] && monitor_args+=(--tokens-no-output "$CLAUDE_ALERT_TOKENS_NO_OUTPUT")
+  [[ -n "${CLAUDE_ALERT_CONSECUTIVE_FAILURES:-}" ]] && monitor_args+=(--consecutive-failures "$CLAUDE_ALERT_CONSECUTIVE_FAILURES")
+  python3 "$MONITOR_SCRIPT" "${monitor_args[@]}" >&2 || true
+fi
+
+# --- UPDATE CONTROL FILE (only on success) ---
+if [[ $EXIT_CODE -eq 0 ]]; then
+  python3 "${SCRIPT_DIR}/auto_claude_postrun.py" update-control "$REPO_NAME" || true
+fi
+
+# --- WORKTREE CLEANUP ---
+if [[ -n "${WORKTREE_DIR:-}" ]] && [[ -d "$WORKTREE_DIR" ]]; then
+  if [[ $EXIT_CODE -eq 0 ]]; then
+    echo "[$RUN_ID] INFO: Cleaning up worktree (success)" >> "$SUMMARY_LOG"
+
+    # Remove worktree and branch - only proceed if we can cd to the correct directory
+    if pushd "$ORIGINAL_TARGET_DIR" >/dev/null 2>&1; then
+      git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
+        echo "[$RUN_ID] WARNING: Failed to remove worktree $WORKTREE_DIR" >> "$SUMMARY_LOG"
+      }
+      git branch -D "$BRANCH_NAME" 2>/dev/null || {
+        echo "[$RUN_ID] WARNING: Failed to delete branch $BRANCH_NAME" >> "$SUMMARY_LOG"
+      }
+      popd >/dev/null || true
+    else
+      echo "[$RUN_ID] WARNING: Cannot cd to $ORIGINAL_TARGET_DIR for cleanup, worktree preserved at $WORKTREE_DIR" >> "$SUMMARY_LOG"
+    fi
+  else
+    echo "[$RUN_ID] INFO: Preserving worktree for inspection (failed run): $WORKTREE_DIR" >> "$SUMMARY_LOG"
+    echo "    To clean up manually: cd \"$ORIGINAL_TARGET_DIR\" && git worktree remove \"$WORKTREE_DIR\" --force" >> "$SUMMARY_LOG"
+  fi
+fi
+
+echo "" >> "$SUMMARY_LOG"
+exit "$EXIT_CODE"

--- a/nix-ai-claude/modules/claude/auto-claude/options.nix
+++ b/nix-ai-claude/modules/claude/auto-claude/options.nix
@@ -1,0 +1,122 @@
+# Auto-Claude Options
+#
+# Options for scheduled autonomous maintenance via launchd agents.
+# Implementation in ../auto-claude.nix
+{ lib, ... }:
+
+{
+  options.programs.claude.autoClaude = {
+    enable = lib.mkEnableOption "Auto-Claude scheduled maintenance";
+
+    repositories = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            path = lib.mkOption {
+              type = lib.types.str;
+              description = "Absolute path to the git repository";
+            };
+
+            schedule = lib.mkOption {
+              type = lib.types.submodule {
+                options = {
+                  hour = lib.mkOption {
+                    type = lib.types.nullOr (lib.types.ints.between 0 23);
+                    default = null;
+                    description = "Hour of day to run (0-23). Deprecated in favor of hours/times.";
+                  };
+
+                  hours = lib.mkOption {
+                    type = lib.types.listOf (lib.types.ints.between 0 23);
+                    default = [ ];
+                    description = ''
+                      List of hours (0-23) to run each day at minute 0.
+                      Deprecated in favor of times for hour+minute control.
+
+                      If empty and schedule.hour is set, falls back to that single hour.
+                      Example: To run every 2 hours, set to [0 2 4 6 8 10 12 14 16 18 20 22].
+                    '';
+                  };
+
+                  times = lib.mkOption {
+                    type = lib.types.listOf (
+                      lib.types.submodule {
+                        options = {
+                          hour = lib.mkOption {
+                            type = lib.types.ints.between 0 23;
+                            description = "Hour of day (0-23)";
+                          };
+                          minute = lib.mkOption {
+                            type = lib.types.ints.between 0 59;
+                            default = 0;
+                            description = "Minute of hour (0-59)";
+                          };
+                        };
+                      }
+                    );
+                    default = [ ];
+                    description = ''
+                      List of times to run each day. Each time has hour (0-23) and minute (0-59).
+
+                      If empty, falls back to the deprecated 'hours' or 'hour' options.
+                      Default runs once daily at 2:00 PM to minimize unexpected costs.
+                      Add more times for more frequent maintenance runs.
+
+                      Example:
+                        times = [
+                          { hour = 9; minute = 30; }   # 9:30 AM
+                          { hour = 14; minute = 0; }   # 2:00 PM
+                          { hour = 18; minute = 30; }  # 6:30 PM
+                        ];
+                    '';
+                  };
+                };
+              };
+              description = "When to run the maintenance task";
+            };
+
+            maxBudget = lib.mkOption {
+              type = lib.types.float;
+              default = 50.0;
+              description = ''
+                Maximum cost per run in USD. Uses Haiku model exclusively.
+
+                IMPORTANT: This default is set to $50.0 and uses Claude Haiku exclusively.
+                Auto-claude enforces Haiku-only operation via environment variables,
+                settings.json, and explicit --model haiku flag for defense-in-depth.
+
+                With the default once-daily schedule, this means up to $50/day per repository.
+                Haiku provides cost-effective operation while maintaining quality output.
+              '';
+            };
+
+            model = lib.mkOption {
+              type = lib.types.str;
+              default = "haiku";
+              description = ''
+                Claude model to use for auto-claude runs.
+
+                Strongly recommended: "haiku" - cost-effective, excellent for autonomous tasks
+                Alternatives: "sonnet", "opus" (significantly higher cost)
+              '';
+            };
+
+            slackChannel = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Slack channel ID for notifications (e.g., C0123456789)";
+            };
+
+            enabled = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether this repository's schedule is active";
+            };
+          };
+        }
+      );
+      default = { };
+      description = "Repositories to run auto-claude on";
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/auto_claude_db.py
+++ b/nix-ai-claude/modules/claude/auto_claude_db.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""
+Auto-Claude Database Module
+
+SQLite aggregation layer for auto-claude monitoring.
+Parses JSONL logs and maintains summary data for efficient reporting.
+
+Usage:
+    # As module
+    from auto_claude_db import AutoClaudeDB
+    db = AutoClaudeDB()
+    db.insert_run(run_data)
+    runs = db.get_runs_since(timestamp)
+
+    # As CLI
+    auto-claude-db.py insert --run-id 20251222_150007 --log-file path/to/log.jsonl
+    auto-claude-db.py query --since "2025-12-22T08:00:00"
+    auto-claude-db.py backfill --days 30
+"""
+
+import argparse
+import json
+import re
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+# Default paths
+DEFAULT_DB_PATH = Path.home() / ".claude" / "logs" / "summary.db"
+DEFAULT_LOGS_DIR = Path.home() / ".claude" / "logs"
+
+
+class AutoClaudeDB:
+    """SQLite database for auto-claude run aggregation."""
+
+    SCHEMA = """
+    CREATE TABLE IF NOT EXISTS runs (
+        run_id TEXT PRIMARY KEY,
+        repo TEXT NOT NULL,
+        started_at TEXT,
+        ended_at TEXT,
+        duration_sec INTEGER DEFAULT 0,
+        exit_code INTEGER,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        context_window INTEGER DEFAULT 200000,
+        context_usage_pct INTEGER DEFAULT 0,
+        tasks_completed INTEGER DEFAULT 0,
+        tasks_blocked INTEGER DEFAULT 0,
+        prs_created INTEGER DEFAULT 0,
+        issues_resolved INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS work_units (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id TEXT NOT NULL,
+        unit_type TEXT NOT NULL,  -- 'pr', 'issue', 'task', 'fix'
+        identifier TEXT,          -- PR number, issue number, task desc
+        tokens_used INTEGER DEFAULT 0,
+        duration_sec INTEGER DEFAULT 0,
+        status TEXT DEFAULT 'completed',  -- 'completed', 'blocked', 'in_progress'
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (run_id) REFERENCES runs(run_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS report_checkpoints (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        report_type TEXT NOT NULL,  -- 'scheduled', 'daily', 'weekly'
+        sent_at TEXT NOT NULL,
+        runs_included TEXT,  -- JSON array of run_ids
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_runs_started_at ON runs(started_at);
+    CREATE INDEX IF NOT EXISTS idx_runs_repo ON runs(repo);
+    CREATE INDEX IF NOT EXISTS idx_work_units_run_id ON work_units(run_id);
+    CREATE INDEX IF NOT EXISTS idx_checkpoints_sent_at ON report_checkpoints(sent_at);
+    """
+
+    def __init__(self, db_path: Optional[Path] = None):
+        """Initialize database connection."""
+        self.db_path = db_path or DEFAULT_DB_PATH
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _init_db(self):
+        """Create tables if they don't exist."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executescript(self.SCHEMA)
+
+    def _connect(self) -> sqlite3.Connection:
+        """Get a database connection with row factory."""
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def insert_run(self, run_data: dict) -> bool:
+        """Insert or update a run record."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO runs (
+                    run_id, repo, started_at, ended_at, duration_sec, exit_code,
+                    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                    context_window, context_usage_pct, tasks_completed, tasks_blocked,
+                    prs_created, issues_resolved
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_data.get("run_id"),
+                    run_data.get("repo"),
+                    run_data.get("started_at"),
+                    run_data.get("ended_at"),
+                    run_data.get("duration_sec", 0),
+                    run_data.get("exit_code"),
+                    run_data.get("input_tokens", 0),
+                    run_data.get("output_tokens", 0),
+                    run_data.get("cache_read_tokens", 0),
+                    run_data.get("cache_write_tokens", 0),
+                    run_data.get("context_window", 200000),
+                    run_data.get("context_usage_pct", 0),
+                    run_data.get("tasks_completed", 0),
+                    run_data.get("tasks_blocked", 0),
+                    run_data.get("prs_created", 0),
+                    run_data.get("issues_resolved", 0),
+                ),
+            )
+            conn.commit()
+            return True
+
+    def insert_work_unit(self, work_unit: dict) -> bool:
+        """Insert a work unit record."""
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO work_units (run_id, unit_type, identifier, tokens_used, duration_sec, status)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    work_unit.get("run_id"),
+                    work_unit.get("unit_type"),
+                    work_unit.get("identifier"),
+                    work_unit.get("tokens_used", 0),
+                    work_unit.get("duration_sec", 0),
+                    work_unit.get("status", "completed"),
+                ),
+            )
+            conn.commit()
+            return True
+
+    def get_runs_since(self, since: str, repo: Optional[str] = None) -> list[dict]:
+        """Get all runs since a given timestamp."""
+        with self._connect() as conn:
+            if repo:
+                cursor = conn.execute(
+                    "SELECT * FROM runs WHERE started_at >= ? AND repo = ? ORDER BY started_at",
+                    (since, repo),
+                )
+            else:
+                cursor = conn.execute(
+                    "SELECT * FROM runs WHERE started_at >= ? ORDER BY started_at",
+                    (since,),
+                )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_last_report_time(self, report_type: str = "scheduled") -> Optional[str]:
+        """Get the timestamp of the last report sent."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "SELECT sent_at FROM report_checkpoints WHERE report_type = ? ORDER BY sent_at DESC LIMIT 1",
+                (report_type,),
+            )
+            row = cursor.fetchone()
+            return row["sent_at"] if row else None
+
+    def record_report_sent(self, report_type: str, run_ids: list[str]) -> bool:
+        """Record that a report was sent."""
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO report_checkpoints (report_type, sent_at, runs_included) VALUES (?, ?, ?)",
+                (report_type, datetime.now(timezone.utc).isoformat(), json.dumps(run_ids)),
+            )
+            conn.commit()
+            return True
+
+    def get_work_units_for_run(self, run_id: str) -> list[dict]:
+        """Get all work units for a specific run."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "SELECT * FROM work_units WHERE run_id = ?",
+                (run_id,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_summary_since(self, since: str) -> dict:
+        """Get aggregated summary stats since a timestamp."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT
+                    COUNT(*) as run_count,
+                    SUM(input_tokens) as total_input_tokens,
+                    SUM(output_tokens) as total_output_tokens,
+                    SUM(cache_read_tokens) as total_cache_read_tokens,
+                    SUM(tasks_completed) as total_tasks_completed,
+                    SUM(tasks_blocked) as total_tasks_blocked,
+                    SUM(prs_created) as total_prs_created,
+                    SUM(issues_resolved) as total_issues_resolved,
+                    AVG(context_usage_pct) as avg_context_usage,
+                    MAX(context_usage_pct) as max_context_usage
+                FROM runs
+                WHERE started_at >= ?
+                """,
+                (since,),
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else {}
+
+    def get_efficiency_breakdown(self, since: str) -> list[dict]:
+        """Get per-run efficiency breakdown (tokens per work unit)."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT
+                    run_id,
+                    repo,
+                    started_at,
+                    (input_tokens + output_tokens) as total_tokens,
+                    (tasks_completed + prs_created + issues_resolved) as work_units,
+                    context_usage_pct,
+                    exit_code,
+                    CASE
+                        WHEN (tasks_completed + prs_created + issues_resolved) > 0
+                        THEN (input_tokens + output_tokens) / (tasks_completed + prs_created + issues_resolved)
+                        ELSE (input_tokens + output_tokens)
+                    END as tokens_per_unit
+                FROM runs
+                WHERE started_at >= ?
+                ORDER BY tokens_per_unit DESC
+                """,
+                (since,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_average_tokens_per_unit(self, days: int = 7) -> float:
+        """Get average tokens per work unit over the past N days."""
+        since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT AVG(tokens_per_unit) as avg_tpu FROM (
+                    SELECT
+                        CASE
+                            WHEN (tasks_completed + prs_created + issues_resolved) > 0
+                            THEN (input_tokens + output_tokens) / (tasks_completed + prs_created + issues_resolved)
+                            ELSE NULL
+                        END as tokens_per_unit
+                    FROM runs
+                    WHERE started_at >= ?
+                    AND (tasks_completed + prs_created + issues_resolved) > 0
+                )
+                """,
+                (since,),
+            )
+            row = cursor.fetchone()
+            return row["avg_tpu"] or 50000.0  # Default if no data
+
+
+def parse_jsonl_log(log_path: Path) -> dict:
+    """Parse a JSONL log file and extract run data."""
+    run_data = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "tasks_completed": 0,
+        "tasks_blocked": 0,
+        "prs_created": 0,
+        "issues_resolved": 0,
+        "context_usage_pct": 0,
+        "started_at": None,
+        "ended_at": None,
+        "exit_code": None,
+        "work_units": [],
+    }
+
+    if not log_path.exists():
+        return run_data
+
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            # Track timestamps
+            if "timestamp" in data:
+                ts = data["timestamp"]
+                if run_data["started_at"] is None:
+                    run_data["started_at"] = ts
+                run_data["ended_at"] = ts
+
+            # Extract token usage from assistant messages
+            if data.get("type") == "message" and data.get("message", {}).get("role") == "assistant":
+                usage = data.get("message", {}).get("usage", {})
+                run_data["input_tokens"] += usage.get("input_tokens", 0)
+                run_data["output_tokens"] += usage.get("output_tokens", 0)
+                run_data["cache_read_tokens"] += usage.get("cache_read_input_tokens", 0)
+                run_data["cache_write_tokens"] += usage.get("cache_creation_input_tokens", 0)
+
+            # Extract events from events.jsonl format
+            event = data.get("event")
+            if event == "run_started":
+                run_data["run_id"] = data.get("run_id")
+                run_data["repo"] = data.get("repo")
+                run_data["started_at"] = data.get("timestamp")
+
+            elif event == "run_completed":
+                run_data["exit_code"] = data.get("exit_code")
+                run_data["ended_at"] = data.get("timestamp")
+                run_data["duration_sec"] = data.get("duration_sec", 0)
+
+            elif event == "context_checkpoint":
+                run_data["context_usage_pct"] = max(
+                    run_data["context_usage_pct"],
+                    data.get("usage_pct", 0)
+                )
+
+            elif event == "task_completed":
+                run_data["tasks_completed"] += 1
+                pr = data.get("pr")
+                if pr:
+                    run_data["prs_created"] += 1
+                    run_data["work_units"].append({
+                        "unit_type": "pr",
+                        "identifier": pr,
+                        "status": "completed",
+                    })
+                else:
+                    run_data["work_units"].append({
+                        "unit_type": "task",
+                        "identifier": data.get("task", "unknown"),
+                        "status": "completed",
+                    })
+
+            elif event == "task_blocked":
+                run_data["tasks_blocked"] += 1
+                run_data["work_units"].append({
+                    "unit_type": "task",
+                    "identifier": data.get("task", "unknown"),
+                    "status": "blocked",
+                })
+
+    # Calculate duration if not set
+    if run_data["started_at"] and run_data["ended_at"] and not run_data.get("duration_sec"):
+        def _parse_timestamp(ts: str) -> datetime:
+            """Parse ISO 8601 timestamp, handling 'Z' suffix and naive datetimes as UTC."""
+            if ts is None:
+                raise TypeError("Timestamp is None")
+            # Normalize trailing 'Z' (UTC) without affecting other offsets
+            if ts.endswith("Z"):
+                ts = ts[:-1] + "+00:00"
+            dt = datetime.fromisoformat(ts)
+            # If no timezone info is present, assume UTC for consistency
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+
+        try:
+            start = _parse_timestamp(run_data["started_at"])
+            end = _parse_timestamp(run_data["ended_at"])
+            run_data["duration_sec"] = int((end - start).total_seconds())
+        except (ValueError, TypeError):
+            # If timestamps are malformed, skip duration calculation and keep other stats
+            pass
+
+    return run_data
+
+
+def extract_run_id_from_filename(filename: str) -> Optional[tuple[str, str]]:
+    """Extract repo name and run_id from filename like 'repo_20251222_150007.jsonl'."""
+    match = re.match(r"^(.+)_(\d{8}_\d{6})\.jsonl$", filename)
+    if match:
+        return match.group(1), match.group(2)
+    return None
+
+
+def backfill_from_logs(db: AutoClaudeDB, logs_dir: Path, days: int = 30) -> int:
+    """Backfill database from existing JSONL logs."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    count = 0
+
+    for log_file in logs_dir.glob("*_*.jsonl"):
+        # Skip events.jsonl
+        if log_file.name == "events.jsonl":
+            continue
+
+        # Check file modification time
+        mtime = datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc)
+        if mtime < cutoff:
+            continue
+
+        # Extract repo and run_id from filename
+        parsed = extract_run_id_from_filename(log_file.name)
+        if not parsed:
+            continue
+
+        repo, run_id = parsed
+
+        # Parse log file
+        run_data = parse_jsonl_log(log_file)
+        run_data["run_id"] = run_id
+        run_data["repo"] = repo
+
+        # Insert run
+        if db.insert_run(run_data):
+            count += 1
+
+            # Insert work units
+            for wu in run_data.get("work_units", []):
+                wu["run_id"] = run_id
+                db.insert_work_unit(wu)
+
+    return count
+
+
+def main():
+    """CLI interface for auto-claude-db."""
+    parser = argparse.ArgumentParser(description="Auto-Claude Database Module")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Insert command
+    p_insert = subparsers.add_parser("insert", help="Insert run from log file")
+    p_insert.add_argument("--run-id", required=True, help="Run ID")
+    p_insert.add_argument("--repo", required=True, help="Repository name")
+    p_insert.add_argument("--log-file", type=Path, required=True, help="Path to JSONL log")
+
+    # Query command
+    p_query = subparsers.add_parser("query", help="Query runs since timestamp")
+    p_query.add_argument("--since", required=True, help="ISO timestamp")
+    p_query.add_argument("--repo", help="Filter by repository")
+    p_query.add_argument("--format", choices=["json", "table"], default="json")
+
+    # Summary command
+    p_summary = subparsers.add_parser("summary", help="Get summary stats")
+    p_summary.add_argument("--since", required=True, help="ISO timestamp")
+
+    # Efficiency command
+    p_efficiency = subparsers.add_parser("efficiency", help="Get efficiency breakdown")
+    p_efficiency.add_argument("--since", required=True, help="ISO timestamp")
+
+    # Backfill command
+    p_backfill = subparsers.add_parser("backfill", help="Backfill from existing logs")
+    p_backfill.add_argument("--days", type=int, default=30, help="Days to backfill")
+    p_backfill.add_argument("--logs-dir", type=Path, default=DEFAULT_LOGS_DIR)
+
+    args = parser.parse_args()
+    db = AutoClaudeDB()
+
+    if args.command == "insert":
+        run_data = parse_jsonl_log(args.log_file)
+        run_data["run_id"] = args.run_id
+        run_data["repo"] = args.repo
+        if db.insert_run(run_data):
+            print(f"Inserted run {args.run_id}")
+            for wu in run_data.get("work_units", []):
+                wu["run_id"] = args.run_id
+                db.insert_work_unit(wu)
+        else:
+            print("Failed to insert run", file=sys.stderr)
+            return 1
+
+    elif args.command == "query":
+        runs = db.get_runs_since(args.since, args.repo)
+        if args.format == "json":
+            print(json.dumps(runs, indent=2))
+        else:
+            for run in runs:
+                print(f"{run['run_id']} | {run['repo']} | {run['input_tokens'] + run['output_tokens']} tokens")
+
+    elif args.command == "summary":
+        summary = db.get_summary_since(args.since)
+        print(json.dumps(summary, indent=2))
+
+    elif args.command == "efficiency":
+        breakdown = db.get_efficiency_breakdown(args.since)
+        print(json.dumps(breakdown, indent=2))
+
+    elif args.command == "backfill":
+        count = backfill_from_logs(db, args.logs_dir, args.days)
+        print(f"Backfilled {count} runs")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nix-ai-claude/modules/claude/auto_claude_postrun.py
+++ b/nix-ai-claude/modules/claude/auto_claude_postrun.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Auto-Claude Post-Run Processing
+
+Handles post-run operations:
+- Token usage calculation from JSONL logs
+- Context usage threshold checks
+- Control file updates
+- Event emission
+
+Usage:
+    python3 auto_claude_postrun.py token-usage <log_file>
+    python3 auto_claude_postrun.py check-context <log_file> --run-id ID --repo NAME
+    python3 auto_claude_postrun.py update-control <repo>
+    python3 auto_claude_postrun.py emit-event <type> --run-id ID --repo NAME [--key value ...]
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from auto_claude_utils import emit_event
+
+CONTROL_FILE = Path.home() / ".claude/auto-claude-control.json"
+EVENTS_LOG = Path.home() / ".claude/logs/events.jsonl"
+CONTEXT_WINDOW = 200_000  # Standard tier
+
+
+def calculate_token_usage(log_file: Path) -> int:
+    """Calculate total tokens used from JSONL log file."""
+    if not log_file.exists():
+        return 0
+
+    total = 0
+    with log_file.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                if data.get("type") == "message" and data.get("message", {}).get("role") == "assistant":
+                    usage = data.get("message", {}).get("usage", {})
+                    total += usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
+            except json.JSONDecodeError:
+                # Skip malformed JSON lines (partial writes, corruption)
+                continue
+    return total
+
+
+def check_context_usage(
+    log_file: Path,
+    run_id: str,
+    repo: str,
+    threshold_pct: int = 90,
+) -> dict:
+    """Check context usage and emit events if needed."""
+    total_tokens = calculate_token_usage(log_file)
+    usage_pct = (total_tokens * 100) // CONTEXT_WINDOW if CONTEXT_WINDOW > 0 else 0
+    tokens_remaining = CONTEXT_WINDOW - total_tokens
+
+    result = {
+        "tokens_used": total_tokens,
+        "tokens_remaining": tokens_remaining,
+        "usage_pct": usage_pct,
+        "context_window": CONTEXT_WINDOW,
+        "exceeded_threshold": usage_pct > threshold_pct,
+    }
+
+    # Emit context checkpoint event
+    emit_event(
+        EVENTS_LOG,
+        "context_checkpoint",
+        run_id,
+        repo,
+        tokens_used=total_tokens,
+        tokens_remaining=tokens_remaining,
+        usage_pct=usage_pct,
+        context_window=CONTEXT_WINDOW,
+    )
+
+    if result["exceeded_threshold"]:
+        emit_event(
+            EVENTS_LOG,
+            "context_warning",
+            run_id,
+            repo,
+            usage_pct=usage_pct,
+            reason="exceeded_threshold",
+        )
+
+    return result
+
+
+def update_control_file(repo: str) -> bool:
+    """Update control file with last run info."""
+    if not CONTROL_FILE.exists():
+        return False
+
+    try:
+        control = json.loads(CONTROL_FILE.read_text())
+        control["last_run"] = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        control["last_run_repo"] = repo
+        CONTROL_FILE.write_text(json.dumps(control, indent=2))
+        return True
+    except (json.JSONDecodeError, OSError):
+        # Control file corrupt or inaccessible - non-critical, continue
+        return False
+
+
+def emit_run_event(
+    event_type: str,
+    run_id: str,
+    repo: str,
+    exit_code: int | None = None,
+    duration_sec: int | None = None,
+    budget: float | None = None,
+    **kwargs,
+) -> dict:
+    """Emit a run lifecycle event."""
+    extra = {}
+    if exit_code is not None:
+        extra["exit_code"] = exit_code
+        extra["status"] = "success" if exit_code == 0 else "failed"
+    if duration_sec is not None:
+        extra["duration_sec"] = duration_sec
+        extra["duration_min"] = duration_sec // 60
+    if budget is not None:
+        extra["budget"] = budget
+    extra.update(kwargs)
+
+    return emit_event(EVENTS_LOG, event_type, run_id, repo, **extra)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auto-Claude post-run processing")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # token-usage
+    p_tokens = subparsers.add_parser("token-usage", help="Calculate token usage from log")
+    p_tokens.add_argument("log_file", type=Path, help="Path to JSONL log file")
+
+    # check-context
+    p_context = subparsers.add_parser("check-context", help="Check context usage and emit events")
+    p_context.add_argument("log_file", type=Path, help="Path to JSONL log file")
+    p_context.add_argument("--run-id", required=True, help="Run ID")
+    p_context.add_argument("--repo", required=True, help="Repository name")
+    p_context.add_argument("--threshold", type=int, default=90, help="Warning threshold %%")
+
+    # update-control
+    p_update = subparsers.add_parser("update-control", help="Update control file with last run")
+    p_update.add_argument("repo", help="Repository name")
+
+    # emit-event
+    p_emit = subparsers.add_parser("emit-event", help="Emit a structured event")
+    p_emit.add_argument("event_type", help="Event type (e.g., run_started, run_completed)")
+    p_emit.add_argument("--run-id", required=True, help="Run ID")
+    p_emit.add_argument("--repo", required=True, help="Repository name")
+    p_emit.add_argument("--exit-code", type=int, help="Exit code")
+    p_emit.add_argument("--duration", type=int, help="Duration in seconds")
+    p_emit.add_argument("--budget", type=float, help="Budget in USD")
+    p_emit.add_argument("--extra", nargs="*", help="Extra key=value pairs")
+
+    args = parser.parse_args()
+
+    if args.command == "token-usage":
+        tokens = calculate_token_usage(args.log_file)
+        print(tokens)
+
+    elif args.command == "check-context":
+        result = check_context_usage(
+            args.log_file,
+            args.run_id,
+            args.repo,
+            threshold_pct=args.threshold,
+        )
+        print(json.dumps(result))
+        if result["exceeded_threshold"]:
+            sys.exit(1)
+
+    elif args.command == "update-control":
+        success = update_control_file(args.repo)
+        print("OK" if success else "FAILED")
+        sys.exit(0 if success else 1)
+
+    elif args.command == "emit-event":
+        extra = {}
+        if args.extra:
+            for pair in args.extra:
+                if "=" in pair:
+                    k, v = pair.split("=", 1)
+                    # Try to parse as number
+                    try:
+                        v = int(v)
+                    except ValueError:
+                        # Not an int, try float
+                        try:
+                            v = float(v)
+                        except ValueError:
+                            # Not a number, keep as string
+                            pass
+                    extra[k] = v
+
+        # If budget was passed via --extra, use it; otherwise use --budget arg
+        # This prevents "multiple values for keyword argument" errors
+        budget = extra.pop("budget", None) or args.budget
+        event = emit_run_event(
+            args.event_type,
+            args.run_id,
+            args.repo,
+            exit_code=args.exit_code,
+            duration_sec=args.duration,
+            budget=budget,
+            **extra,
+        )
+        print(json.dumps(event))
+
+
+if __name__ == "__main__":
+    main()

--- a/nix-ai-claude/modules/claude/auto_claude_preflight.py
+++ b/nix-ai-claude/modules/claude/auto_claude_preflight.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""
+Auto-Claude Preflight Checks
+
+Handles pre-run validation:
+- Control file (pause/skip) checks
+- Slack channel resolution
+- Git repository state validation
+
+Usage:
+    python3 auto_claude_preflight.py check-control
+    python3 auto_claude_preflight.py resolve-channel <target_dir>
+    python3 auto_claude_preflight.py check-git <target_dir>
+    python3 auto_claude_preflight.py all <target_dir>  # Run all checks
+
+Exit codes:
+    0 = OK to proceed
+    1 = Error (should not run)
+    2 = Skip (paused or skip_count > 0)
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from auto_claude_utils import (
+    get_keychain_value,
+    get_repo_name,
+    iso_to_epoch,
+    load_bws_env,
+    sanitize_repo_name,
+)
+
+CONTROL_FILE = Path.home() / ".claude/auto-claude-control.json"
+
+
+def check_control_file(force_run: bool = False) -> dict:
+    """Check control file for pause/skip states. Returns status dict."""
+    result = {"should_run": True, "reason": None, "skip_count": 0}
+
+    if force_run:
+        return result
+
+    if not CONTROL_FILE.exists():
+        return result
+
+    try:
+        control = json.loads(CONTROL_FILE.read_text())
+    except (json.JSONDecodeError, OSError):
+        return result
+
+    # Check pause_until
+    pause_until = control.get("pause_until")
+    if pause_until:
+        pause_epoch = iso_to_epoch(pause_until)
+        if pause_epoch and time.time() < pause_epoch:
+            result["should_run"] = False
+            result["reason"] = f"Paused until {pause_until}"
+            return result
+
+    # Check skip_count
+    skip_count = control.get("skip_count", 0)
+    if isinstance(skip_count, int) and skip_count > 0:
+        # Decrement skip count
+        control["skip_count"] = skip_count - 1
+        try:
+            CONTROL_FILE.write_text(json.dumps(control, indent=2))
+        except OSError:
+            pass
+        result["should_run"] = False
+        result["reason"] = f"Skip count was {skip_count}, now {skip_count - 1}"
+        result["skip_count"] = skip_count - 1
+        return result
+
+    return result
+
+
+def resolve_slack_channel(target_dir: str) -> dict:
+    """Resolve Slack channel for a repository. Returns channel info."""
+    config = load_bws_env()
+    bws_account = config.get("BWS_KEYCHAIN_ACCOUNT")
+
+    repo_name = get_repo_name(target_dir)
+    sanitized = sanitize_repo_name(repo_name)
+    keychain_key = f"SLACK_CHANNEL_ID_{sanitized}"
+
+    # Try repo-specific channel (Slack channel IDs like C1234ABCD are not secrets)
+    channel = get_keychain_value(keychain_key, bws_account)
+    if channel:
+        return {
+            "channel": channel,
+            "source": "keychain",
+            "repo_name": repo_name,
+            "keychain_key": keychain_key,
+        }
+
+    # Try fallback
+    fallback = config.get("SLACK_DEFAULT_CHANNEL")
+    if fallback:
+        return {
+            "channel": fallback,
+            "source": "fallback",
+            "repo_name": repo_name,
+            "keychain_key": keychain_key,
+        }
+
+    return {
+        "channel": None,
+        "source": "none",
+        "repo_name": repo_name,
+        "keychain_key": keychain_key,
+    }
+
+
+def check_git_status(target_dir: str) -> dict:
+    """Check git repository state. Returns status dict."""
+    result = {
+        "ok": True,
+        "branch": None,
+        "clean": True,
+        "synced": True,
+        "message": "Git checks passed",
+    }
+
+    try:
+        # Get current branch
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        result["branch"] = branch_result.stdout.strip()
+
+        # Must be on main or master
+        if result["branch"] not in ("main", "master"):
+            result["ok"] = False
+            result["message"] = f"Not on main/master branch (on: {result['branch']})"
+            return result
+
+        # Check for uncommitted changes
+        status_result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        if status_result.stdout.strip():
+            result["ok"] = False
+            result["clean"] = False
+            result["message"] = "Working tree has uncommitted changes"
+            return result
+
+        # Fetch latest
+        subprocess.run(
+            ["git", "fetch", "origin", result["branch"], "--quiet"],
+            cwd=target_dir,
+            capture_output=True,
+            check=False,
+        )
+
+        # Check divergence
+        local_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        remote_sha_result = subprocess.run(
+            ["git", "rev-parse", f"origin/{result['branch']}"],
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        remote_sha = remote_sha_result.stdout.strip() if remote_sha_result.returncode == 0 else None
+
+        if remote_sha and local_sha != remote_sha:
+            base_result = subprocess.run(
+                ["git", "merge-base", "HEAD", f"origin/{result['branch']}"],
+                cwd=target_dir,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            base = base_result.stdout.strip() if base_result.returncode == 0 else None
+
+            if base == remote_sha:
+                result["message"] = "Local is ahead of origin (unpushed commits)"
+            elif base == local_sha:
+                result["message"] = "Local is behind origin (needs pull)"
+                result["needs_pull"] = True
+            else:
+                result["ok"] = False
+                result["synced"] = False
+                result["message"] = "Branch has diverged from origin"
+
+    except subprocess.CalledProcessError:
+        result["message"] = "Not a git repository or git unavailable"
+        # Continue anyway - might not be a git repo
+
+    return result
+
+
+def check_stale_instance(target_dir: str) -> dict[str, Any]:
+    """Check for stale auto-claude instances and kill them if inactive."""
+    import glob
+    import time
+
+    result = {"ok": True, "killed": False, "message": "No stale instance found"}
+
+    try:
+        # Find auto-claude processes for this repo.
+        # Escape target_dir to prevent regex metacharacters from being interpreted
+        # by pgrep's -f pattern matching (fix: regex injection via target_dir).
+        escaped_target_dir = re.escape(target_dir)
+        ps_result = subprocess.run(
+            ["pgrep", "-f", f"auto-claude.sh.*{escaped_target_dir}"],
+            capture_output=True, text=True,
+        )
+
+        if ps_result.returncode != 0:
+            # No running instance found
+            return result
+
+        pids = ps_result.stdout.strip().split("\n")
+        current_pid = str(os.getppid())
+
+        for pid in pids:
+            if not pid or pid == current_pid:
+                continue
+
+            # Check if process is actually doing something
+            # "Recent" = last 1 hour. If no activity in last hour, process is considered idle.
+            # Auto-claude runs every 4 hours, so a process idle for 4+ hours should be killed.
+            has_recent_activity = False
+
+            # Check recent log files (modified in last 1 hour = 3600 seconds)
+            now = time.time()
+            log_patterns = [
+                f"{Path.home()}/.claude/logs/nix_*.jsonl",
+                f"{Path.home()}/.claude/logs/launchd-*.log",
+            ]
+
+            for pattern in log_patterns:
+                for log_file in glob.glob(pattern):
+                    try:
+                        mtime = os.path.getmtime(log_file)
+                        if (now - mtime) < 3600:  # 1 hour
+                            has_recent_activity = True
+                            break
+                    except OSError:
+                        pass
+
+            # Check recent git activity in target_dir (last 1 hour)
+            if not has_recent_activity:
+                try:
+                    git_result = subprocess.run(
+                        ["git", "log", "--since=1 hour ago", "--oneline"],
+                        cwd=target_dir,
+                        capture_output=True, text=True, check=False,
+                    )
+                    if git_result.stdout.strip():
+                        has_recent_activity = True
+                except Exception:
+                    pass
+
+            # Check recent GitHub activity (PRs, issues, commits)
+            if not has_recent_activity:
+                try:
+                    # Check for recent PR activity
+                    pr_result = subprocess.run(
+                        ["gh", "pr", "list", "--state", "all", "--limit", "5"],
+                        cwd=target_dir, capture_output=True, text=True, check=False,
+                    )
+                    if pr_result.stdout.strip():
+                        has_recent_activity = True
+                except Exception:
+                    pass
+
+            if not has_recent_activity:
+                # Kill the stale process
+                try:
+                    subprocess.run(["kill", pid], check=True)
+                    result["killed"] = True
+                    result["message"] = f"Killed stale auto-claude process (PID {pid}) with no recent activity"
+                except subprocess.CalledProcessError:
+                    pass
+
+        return result
+
+    except Exception as e:
+        # Don't fail on stale check errors, but log the specific exception for debugging
+        return {"ok": True, "killed": False, "message": f"Warning: Stale instance check failed with an error: {e}"}
+
+
+def _get_repo_stats(target_dir: str) -> dict:
+    """Fetches issue and PR counts from GitHub."""
+    stats = {
+        "total_issues": -1,
+        "ai_created": -1,
+        "pr_count": -1,
+        "error": None,
+    }
+    try:
+        # Count total open issues
+        total_result = subprocess.run(
+            ["gh", "issue", "list", "--state", "open", "--json", "number"],
+            cwd=target_dir, capture_output=True, text=True, check=True,
+        )
+        stats["total_issues"] = len(json.loads(total_result.stdout))
+
+        # Count ai-created issues
+        ai_result = subprocess.run(
+            ["gh", "issue", "list", "--state", "open", "--label", "ai-created", "--json", "number"],
+            cwd=target_dir, capture_output=True, text=True, check=True,
+        )
+        stats["ai_created"] = len(json.loads(ai_result.stdout))
+
+        # Count open PRs authored by auto-claude
+        pr_result = subprocess.run(
+            ["gh", "pr", "list", "--author", "@me", "--state", "open", "--json", "number"],
+            cwd=target_dir, capture_output=True, text=True, check=True,
+        )
+        stats["pr_count"] = len(json.loads(pr_result.stdout))
+
+    except Exception as e:
+        stats["error"] = f"Warning: GitHub stats check failed: {e}"
+
+    return stats
+
+
+def check_issue_totals(total_count: int, ai_count: int, force_run: bool = False) -> dict:
+    """Check hard limits: 100 total issues max, 25 ai-created max.
+
+    Returns enforcement mode:
+    - NORMAL: All limits OK, proceed normally
+    - CONSOLIDATION: AI-created limit hit, focus on consolidation
+    - PAUSED: Total limit hit, skip entire run
+    """
+    if force_run:
+        return {
+            "ok": True,
+            "total_issues": 0,
+            "ai_created": 0,
+            "enforcement_mode": "NORMAL",
+            "message": "Bypassed (force)",
+        }
+
+    if total_count == -1 or ai_count == -1:
+        return {
+            "ok": True,
+            "total_issues": -1,
+            "ai_created": -1,
+            "enforcement_mode": "NORMAL",
+            "message": "Warning: Issue count check skipped due to stat fetch failure.",
+        }
+
+    # Determine enforcement mode
+    if total_count >= 100:
+        return {
+            "ok": False,  # HARD STOP
+            "total_issues": total_count,
+            "ai_created": ai_count,
+            "enforcement_mode": "PAUSED",
+            "message": f"HARD LIMIT: Total issues ({total_count}/100) exceeded. Run paused.",
+        }
+    elif ai_count >= 25:
+        return {
+            "ok": True,
+            "total_issues": total_count,
+            "ai_created": ai_count,
+            "enforcement_mode": "CONSOLIDATION",
+            "message": f"AI-created limit ({ai_count}/25) hit. Entering CONSOLIDATION mode.",
+        }
+    else:
+        return {
+            "ok": True,
+            "total_issues": total_count,
+            "ai_created": ai_count,
+            "enforcement_mode": "NORMAL",
+            "message": f"OK: {total_count} total, {ai_count} ai-created",
+        }
+
+
+def check_issue_pr_ratio(issue_count: int, pr_count: int) -> dict:
+    """Calculate issue:PR ratio for mode decision.
+
+    Returns mode recommendation:
+    - NORMAL: Ratio OK, proceed normally
+    - CONSOLIDATION: Ratio > 3 and PRs < 5, focus on consolidation before new work
+    - PR_CREATION: Ratio > 5 with few PRs, focus only on creating PRs
+    - PR_FOCUS: 10+ open PRs, focus only on PR resolution (existing behavior)
+    """
+    if issue_count == -1 or pr_count == -1:
+        return {
+            "ok": True,
+            "issue_count": -1,
+            "pr_count": -1,
+            "ratio": -1,
+            "mode": "NORMAL",
+            "message": "Warning: Ratio check skipped due to stat fetch failure.",
+        }
+
+    # Calculate ratio (issue count for ratio excludes ai-created)
+    ratio = issue_count / max(pr_count, 1)
+
+    # Determine mode
+    if pr_count >= 10:
+        mode = "PR_FOCUS"
+        message = f"PR backlog high ({pr_count} PRs). Focus on PR resolution only."
+    elif ratio > 5 and pr_count < 3:
+        mode = "PR_CREATION"
+        message = f"Ratio critical ({ratio:.1f}:1). Skip issues, create PRs to fix existing issues."
+    elif ratio > 3 and pr_count < 5:
+        mode = "CONSOLIDATION"
+        message = f"Ratio high ({ratio:.1f}:1). Run consolidation before new work."
+    else:
+        mode = "NORMAL"
+        message = f"Ratio OK ({ratio:.1f}:1, {issue_count} issues, {pr_count} PRs)"
+
+    return {
+        "ok": True,
+        "issue_count": issue_count,
+        "pr_count": pr_count,
+        "ratio": round(ratio, 2),
+        "mode": mode,
+        "message": message,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auto-Claude preflight checks")
+    parser.add_argument("command", choices=["check-control", "resolve-channel", "check-git", "all"])
+    parser.add_argument("target_dir", nargs="?", help="Target directory (required for some commands)")
+    parser.add_argument("--force", action="store_true", help="Force run (bypass control file)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    if args.command in ("resolve-channel", "check-git", "all") and not args.target_dir:
+        parser.error(f"{args.command} requires target_dir")
+
+    if args.command == "check-control":
+        result = check_control_file(force_run=args.force)
+        if args.json:
+            print(json.dumps(result))
+        else:
+            if result["should_run"]:
+                print("OK")
+            else:
+                print(f"SKIP: {result['reason']}")
+        sys.exit(0 if result["should_run"] else 2)
+
+    elif args.command == "resolve-channel":
+        result = resolve_slack_channel(args.target_dir)
+        if args.json:
+            print(json.dumps(result))
+        else:
+            # Print the channel ID for callers that use this for scripting (channel resolution helper)
+            # Use sys.stdout.write to output the raw value for command substitution capture
+            channel_id = result.get("channel") or ""
+            sys.stdout.write(channel_id + "\n")
+        sys.exit(0)
+
+    elif args.command == "check-git":
+        result = check_git_status(args.target_dir)
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print(result["message"])
+        sys.exit(0 if result["ok"] else 1)
+
+    elif args.command == "all":
+        # Fetch stats once, then pass to check functions
+        gh_stats = _get_repo_stats(args.target_dir)
+        total_issues = gh_stats.get("total_issues", -1)
+        ai_created = gh_stats.get("ai_created", -1)
+        pr_count = gh_stats.get("pr_count", -1)
+
+        # Issue count for ratio calculation should exclude ai-created
+        issue_count_for_ratio = total_issues - ai_created if total_issues > -1 and ai_created > -1 else -1
+
+        results: dict[str, Any] = {
+            "stale": check_stale_instance(args.target_dir),
+            "control": check_control_file(force_run=args.force),
+            "channel": resolve_slack_channel(args.target_dir),
+            "git": check_git_status(args.target_dir),
+            "totals": check_issue_totals(total_issues, ai_created, force_run=args.force),
+            "ratio": check_issue_pr_ratio(issue_count_for_ratio, pr_count),
+        }
+
+        # Determine overall status
+        # Priority: control file > hard limits > git status > soft limits
+        if not results["control"]["should_run"]:
+            results["status"] = "skip"
+            results["reason"] = results["control"]["reason"]
+        elif not results["totals"]["ok"]:
+            # HARD LIMIT: Total issues >= 100, skip entire run
+            results["status"] = "skip"
+            results["reason"] = results["totals"]["message"]
+        elif not results["git"]["ok"]:
+            results["status"] = "error"
+            results["reason"] = results["git"]["message"]
+        else:
+            results["status"] = "ok"
+            results["reason"] = None
+
+        # Determine enforcement mode (highest priority mode wins)
+        # PR_FOCUS > PR_CREATION > CONSOLIDATION > NORMAL
+        totals_mode = results["totals"].get("enforcement_mode", "NORMAL")
+        ratio_mode = results["ratio"].get("mode", "NORMAL")
+
+        mode_priority = {"PR_FOCUS": 4, "PR_CREATION": 3, "CONSOLIDATION": 2, "PAUSED": 5, "NORMAL": 1}
+        if mode_priority.get(totals_mode, 1) >= mode_priority.get(ratio_mode, 1):
+            results["enforcement_mode"] = totals_mode
+        else:
+            results["enforcement_mode"] = ratio_mode
+
+        # If PAUSED, override status to skip
+        if results["enforcement_mode"] == "PAUSED":
+            results["status"] = "skip"
+            results["reason"] = results["totals"]["message"]
+
+        if args.json:
+            print(json.dumps(results))
+        else:
+            # Extract plain values before printing to avoid taint from dict key names
+            status = results["status"]
+            enforcement_mode = results["enforcement_mode"]
+            reason = results["reason"]
+            total_issues = results["totals"].get("total_issues", "?")
+            ai_created = results["totals"].get("ai_created", "?")
+            issue_ratio = results["ratio"].get("ratio", "?")
+            issue_count = results["ratio"].get("issue_count", "?")
+            pr_count = results["ratio"].get("pr_count", "?")
+            channel_configured = "configured" if results["channel"].get("channel") else "none"
+            print(f"Status: {status}")
+            print(f"Enforcement Mode: {enforcement_mode}")
+            if reason:
+                print(f"Reason: {reason}")
+            print(f"Channel: {channel_configured}")
+            print(f"Issues: {total_issues} total, {ai_created} ai-created")
+            print(f"Ratio: {issue_ratio}:1 ({issue_count} issues, {pr_count} PRs)")
+
+        if results["status"] == "skip":
+            sys.exit(2)
+        elif results["status"] == "error":
+            sys.exit(1)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/nix-ai-claude/modules/claude/auto_claude_utils.py
+++ b/nix-ai-claude/modules/claude/auto_claude_utils.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Shared utilities for auto-claude Python modules.
+
+This module provides common functions used across preflight, postrun,
+and other auto-claude components.
+"""
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def load_bws_env(path: Path | None = None) -> dict[str, str]:
+    """Load BWS .env file into dict."""
+    if path is None:
+        path = Path.home() / ".config/bws/.env"
+    config = {}
+    if not path.exists():
+        return config
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            # Strip inline comments (but preserve # inside quotes)
+            if "#" in line:
+                # Simple approach: if # appears after =, strip from # onwards
+                # This works for unquoted values and simple cases
+                key_part, _, value_part = line.partition("=")
+                if "#" in value_part:
+                    # Check if # is inside quotes
+                    in_quotes = False
+                    quote_char = None
+                    for i, char in enumerate(value_part):
+                        if char in ("'", '"') and (i == 0 or value_part[i - 1] != "\\"):
+                            if not in_quotes:
+                                in_quotes = True
+                                quote_char = char
+                            elif char == quote_char:
+                                in_quotes = False
+                        elif char == "#" and not in_quotes:
+                            value_part = value_part[:i]
+                            break
+                line = key_part + "=" + value_part
+
+            if line.startswith("export "):
+                line = line[7:]
+            key, _, value = line.partition("=")
+            value = value.strip().strip("'\"")
+            config[key.strip()] = value
+    return config
+
+
+def get_keychain_password(service: str, account: str | None = None) -> str | None:
+    """Get password from macOS keychain."""
+    try:
+        cmd = ["security", "find-generic-password", "-s", service, "-w"]
+        if account:
+            cmd = ["security", "find-generic-password", "-s", service, "-a", account, "-w"]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        # Keychain entry not found - this is expected for optional config
+        return None
+
+
+def get_keychain_value(service: str, account: str | None = None) -> str | None:
+    """Get a non-sensitive identifier from macOS keychain (e.g. Slack channel IDs).
+
+    Use this for non-credential keychain entries such as Slack channel identifiers
+    (e.g. C1234ABCD). These are configuration values, not secrets, and may be
+    safely printed to stdout for diagnostic purposes.
+    """
+    try:
+        cmd = ["security", "find-generic-password", "-s", service, "-w"]
+        if account:
+            cmd = ["security", "find-generic-password", "-s", service, "-a", account, "-w"]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        # Keychain entry not found - this is expected for optional config
+        return None
+
+
+def get_repo_name(target_dir: str) -> str:
+    """Get repo name - prefer git remote URL (works for worktrees), fall back to basename."""
+    target_path = Path(target_dir)
+
+    # Try git remote URL first
+    git_dir = target_path / ".git"
+    if git_dir.exists():
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                cwd=target_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            url = result.stdout.strip()
+            name = url.rsplit("/", 1)[-1]
+            if name.endswith(".git"):
+                name = name[:-4]
+            if name:
+                return name
+        except subprocess.CalledProcessError:
+            # Git command failed (not a git repo or no remote) - fall back to directory name
+            pass
+
+    return target_path.name
+
+
+def sanitize_repo_name(name: str) -> str:
+    """Convert repo name to keychain key format (uppercase, underscores for dashes/dots)."""
+    return name.upper().replace("-", "_").replace(".", "_")
+
+
+def emit_event(
+    events_log: Path,
+    event_type: str,
+    run_id: str,
+    repo: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Emit a structured JSON event to the events log."""
+    event = {
+        "event": event_type,
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "run_id": run_id,
+        "repo": repo,
+        **kwargs,
+    }
+    with open(events_log, "a") as f:
+        f.write(json.dumps(event) + "\n")
+    return event
+
+
+def iso_to_epoch(iso_str: str) -> int | None:
+    """Convert ISO8601 timestamp to epoch seconds."""
+    try:
+        # Handle various ISO formats
+        iso_str = iso_str.replace("Z", "+00:00")
+        if "." in iso_str:
+            iso_str = iso_str.split(".")[0] + "+00:00" if "+" not in iso_str else iso_str
+        dt = datetime.fromisoformat(iso_str)
+        return int(dt.timestamp())
+    except (ValueError, AttributeError):
+        return None

--- a/nix-ai-claude/modules/claude/bws-env.example
+++ b/nix-ai-claude/modules/claude/bws-env.example
@@ -1,0 +1,44 @@
+# BWS Configuration for Auto-Claude
+#
+# Copy this file to ~/.config/bws/.env and fill in your values.
+# This file should NEVER be committed to git.
+#
+# Setup (choose one):
+#
+# Option A - Login keychain (recommended, auto-unlocks on login):
+#   security add-generic-password -a <account> -s <service> -w <token> login.keychain
+#
+# Option B - Separate automation keychain (if you need isolation):
+#   1. Create keychain with a password you'll remember
+#   2. In Keychain Access, add it to "Keychains" and configure to unlock on login
+#   3. Add tokens to that keychain
+#
+# Required Variables:
+
+# Keychain configuration for BWS access token
+# These define where the BWS access token is stored in macOS Keychain
+# Example: BWS_KEYCHAIN_SERVICE=bws-claude-access-token
+# Example: BWS_KEYCHAIN_ACCOUNT=claude-automation
+BWS_KEYCHAIN_SERVICE=your-keychain-service-name
+BWS_KEYCHAIN_ACCOUNT=your-keychain-account-name
+
+# BWS secret name mappings (use secret names, not IDs)
+# Format: BWS_SECRET_<KEY>=<secret-name-in-bws>
+# The KEY must match exactly what the code requests
+BWS_SECRET_CLAUDE_OAUTH_TOKEN=CLAUDE_OAUTH_TOKEN
+BWS_SECRET_SLACK_BOT_TOKEN=SLACK_BOT_TOKEN
+
+# Optional: Add more secrets as needed
+# BWS_SECRET_GEMINI_API_KEY=GEMINI_API_KEY
+
+# Slack channel IDs (stored directly in keychain, not BWS)
+# These are less sensitive and stored with the same account name
+# Format: SLACK_CHANNEL_ID_<REPO> in keychain (repo name uppercase, dashes/dots → underscores)
+#
+# To add channel IDs to keychain (use same account as BWS_KEYCHAIN_ACCOUNT):
+#   security add-generic-password -a <account> -s SLACK_CHANNEL_ID_AI_ASSISTANT_INSTRUCTIONS -w C0123456789 automation.keychain
+#   security add-generic-password -a <account> -s SLACK_CHANNEL_ID_NIX_CONFIG -w C9876543210 automation.keychain
+#
+# Examples:
+# - SLACK_CHANNEL_ID_AI_ASSISTANT_INSTRUCTIONS → for ai-assistant-instructions repo
+# - SLACK_CHANNEL_ID_NIX_CONFIG → for nix-config repo

--- a/nix-ai-claude/modules/claude/bws_helper.py
+++ b/nix-ai-claude/modules/claude/bws_helper.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+BWS Helper - Fetch secrets from Bitwarden Secrets Manager via macOS Keychain.
+
+Config: ~/.config/bws/.env (not in git)
+Usage: python3 bws_helper.py CLAUDE_OAUTH_TOKEN  # prints secret value
+"""
+
+import functools
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import keyring
+
+
+@functools.lru_cache(maxsize=1)
+def load_env(path: Path = Path.home() / ".config/bws/.env") -> dict[str, str]:
+    """Load .env file into dict (cached).
+
+    Note: Cache is intentional - config should not change during script execution.
+    Scripts are short-lived (seconds), so stale config is not a concern.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Config not found: {path}")
+    config = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            if line.startswith("export "):
+                line = line[7:]
+            k, _, v = line.partition("=")
+            key = k.strip()
+            # Strip a single pair of matching surrounding quotes after trimming whitespace
+            # This preserves legitimate leading/trailing quotes that are not delimiters
+            raw = v.strip()
+            if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+                value = raw[1:-1]
+            else:
+                value = raw
+            if not value:
+                raise ValueError(f"Empty value for key '{key}' in {path}")
+            config[key] = value
+
+    # Validate required keychain config keys are present
+    required_keys = ["BWS_KEYCHAIN_SERVICE", "BWS_KEYCHAIN_ACCOUNT"]
+    missing = [k for k in required_keys if k not in config]
+    if missing:
+        raise ValueError(f"Missing required config key(s) in {path}: {', '.join(missing)}")
+    return config
+
+
+def get_bws_token() -> str:
+    """Get BWS access token from keychain."""
+    cfg = load_env()
+    service = cfg.get("BWS_KEYCHAIN_SERVICE")
+    account = cfg.get("BWS_KEYCHAIN_ACCOUNT")
+    if not service:
+        raise ValueError("BWS_KEYCHAIN_SERVICE not in config")
+    if not account:
+        raise ValueError("BWS_KEYCHAIN_ACCOUNT not in config")
+    token = keyring.get_password(service, account)
+    if not token:
+        raise RuntimeError(f"No keychain entry for BWS token (service='{service}', account='{account}')")
+    return token
+
+
+def bws_get(name_or_id: str) -> str:
+    """Fetch secret from BWS by name or ID. Secret value flows directly to return."""
+    env = {**os.environ, "BWS_ACCESS_TOKEN": get_bws_token()}
+
+    # If not a UUID, resolve name to ID via list (metadata only, no secret values)
+    if not _is_uuid(name_or_id):
+        try:
+            result = subprocess.run(
+                ["bws", "secret", "list", "-o", "json"],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=True,
+            )
+        except FileNotFoundError:
+            raise RuntimeError("bws command not found. Install it from https://bitwarden.com/help/secrets-manager-cli/") from None
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to list bws secrets to find ID for '{name_or_id}': {e.stderr}") from e
+
+        try:
+            secrets = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Failed to parse bws secret list output: {e}") from e
+
+        original_name = name_or_id
+        for s in secrets:
+            if s.get("key") == name_or_id:
+                name_or_id = s["id"]
+                break
+
+        if not _is_uuid(name_or_id):
+            raise ValueError(f"Secret '{original_name}' not found in BWS")
+
+    # Fetch secret by ID - value goes straight from JSON to return
+    try:
+        result = subprocess.run(
+            ["bws", "secret", "get", name_or_id, "-o", "json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+    except FileNotFoundError:
+        raise RuntimeError("bws command not found. Install it from https://bitwarden.com/help/secrets-manager-cli/") from None
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"bws secret get failed for '{name_or_id}': {e.stderr}") from e
+
+    try:
+        return json.loads(result.stdout)["value"]
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Failed to parse bws secret get output: {e}") from e
+    except KeyError:
+        raise RuntimeError(f"bws secret get returned JSON without 'value' key for '{name_or_id}'") from None
+
+
+def _is_uuid(s: str) -> bool:
+    """Check if string looks like a UUID."""
+    return bool(re.match(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', s, re.I))
+
+
+def get_secret(key: str) -> str:
+    """Get secret using config key (e.g., 'CLAUDE_OAUTH_TOKEN' -> BWS_SECRET_CLAUDE_OAUTH_TOKEN)."""
+    cfg = load_env()
+    name_or_id = cfg.get(f"BWS_SECRET_{key}")
+    if not name_or_id:
+        raise ValueError(f"BWS_SECRET_{key} not in config")
+    return bws_get(name_or_id)
+
+
+def get_keychain(service: str) -> str:
+    """Get non-secret values from keychain (Slack channel IDs, etc.) using BWS account."""
+    cfg = load_env()
+    account = cfg.get("BWS_KEYCHAIN_ACCOUNT")
+    if not account:
+        raise ValueError("BWS_KEYCHAIN_ACCOUNT not in config")
+    value = keyring.get_password(service, account)
+    if not value:
+        raise RuntimeError(f"No keychain entry (service='{service}', account='{account}')")
+    return value
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: bws_helper.py <SECRET_KEY>", file=sys.stderr)
+        sys.exit(1)
+    # Write to fd 1 (stdout) directly — this is a credential helper that emits
+    # the requested secret for capture via shell command substitution.
+    os.write(1, (get_secret(sys.argv[1].upper().replace("-", "_")) + "\n").encode())

--- a/nix-ai-claude/modules/claude/components.nix
+++ b/nix-ai-claude/modules/claude/components.nix
@@ -1,0 +1,75 @@
+# Claude Code Components
+#
+# Manages commands, agents, skills, and rules from various sources:
+# - Flake inputs (immutable, from Nix store)
+# - Local files (direct symlinks)
+# - Live repos (mkOutOfStoreSymlink for updates without rebuild)
+{ config, lib, ... }:
+
+let
+  cfg = config.programs.claude;
+
+  # Helper to create file entries from component list
+  # Uses force = true to overwrite any existing files (git provides version control)
+  mkComponentFiles =
+    type: components:
+    builtins.listToAttrs (
+      map (c: {
+        name = ".claude/${type}s/${c.name}.md";
+        value = {
+          inherit (c) source;
+          force = true;
+        };
+      }) components
+    );
+
+  # Helper for live repo symlinks (if ever needed for writable repos)
+  # Note: Returns empty set when repo is null. Called with cfg.commands.fromLiveRepo
+  # which is null by default - all content comes from Nix store (flake inputs)
+  # Uses force = true to overwrite any existing files
+  mkLiveRepoSymlinks =
+    type: repo: names:
+    if repo == null then
+      { }
+    else
+      builtins.listToAttrs (
+        map (name: {
+          name = ".claude/${type}s/${name}.md";
+          value = {
+            source = config.lib.file.mkOutOfStoreSymlink "${repo}/.claude/${type}s/${name}.md";
+            force = true;
+          };
+        }) names
+      );
+
+  # Helper for local file symlinks
+  # Uses force = true to overwrite any existing files
+  mkLocalSymlinks =
+    type: locals:
+    lib.mapAttrs' (
+      name: path:
+      lib.nameValuePair ".claude/${type}s/${name}.md" {
+        source = path;
+        force = true;
+      }
+    ) locals;
+
+in
+{
+  config = lib.mkIf cfg.enable {
+    home.file =
+      # Commands
+      mkComponentFiles "command" cfg.commands.fromFlakeInputs
+      // mkLocalSymlinks "command" cfg.commands.local
+      // mkLiveRepoSymlinks "command" cfg.commands.fromLiveRepo cfg.commands.liveRepoCommands
+      # Agents
+      // mkComponentFiles "agent" cfg.agents.fromFlakeInputs
+      // mkLocalSymlinks "agent" cfg.agents.local
+      # Skills
+      // mkComponentFiles "skill" cfg.skills.fromFlakeInputs
+      // mkLocalSymlinks "skill" cfg.skills.local
+      # Rules (global user rules, loaded every session)
+      // mkComponentFiles "rule" cfg.rules.fromFlakeInputs
+      // mkLocalSymlinks "rule" cfg.rules.local;
+  };
+}

--- a/nix-ai-claude/modules/claude/default.nix
+++ b/nix-ai-claude/modules/claude/default.nix
@@ -1,0 +1,85 @@
+# Unified Claude Code Configuration Module
+#
+# This module consolidates all Claude Code configuration into a single
+# declarative interface: plugins, commands, agents, skills, hooks, MCP servers.
+#
+# Features:
+# - Declarative plugin management via flake inputs
+# - Hybrid mode: Nix-managed baseline + runtime /plugin install
+# - Cross-platform: Works on Darwin, NixOS, standalone home-manager
+# - Generates settings.json (known_marketplaces.json managed by Claude Code at runtime)
+#
+# Usage:
+#   programs.claude = {
+#     enable = true;
+#     plugins.enabled = { "commit-commands@anthropics/claude-code" = true; };
+#   };
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+in
+{
+  imports = [
+    ./options.nix
+    ./registry.nix
+    ./plugins.nix
+    ./components.nix
+    ./settings.nix
+    ./statusline
+    # Note: MCP server configuration is handled in settings.nix via the `mcpServers` option.
+    ./auto-claude.nix
+    ./auto-claude-reporting.nix
+    ./menubar.nix
+    ./orphan-cleanup.nix
+    ./pal-models.nix
+  ];
+
+  config = lib.mkIf cfg.enable {
+    # Note: apiKeyHelper now reads config from ~/.config/bws/.env
+    # The Python helper (bws_helper.py) will give clear errors if config is missing
+
+    # Ensure ~/.claude directory structure exists
+    # Individual sub-modules populate these directories
+    home.file = {
+      ".claude/.keep".text = ''
+        # Managed by Nix - programs.claude module
+      '';
+      ".claude/plugins/.keep".text = ''
+        # Plugin registry managed by Nix
+      '';
+    }
+    // lib.optionalAttrs cfg.apiKeyHelper.enable {
+      # API Key Helper script for headless authentication
+      # Configuration now comes from ~/.config/bws/.env (not Nix options)
+      "${cfg.apiKeyHelper.scriptPath}" = {
+        source = ./get-api-key.py; # Python script using bws_helper
+        executable = true;
+      };
+    };
+
+    # Activation scripts for directory and config setup
+    # NOTE: "local" marketplace setup removed - Claude Code doesn't use it by default.
+    # See docs/CLAUDE-MARKETPLACE-ARCHITECTURE.md for details.
+    home.activation = {
+      # WakaTime config — fetches API key from Doppler at activation time.
+      # Graceful fallback: keeps existing config if Doppler is unreachable.
+      wakatimeConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        if [ -n "$DRY_RUN_CMD" ]; then
+          echo "wakatime: dry-run — skipping Doppler fetch" >&2
+        elif WAKA_KEY=$(${pkgs.doppler}/bin/doppler secrets get WAKATIME_API_KEY \
+          -p ai-ci-automation -c prd --plain 2>/dev/null); then
+          (umask 077; printf '[settings]\napi_key = %s\nwrites_only = false\n' "$WAKA_KEY" \
+            > "${config.home.homeDirectory}/.wakatime.cfg")
+        else
+          echo "wakatime: Doppler unreachable — keeping existing config" >&2
+        fi
+      '';
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/fabric-curated-patterns.json
+++ b/nix-ai-claude/modules/claude/fabric-curated-patterns.json
@@ -1,0 +1,136 @@
+{
+  "patterns": [
+    {
+      "name": "extract_wisdom",
+      "description": "Extract surprising insights, ideas, quotes, habits, facts, and recommendations from any content. Use when summarizing articles, videos, podcasts, or books to capture the key takeaways."
+    },
+    {
+      "name": "extract_main_idea",
+      "description": "Distill the core thesis of a piece of content into a single clear statement. Use when you need to quickly identify what a text is really arguing."
+    },
+    {
+      "name": "extract_insights",
+      "description": "Pull out the most refined, abstracted insights from content. Use when you want distilled wisdom rather than raw facts."
+    },
+    {
+      "name": "extract_recommendations",
+      "description": "List every actionable recommendation from a piece of content. Use when processing advice articles, tutorials, or expert interviews."
+    },
+    {
+      "name": "extract_references",
+      "description": "Extract all citations, references, and mentioned sources from content. Use when building a reading list from an article or paper."
+    },
+    {
+      "name": "analyze_paper",
+      "description": "Evaluate an academic paper across quality, contribution, and methodology dimensions. Use when reviewing research papers or preprints."
+    },
+    {
+      "name": "analyze_prose",
+      "description": "Critique writing across novelty, clarity, and prose style dimensions. Use when reviewing your own or others' written work."
+    },
+    {
+      "name": "analyze_answers",
+      "description": "Evaluate the quality of answers to questions. Use when grading interviews, tests, or Q&A sessions."
+    },
+    {
+      "name": "analyze_logs",
+      "description": "Identify patterns, anomalies, and root causes in log files. Use when debugging production issues or investigating incidents."
+    },
+    {
+      "name": "analyze_incident",
+      "description": "Break down a security or operational incident into root cause, impact, and mitigation steps. Use when writing post-mortems."
+    },
+    {
+      "name": "analyze_risk",
+      "description": "Assess risks in a proposal, system, or decision. Use when evaluating trade-offs or planning mitigations."
+    },
+    {
+      "name": "analyze_comments",
+      "description": "Summarize the sentiment and key themes in a set of comments. Use when processing user feedback or PR review comments."
+    },
+    {
+      "name": "analyze_threat_report",
+      "description": "Extract threat intelligence from security reports. Use when processing vendor threat bulletins or CVE advisories."
+    },
+    {
+      "name": "find_logical_fallacies",
+      "description": "Identify logical fallacies in an argument. Use when evaluating essays, debates, or persuasive content."
+    },
+    {
+      "name": "rate_content",
+      "description": "Score content on quality, originality, and usefulness. Use when triaging articles or deciding what is worth reading."
+    },
+    {
+      "name": "create_prd",
+      "description": "Draft a product requirements document from a feature description. Use when starting a new feature or scoping a project."
+    },
+    {
+      "name": "create_design_document",
+      "description": "Write a technical design document about a system or component. Use when preparing an RFC or architectural proposal."
+    },
+    {
+      "name": "create_stride_threat_model",
+      "description": "Generate a STRIDE threat model from a system architecture. Use when performing security reviews of new designs."
+    },
+    {
+      "name": "create_threat_scenarios",
+      "description": "Enumerate realistic threat scenarios against a system. Use during security planning and red-team exercises."
+    },
+    {
+      "name": "create_git_diff_commit",
+      "description": "Generate a conventional commit message from a git diff. Use when you need a clean commit message and don't want to write it by hand."
+    },
+    {
+      "name": "create_command",
+      "description": "Generate a shell command from a described task. Use when you know what you want but can't remember the flags."
+    },
+    {
+      "name": "create_summary",
+      "description": "Create a tight, well-structured summary of any input. Use when briefing yourself on a long document."
+    },
+    {
+      "name": "create_coding_feature",
+      "description": "Plan the implementation of a new coding feature from a description. Use when starting a non-trivial feature."
+    },
+    {
+      "name": "summarize",
+      "description": "Produce a concise, information-dense summary of arbitrary content. Use as a general-purpose summarization tool."
+    },
+    {
+      "name": "summarize_git_changes",
+      "description": "Summarize a series of git changes (log or diff). Use when writing release notes or retrospectives."
+    },
+    {
+      "name": "summarize_meeting",
+      "description": "Convert a meeting transcript into decisions, action items, and key discussion points. Use after recording meetings."
+    },
+    {
+      "name": "improve_writing",
+      "description": "Rewrite text to be clearer, more concise, and more engaging while preserving meaning. Use when polishing drafts."
+    },
+    {
+      "name": "humanize",
+      "description": "Rewrite AI-generated text so it reads more like human writing. Use when AI output sounds stilted or formulaic."
+    },
+    {
+      "name": "write_pull-request",
+      "description": "Write a complete pull request description from a set of changes. Use when preparing PRs against code review."
+    },
+    {
+      "name": "write_essay",
+      "description": "Draft a well-structured essay on a given topic. Use when working on long-form writing where clarity of argument matters."
+    },
+    {
+      "name": "review_code",
+      "description": "Review code on bugs, style issues, and improvements. Use as a complementary pass alongside other code review tools."
+    },
+    {
+      "name": "explain_code",
+      "description": "Explain what a piece of code does in plain language. Use when onboarding to unfamiliar code or documenting legacy systems."
+    },
+    {
+      "name": "clean_text",
+      "description": "Strip noise (ads, navigation, boilerplate) from scraped text content. Use when preprocessing web-extracted content."
+    }
+  ]
+}

--- a/nix-ai-claude/modules/claude/get-api-key.py
+++ b/nix-ai-claude/modules/claude/get-api-key.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+Claude API Key Helper - Retrieves Claude OAuth token for headless authentication.
+
+Used by Claude Code's apiKeyHelper mechanism for headless authentication
+(cron jobs, CI/CD pipelines, launchd agents, etc.)
+
+Configuration: ~/.config/bws/.env (see bws_helper.py)
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Import bws_helper from same directory
+sys.path.insert(0, str(Path(__file__).parent))
+import bws_helper
+
+if __name__ == "__main__":
+    try:
+        # Write to fd 1 (stdout) directly — this is Claude Code's apiKeyHelper,
+        # which emits the OAuth token for capture by the Claude CLI.
+        os.write(1, (bws_helper.get_secret("CLAUDE_OAUTH_TOKEN") + "\n").encode())
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/nix-ai-claude/modules/claude/hooks/ask-user-notify.sh
+++ b/nix-ai-claude/modules/claude/hooks/ask-user-notify.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Claude Code Hook: Notify on AskUserQuestion
+#
+# Sends Slack notification when Claude Code needs user input.
+# This enables mobile/async workflows where users may not be watching the terminal.
+#
+# Hook Type: preToolUse
+# Triggers: When Claude calls AskUserQuestion tool
+#
+# Environment Variables:
+#   TOOL_NAME: Name of the tool being invoked
+#   TOOL_INPUT: JSON input to the tool
+#   CLAUDE_SESSION_ID: Current session ID (if available)
+#   CLAUDE_SESSION_DIR: Session directory path (if available)
+
+set -euo pipefail
+
+# Only trigger for AskUserQuestion
+if [[ "${TOOL_NAME:-}" != "AskUserQuestion" ]]; then
+  exit 0
+fi
+
+# Extract question from tool input
+# Try multiple JSON paths since the structure varies:
+# - .question (single question)
+# - .questions[0].question (multiple questions)
+# - .prompt (alternative field name)
+QUESTION=$(echo "${TOOL_INPUT:-{}}" | jq -r '.question // .questions[0].question // .prompt // "User input needed"' 2>/dev/null || echo "User input needed")
+
+# Get current working directory and repo name
+REPO_NAME=$(basename "$(pwd)")
+SESSION_INFO="${REPO_NAME}"
+
+# Add session context if available
+if [[ -n "${CLAUDE_SESSION_DIR:-}" ]]; then
+  SESSION_BRANCH=$(git -C "$(pwd)" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  SESSION_INFO="${REPO_NAME} @ ${SESSION_BRANCH}"
+fi
+
+# Get Slack channel from environment or keychain
+SLACK_CHANNEL="${SLACK_CHANNEL:-}"
+if [[ -z "$SLACK_CHANNEL" ]]; then
+  # Try to get from keychain (format: SLACK_CHANNEL_<REPO>)
+  KEYCHAIN_KEY="SLACK_CHANNEL_$(echo "$REPO_NAME" | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
+  SLACK_CHANNEL=$(security find-generic-password -a "$USER" -s "$KEYCHAIN_KEY" -w 2>/dev/null || echo "")
+fi
+
+# If still no channel, use default or skip notification
+if [[ -z "$SLACK_CHANNEL" ]]; then
+  # Silent exit - don't break Claude Code if notifications aren't configured
+  exit 0
+fi
+
+# Call auto-claude-notify.py with user_input_needed event
+# Script is deployed by home-manager to ~/.claude/scripts/
+NOTIFY_SCRIPT="${HOME}/.claude/scripts/auto-claude-notify.py"
+if [[ -x "$NOTIFY_SCRIPT" ]]; then
+  if ! "$NOTIFY_SCRIPT" user_input_needed \
+    --session "$SESSION_INFO" \
+    --question "$QUESTION" \
+    --channel "$SLACK_CHANNEL" >&2; then
+    echo "Warning: Notification script failed to send message." >&2
+  fi
+fi
+
+exit 0

--- a/nix-ai-claude/modules/claude/hooks/ask-user-notify.sh
+++ b/nix-ai-claude/modules/claude/hooks/ask-user-notify.sh
@@ -25,7 +25,14 @@ fi
 # - .question (single question)
 # - .questions[0].question (multiple questions)
 # - .prompt (alternative field name)
-QUESTION=$(echo "${TOOL_INPUT:-{}}" | jq -r '.question // .questions[0].question // .prompt // "User input needed"' 2>/dev/null || echo "User input needed")
+QUESTION="User input needed"
+if command -v jq >/dev/null 2>&1; then
+  QUESTION=$(
+    printf '%s' "${TOOL_INPUT:-{}}" |
+      jq -r '.question // .questions[0].question // .prompt // "User input needed"' 2>/dev/null ||
+      printf '%s' "User input needed"
+  )
+fi
 
 # Get current working directory and repo name
 REPO_NAME=$(basename "$(pwd)")
@@ -33,16 +40,30 @@ SESSION_INFO="${REPO_NAME}"
 
 # Add session context if available
 if [[ -n "${CLAUDE_SESSION_DIR:-}" ]]; then
-  SESSION_BRANCH=$(git -C "$(pwd)" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  SESSION_BRANCH="unknown"
+  if command -v git >/dev/null 2>&1; then
+    SESSION_BRANCH=$(git -C "$(pwd)" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '%s' "unknown")
+  fi
   SESSION_INFO="${REPO_NAME} @ ${SESSION_BRANCH}"
 fi
 
 # Get Slack channel from environment or keychain
 SLACK_CHANNEL="${SLACK_CHANNEL:-}"
 if [[ -z "$SLACK_CHANNEL" ]]; then
-  # Try to get from keychain (format: SLACK_CHANNEL_<REPO>)
-  KEYCHAIN_KEY="SLACK_CHANNEL_$(echo "$REPO_NAME" | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
-  SLACK_CHANNEL=$(security find-generic-password -a "$USER" -s "$KEYCHAIN_KEY" -w 2>/dev/null || echo "")
+  # Try to get from keychain (format: SLACK_CHANNEL_ID_<REPO>)
+  KEYCHAIN_KEY="SLACK_CHANNEL_ID_$(echo "$REPO_NAME" | tr '[:lower:]' '[:upper:]' | tr '-.' '__')"
+  KEYCHAIN_ACCOUNT="${BWS_KEYCHAIN_ACCOUNT:-$USER}"
+  if [[ -f "${HOME}/.config/bws/.env" ]] && [[ -z "${BWS_KEYCHAIN_ACCOUNT:-}" ]]; then
+    KEYCHAIN_ACCOUNT=$(
+      grep -E '^(export )?BWS_KEYCHAIN_ACCOUNT=' "${HOME}/.config/bws/.env" 2>/dev/null |
+        tail -n 1 |
+        sed -E "s/^(export )?BWS_KEYCHAIN_ACCOUNT=//; s/^['\"]//; s/['\"]$//"
+    )
+    KEYCHAIN_ACCOUNT="${KEYCHAIN_ACCOUNT:-$USER}"
+  fi
+  if command -v security >/dev/null 2>&1; then
+    SLACK_CHANNEL=$(security find-generic-password -a "$KEYCHAIN_ACCOUNT" -s "$KEYCHAIN_KEY" -w 2>/dev/null || echo "")
+  fi
 fi
 
 # If still no channel, use default or skip notification

--- a/nix-ai-claude/modules/claude/hooks/last-output.sh
+++ b/nix-ai-claude/modules/claude/hooks/last-output.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Claude Code Hook: Capture Last Output
+#
+# Captures Claude's last response output to a file for statusline/terminal display.
+# This enables quick reference to the most recent Claude action without scrolling.
+#
+# Hook Type: postToolUse
+# Triggers: After any tool execution
+#
+# Environment Variables:
+#   TOOL_NAME: Name of the tool that was invoked
+#   TOOL_OUTPUT: Output from the tool execution
+#   CLAUDE_SESSION_ID: Current session ID (if available)
+#   CLAUDE_SESSION_DIR: Session directory path (if available)
+
+set -euo pipefail
+
+# Output file for last result (used by statusline or other display tools)
+OUTPUT_FILE="${HOME}/.cache/claude-last-output.txt"
+OUTPUT_DIR=$(dirname "$OUTPUT_FILE")
+
+# Ensure cache directory exists
+mkdir -p "$OUTPUT_DIR"
+
+# Extract a compact summary of the tool output
+# For different tool types, we want different information:
+case "${TOOL_NAME:-}" in
+  "Bash")
+    # For bash commands, show the command and exit code
+    COMMAND=$(echo "${TOOL_INPUT:-}" | jq -r '.command // "unknown"' 2>/dev/null || echo "unknown")
+    EXIT_CODE=$(echo "${TOOL_OUTPUT:-}" | jq -r '.exit_code // .exitCode // "?"' 2>/dev/null || echo "?")
+    SUMMARY="bash: ${COMMAND:0:50} (exit: ${EXIT_CODE})"
+    ;;
+
+  "Read")
+    # For file reads, show the file path
+    FILE_PATH=$(echo "${TOOL_INPUT:-}" | jq -r '.file_path // .filePath // "unknown"' 2>/dev/null || echo "unknown")
+    SUMMARY="read: $(basename "${FILE_PATH}")"
+    ;;
+
+  "Write"|"Edit")
+    # For file writes/edits, show the file path
+    FILE_PATH=$(echo "${TOOL_INPUT:-}" | jq -r '.file_path // .filePath // "unknown"' 2>/dev/null || echo "unknown")
+    SUMMARY="$(echo "${TOOL_NAME}" | tr '[:upper:]' '[:lower:]'): $(basename "${FILE_PATH}")"
+    ;;
+
+  "Grep"|"Glob")
+    # For searches, show the pattern
+    PATTERN=$(echo "${TOOL_INPUT:-}" | jq -r '.pattern // "unknown"' 2>/dev/null || echo "unknown")
+    SUMMARY="$(echo "${TOOL_NAME}" | tr '[:upper:]' '[:lower:]'): ${PATTERN:0:50}"
+    ;;
+
+  *)
+    # For other tools, just show the tool name
+    SUMMARY="${TOOL_NAME:-unknown}"
+    ;;
+esac
+
+# Add timestamp
+TIMESTAMP=$(date '+%H:%M:%S')
+OUTPUT="${TIMESTAMP} ${SUMMARY}"
+
+# Write to file (truncate to keep it compact)
+echo "$OUTPUT" > "$OUTPUT_FILE"
+
+# Optional: Also update a persistent log (append-only)
+LOG_FILE="${HOME}/.cache/claude-output.log"
+echo "$OUTPUT" >> "$LOG_FILE"
+
+# Keep log file size under control (last 100 lines)
+if [[ -f "$LOG_FILE" ]]; then
+  TMP_LOG=$(mktemp)
+  tail -n 100 "$LOG_FILE" > "$TMP_LOG" && mv "$TMP_LOG" "$LOG_FILE"
+fi
+
+exit 0

--- a/nix-ai-claude/modules/claude/keychain_error_handler.py
+++ b/nix-ai-claude/modules/claude/keychain_error_handler.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Keychain Error Handler
+
+Handles keychain-related errors and emits diagnostic events for later analysis.
+Integrates with auto-claude error tracking system.
+
+Usage:
+    python3 keychain_error_handler.py emit --run-id ID --repo NAME --service SERVICE --exit-code CODE --error ERROR
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from auto_claude_utils import emit_event
+
+
+def emit_keychain_error_event(
+    events_log: Path,
+    run_id: str,
+    repo: str,
+    service: str,
+    account: Optional[str],
+    exit_code: int,
+    error_message: str,
+) -> dict:
+    """Emit a keychain error event to the events log."""
+    return emit_event(
+        events_log,
+        "keychain_error",
+        run_id,
+        repo,
+        service=service,
+        account=account or "unknown",
+        exit_code=exit_code,
+        error_message=error_message,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Handle keychain errors and emit diagnostic events")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # emit subcommand
+    p_emit = subparsers.add_parser("emit", help="Emit a keychain error event")
+    p_emit.add_argument("--run-id", required=True, help="Run ID")
+    p_emit.add_argument("--repo", required=True, help="Repository name")
+    p_emit.add_argument("--service", required=True, help="Keychain service name")
+    p_emit.add_argument("--account", help="Keychain account (optional)")
+    p_emit.add_argument("--exit-code", type=int, required=True, help="Exit code from failed operation")
+    p_emit.add_argument("--error", required=True, dest="error_message", help="Error message")
+
+    args = parser.parse_args()
+
+    if args.command == "emit":
+        try:
+            events_log = Path(os.environ.get("CLAUDE_EVENTS_LOG", str(Path.home() / ".claude/logs/events.jsonl")))
+            events_log.parent.mkdir(parents=True, exist_ok=True)
+
+            event = emit_keychain_error_event(
+                events_log,
+                args.run_id,
+                args.repo,
+                args.service,
+                args.account,
+                args.exit_code,
+                args.error_message,
+            )
+            print(f"Keychain error event emitted: {event['timestamp']}")
+            return 0
+        except (OSError, IOError) as e:
+            print(f"Failed to emit keychain error event: {e}", file=sys.stderr)
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nix-ai-claude/modules/claude/marketplace-overrides.nix
+++ b/nix-ai-claude/modules/claude/marketplace-overrides.nix
@@ -1,0 +1,223 @@
+# Marketplace Derivation Overrides
+#
+# Custom derivations that wrap marketplace flake inputs to add local content
+# or create synthetic marketplace structure for repos that lack it.
+# Consumed by claude-config.nix via the marketplaces flakeInput override mechanism.
+{
+  pkgs,
+  lib,
+  marketplaceInputs,
+  fabric-src,
+  fabricVersion,
+  ...
+}:
+
+{
+  # Synthetic marketplace wrapper for browser-use skills (repo lacks .claude-plugin structure)
+  browserUseMarketplace =
+    let
+      # Pinned to match uv-installed CLI version (modules/default.nix installBrowserUse)
+      # renovate: datasource=pypi depName=browser-use
+      browserUseVersion = "0.12.6";
+      manifestJson = builtins.toFile "marketplace.json" (
+        builtins.toJSON {
+          name = "browser-use-skills";
+          metadata = {
+            description = "Browser automation skills from browser-use";
+            version = browserUseVersion;
+          };
+          owner = {
+            name = "Browser Use";
+            url = "https://browser-use.com";
+          };
+          plugins = [
+            {
+              name = "browser-use";
+              source = "./browser-use";
+              description = "Browser automation via browser-use CLI and Python library";
+              version = browserUseVersion;
+              author = {
+                name = "Browser Use";
+              };
+            }
+          ];
+        }
+      );
+      # Per-plugin manifest (Claude Code requires .claude-plugin/plugin.json in each plugin dir)
+      pluginJson = builtins.toFile "plugin.json" (
+        builtins.toJSON {
+          name = "browser-use";
+          version = browserUseVersion;
+          description = "Browser automation via browser-use CLI and Python library";
+          author = {
+            name = "Browser Use";
+          };
+          skills = [
+            "./skills/browser-use"
+            "./skills/cloud"
+            "./skills/open-source"
+            "./skills/remote-browser"
+          ];
+        }
+      );
+    in
+    pkgs.runCommand "browser-use-marketplace" { } ''
+      mkdir -p $out/.claude-plugin $out/browser-use/.claude-plugin
+      cp ${manifestJson} $out/.claude-plugin/marketplace.json
+      cp ${pluginJson} $out/browser-use/.claude-plugin/plugin.json
+      ln -s ${marketplaceInputs.browser-use-skills}/skills $out/browser-use/skills
+    '';
+
+  # Synthetic marketplace wrapper for Daniel Miessler's Fabric patterns.
+  #
+  # Wraps a curated subset of fabric patterns (defined in
+  # ./fabric-curated-patterns.json) into a Claude Code .claude-plugin/ layout
+  # so each pattern appears as a Claude Code skill.
+  #
+  # The pattern list lives in JSON instead of inline Nix attrs to keep this
+  # file lean and let the SKILL.md frontmatter generation stay pure Nix.
+  fabricMarketplace =
+    let
+      curated = builtins.fromJSON (builtins.readFile ./fabric-curated-patterns.json);
+      curatedPatterns = curated.patterns;
+
+      # Build each SKILL.md as a pure Nix string (frontmatter + upstream system.md).
+      mkSkillFile =
+        p:
+        let
+          systemMd = builtins.readFile "${fabric-src}/data/patterns/${p.name}/system.md";
+          skillContent = ''
+            ---
+            name: ${p.name}
+            description: ${p.description}
+            ---
+
+            ${systemMd}
+          '';
+        in
+        {
+          inherit (p) name;
+          path = builtins.toFile "SKILL-${p.name}.md" skillContent;
+        };
+
+      skillFiles = map mkSkillFile curatedPatterns;
+
+      # One install line per skill — no shell control flow, no loops.
+      copySkillCommands = lib.concatMapStringsSep "\n" (sf: ''
+        install -D -m 644 ${sf.path} $out/fabric-patterns/skills/${sf.name}/SKILL.md
+      '') skillFiles;
+
+      marketplaceJson = builtins.toFile "marketplace.json" (
+        builtins.toJSON {
+          name = "fabric-patterns";
+          metadata = {
+            description = "Curated subset of Daniel Miessler's Fabric AI prompt patterns wrapped as Claude Code skills";
+            version = fabricVersion;
+          };
+          owner = {
+            name = "Daniel Miessler";
+            url = "https://github.com/danielmiessler/fabric";
+          };
+          plugins = [
+            {
+              name = "fabric-patterns";
+              source = "./fabric-patterns";
+              description = "Curated Fabric AI prompt patterns: extraction, analysis, creation, summarization, writing, review.";
+              version = fabricVersion;
+              author = {
+                name = "Daniel Miessler";
+              };
+            }
+          ];
+        }
+      );
+
+      pluginJson = builtins.toFile "plugin.json" (
+        builtins.toJSON {
+          name = "fabric-patterns";
+          version = fabricVersion;
+          description = "Curated Fabric AI prompt patterns wrapped as Claude Code skills.";
+          author = {
+            name = "Daniel Miessler";
+          };
+          skills = map (p: "./skills/${p.name}") curatedPatterns;
+        }
+      );
+    in
+    pkgs.runCommand "fabric-patterns-marketplace" { } ''
+      install -D -m 644 ${marketplaceJson} $out/.claude-plugin/marketplace.json
+      install -D -m 644 ${pluginJson} $out/fabric-patterns/.claude-plugin/plugin.json
+      ${copySkillCommands}
+    '';
+
+  # Auto-generated marketplace manifest for jacobpevans-cc-plugins
+  # Ensures every plugin directory is registered — eliminates manual marketplace.json maintenance.
+  jacobpevansMarketplace =
+    let
+      src = marketplaceInputs.jacobpevans-cc-plugins;
+      entries = builtins.readDir src;
+
+      # Discovery filter matching plugins/development.nix + pathExists guard.
+      # nonPluginDirs is kept for fast-path (avoids stat calls) and consistency
+      # with development.nix which uses the same list.
+      nonPluginDirs = [
+        "docs"
+        "schemas"
+        ".claude-plugin"
+        ".github"
+        "scripts"
+        "tests"
+      ];
+      isPluginDir =
+        name: type:
+        type == "directory"
+        && !(lib.hasPrefix "." name)
+        && !(builtins.elem name nonPluginDirs)
+        && builtins.pathExists "${src}/${name}/.claude-plugin/plugin.json";
+      pluginDirNames = builtins.attrNames (lib.filterAttrs isPluginDir entries);
+
+      # Read plugin metadata from each plugin.json (defaults for robustness)
+      readPluginMeta =
+        name:
+        let
+          meta = builtins.fromJSON (builtins.readFile "${src}/${name}/.claude-plugin/plugin.json");
+        in
+        {
+          inherit name;
+          description = meta.description or "";
+          version = meta.version or "0.0.1";
+          author = meta.author or { name = "Unknown"; };
+          source = "./${name}";
+        };
+
+      # Preserve all upstream marketplace metadata, only replace plugins array
+      existingManifest = builtins.fromJSON (builtins.readFile "${src}/.claude-plugin/marketplace.json");
+      manifest = existingManifest // {
+        plugins = map readPluginMeta pluginDirNames;
+      };
+
+      manifestJson = builtins.toFile "marketplace.json" (builtins.toJSON manifest);
+    in
+    pkgs.runCommand "jacobpevans-cc-plugins-patched" { } ''
+      mkdir -p $out/.claude-plugin
+
+      # Symlink all entries except .claude-plugin (guard against empty glob)
+      for f in ${src}/* ${src}/.[!.]*; do
+        [ -e "$f" ] || continue
+        name=$(basename "$f")
+        [ "$name" = ".claude-plugin" ] && continue
+        ln -s "$f" "$out/$name"
+      done
+
+      # Preserve upstream .claude-plugin contents, only replace marketplace.json
+      for f in ${src}/.claude-plugin/*; do
+        [ -e "$f" ] || continue
+        name=$(basename "$f")
+        [ "$name" = "marketplace.json" ] && continue
+        ln -s "$f" "$out/.claude-plugin/$name"
+      done
+
+      # Generated marketplace.json replaces the manual one
+      cp ${manifestJson} $out/.claude-plugin/marketplace.json
+    '';
+}

--- a/nix-ai-claude/modules/claude/menubar.nix
+++ b/nix-ai-claude/modules/claude/menubar.nix
@@ -1,0 +1,50 @@
+# Auto-Claude Menu Bar Status
+#
+# SwiftBar plugin for monitoring auto-claude status in real-time.
+# Shows current state (active/paused/running) and provides quick actions.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+
+  # SwiftBar plugin script - reference external Python file
+  menubarScript = ./auto-claude-status.py;
+
+  # Use a simple path without spaces for reliability
+  pluginDir = ".config/swiftbar/plugins";
+  pluginName = "auto-claude.${toString cfg.menubar.refreshInterval}s.py";
+
+in
+{
+  options.programs.claude.menubar = {
+    enable = lib.mkEnableOption "Auto-Claude menu bar status via SwiftBar";
+
+    refreshInterval = lib.mkOption {
+      type = lib.types.ints.between 1 86400;
+      default = 30;
+      description = "Refresh interval in seconds for the menu bar plugin (1 second to 24 hours)";
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.menubar.enable) {
+    # Deploy the SwiftBar plugin
+    home.file."${pluginDir}/${pluginName}" = {
+      source = menubarScript;
+      executable = true;
+    };
+
+    # Note: User must configure SwiftBar to use ~/.config/swiftbar/plugins/
+    # on first launch, or symlink from their chosen location.
+
+    # Add a note about SwiftBar setup
+    warnings = lib.optional (!config.programs.claude.autoClaude.enable) ''
+      programs.claude.menubar is enabled but programs.claude.autoClaude is not.
+      The menu bar will show status but auto-claude won't be running.
+    '';
+  };
+}

--- a/nix-ai-claude/modules/claude/options.nix
+++ b/nix-ai-claude/modules/claude/options.nix
@@ -1,0 +1,443 @@
+# Claude Code Module Options
+#
+# All configuration options for the unified Claude Code module.
+# Cross-platform: no Darwin-specific code here.
+{ lib, ... }:
+
+let
+  # Reusable submodule types
+  marketplaceModule = lib.types.submodule {
+    options = {
+      source = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            type = lib.mkOption {
+              type = lib.types.enum [
+                "git"
+                "github"
+                "local"
+              ];
+              default = "git";
+            };
+            url = lib.mkOption { type = lib.types.str; };
+          };
+        };
+      };
+      flakeInput = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Flake input for Nix-managed (immutable) plugins";
+      };
+      overlayFiles = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        default = { };
+        description = "Files to overlay onto the marketplace (dest path relative to marketplace root → source file)";
+      };
+    };
+  };
+
+  componentModule = lib.types.submodule {
+    options = {
+      name = lib.mkOption { type = lib.types.str; };
+      source = lib.mkOption { type = lib.types.path; };
+    };
+  };
+
+  mcpServerModule = lib.types.submodule {
+    options = {
+      type = lib.mkOption {
+        type = lib.types.enum [
+          "stdio"
+          "sse"
+          "http"
+        ];
+        default = "stdio";
+      };
+      command = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      args = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+      env = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+      };
+      url = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      headers = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+      };
+      disabled = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+    };
+  };
+
+  hookType = lib.types.nullOr (lib.types.either lib.types.path lib.types.lines);
+
+in
+{
+  options.programs.claude = {
+    enable = lib.mkEnableOption "Claude Code configuration";
+
+    # Plugins
+    plugins = {
+      marketplaces = lib.mkOption {
+        type = lib.types.attrsOf marketplaceModule;
+        default = { };
+      };
+      enabled = lib.mkOption {
+        type = lib.types.attrsOf lib.types.bool;
+        default = { };
+      };
+      allowRuntimeInstall = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+      };
+    };
+
+    # Commands
+    commands = {
+      fromFlakeInputs = lib.mkOption {
+        type = lib.types.listOf componentModule;
+        default = [ ];
+      };
+      local = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        default = { };
+      };
+      fromLiveRepo = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+      };
+      liveRepoCommands = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+    };
+
+    # Agents
+    agents = {
+      fromFlakeInputs = lib.mkOption {
+        type = lib.types.listOf componentModule;
+        default = [ ];
+      };
+      local = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        default = { };
+      };
+    };
+
+    # Skills
+    skills = {
+      fromFlakeInputs = lib.mkOption {
+        type = lib.types.listOf componentModule;
+        default = [ ];
+      };
+      local = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        default = { };
+      };
+    };
+
+    # Rules (global user rules, loaded every session regardless of project)
+    rules = {
+      fromFlakeInputs = lib.mkOption {
+        type = lib.types.listOf componentModule;
+        default = [ ];
+      };
+      local = lib.mkOption {
+        type = lib.types.attrsOf lib.types.path;
+        default = { };
+      };
+    };
+
+    # Hooks - fully implemented in modules/claude/settings.nix
+    # Generates executable scripts in ~/.claude/hooks/ via home.file.
+    hooks = {
+      preToolUse = lib.mkOption {
+        type = hookType;
+        default = null;
+      };
+      postToolUse = lib.mkOption {
+        type = hookType;
+        default = null;
+      };
+      userPromptSubmit = lib.mkOption {
+        type = hookType;
+        default = null;
+      };
+      stop = lib.mkOption {
+        type = hookType;
+        default = null;
+      };
+      subagentStop = lib.mkOption {
+        type = hookType;
+        default = null;
+      };
+      sessionStart = lib.mkOption {
+        type = hookType;
+        default = null;
+      };
+      sessionEnd = lib.mkOption {
+        type = hookType;
+        default = null;
+      };
+    };
+
+    # MCP Servers
+    mcpServers = lib.mkOption {
+      type = lib.types.attrsOf mcpServerModule;
+      default = { };
+    };
+
+    # API Key Helper (for headless authentication)
+    # Requires ~/.config/bws/.env with Bitwarden/Claude API key env vars.
+    # bws_helper.py performs minimal validation — see it for required vars.
+    apiKeyHelper = {
+      enable = lib.mkEnableOption "API key helper for headless Claude authentication";
+
+      scriptPath = lib.mkOption {
+        type = lib.types.str;
+        default = ".local/bin/claude-api-key-helper";
+        description = "Path (relative to home) where the API key helper script is installed";
+      };
+    };
+
+    # Agent teams: coordinate multiple Claude Code instances
+    # See: https://code.claude.com/docs/en/agent-teams
+    teammateMode = lib.mkOption {
+      type = lib.types.enum [
+        "auto"
+        "in-process"
+        "tmux"
+      ];
+      default = "auto";
+      description = ''
+        Display mode for agent team teammates.
+        - "auto": split panes if already in tmux, in-process otherwise
+        - "in-process": all teammates in main terminal (Shift+Up/Down to navigate)
+        - "tmux": force split-pane mode (requires tmux)
+      '';
+    };
+
+    # Auto-update channel for Claude Code binary
+    autoUpdatesChannel = lib.mkOption {
+      type = lib.types.enum [
+        "stable"
+        "latest"
+      ];
+      default = "latest";
+      description = ''
+        Release channel for Claude Code binary updates.
+        - "latest": newest releases immediately (default upstream)
+        - "stable": ~1 week delay, fewer regressions
+      '';
+    };
+
+    # Show turn duration in UI
+    showTurnDuration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Show how long each turn takes in the Claude Code UI";
+    };
+
+    # Remote Control auto-start (Feb 2026 feature)
+    # Stored in ~/.claude.json (global config) via home.activation.
+    # See: https://code.claude.com/docs/en/remote-control
+    remoteControlAtStartup = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = ''
+        Enable Remote Control for all sessions automatically.
+        null = leave unmanaged (Claude Code default is false).
+      '';
+    };
+
+    # Trusted project directories for CLAUDE.md external import approval.
+    # Stored in ~/.claude.json under projects.<path> at activation time.
+    trustedProjectDirs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Base directories containing git repos (worktree layout).
+        At activation time, discovers all subdirectories and generates
+        trust entries (hasClaudeMdExternalIncludesApproved, hasTrustDialogAccepted)
+        for each "$baseDir/$repo/main" path in ~/.claude.json.
+      '';
+      example = [ "~/git" ];
+    };
+
+    model = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Override the default model. Accepts aliases ("opus", "sonnet",
+        "haiku", "opusplan") or full names ("claude-opus-4-6").
+        null = account-tier default. See: https://code.claude.com/docs/en/model-config
+      '';
+    };
+
+    effortLevel = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "low"
+          "medium"
+          "high"
+        ]
+      );
+      default = null;
+      description = ''
+        Adaptive reasoning effort for Opus 4.6 and Sonnet 4.6.
+        - null: Use upstream default (medium for Max/Team as of v2.1.68)
+        - "high": Full reasoning
+        - "medium": Balanced cost/quality
+        - "low": Minimal reasoning, fastest and cheapest
+        Override per-session via /model effort slider or "ultrathink" keyword.
+      '';
+    };
+
+    attribution = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Commit attribution trailer. Set commit = \"(claude)\" for minimal attribution.";
+    };
+
+    # Settings
+    settings = {
+      # Extended thinking mode
+      alwaysThinkingEnabled = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Enable Claude's extended thinking capability by default.
+          When enabled, Claude can reason through complex problems step-by-step.
+          Token budget controlled by MAX_THINKING_TOKENS in env.
+        '';
+      };
+
+      # Session management
+      cleanupPeriodDays = lib.mkOption {
+        type = lib.types.int;
+        default = 30;
+        description = ''
+          Sessions inactive longer than this period are deleted.
+          Upstream Claude default is 30 days.
+        '';
+      };
+
+      # Permissions
+      permissions = {
+        allow = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Commands and operations to auto-approve without prompting";
+        };
+        deny = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Commands and operations to permanently block";
+        };
+        ask = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Commands and operations requiring user confirmation";
+        };
+      };
+
+      additionalDirectories = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Directories accessible to Claude Code without prompts";
+        example = [
+          "~/projects"
+          "~/Documents"
+          "~/.config"
+        ];
+      };
+
+      # Environment variables for Claude Code
+      # See: https://code.claude.com/docs/en/settings
+      env = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = ''
+          Environment variables passed to Claude Code.
+          See: https://code.claude.com/docs/en/settings
+        '';
+        example = {
+          MAX_THINKING_TOKENS = "16000";
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS = "16000";
+        };
+      };
+
+      schemaUrl = lib.mkOption {
+        type = lib.types.str;
+        default = "https://json.schemastore.org/claude-code-settings.json";
+        description = "JSON schema URL for settings validation";
+      };
+
+      # Sandbox configuration (Dec 2025 feature)
+      # Provides filesystem/network isolation for untrusted codebases
+      sandbox = {
+        enabled = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Enable sandbox mode for filesystem/network isolation.
+            Useful when working in untrusted codebases.
+          '';
+        };
+        autoAllowBashIfSandboxed = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Automatically allow bash commands when sandboxed.
+            Safe because sandbox prevents destructive operations.
+          '';
+        };
+        excludedCommands = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Commands to exclude from sandbox restrictions";
+          example = [
+            "git"
+            "nix"
+            "darwin-rebuild"
+          ];
+        };
+      };
+    };
+
+    # Status Line (supports claude-code-statusline)
+    statusLine = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+      script = lib.mkOption {
+        type = lib.types.nullOr lib.types.lines;
+        default = null;
+      };
+    };
+
+    # Feature Flags
+    features = {
+      pluginSchemaVersion = lib.mkOption {
+        type = lib.types.int;
+        default = 1;
+      };
+      experimental = lib.mkOption {
+        type = lib.types.attrsOf lib.types.bool;
+        default = { };
+      };
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/orchestrator-prompt.txt
+++ b/nix-ai-claude/modules/claude/orchestrator-prompt.txt
@@ -1,0 +1,600 @@
+IDENTITY
+You are the Autonomous Maintenance Orchestrator running unattended via launchd.
+You coordinate work - you never execute code changes directly.
+Your role is to continuously find work and dispatch sub-agents until budget is exhausted.
+
+Model: Always run as Sonnet. Sub-agents may use different models as appropriate for their tasks.
+
+CONTEXT WINDOW AWARENESS
+You are operating with a 200,000 token context window (standard tier).
+
+CRITICAL: You receive real-time context usage warnings after each tool call:
+  <system_warning>Token usage: 35000/200000; 165000 remaining</system_warning>
+
+Before spawning ANY sub-agent, you MUST:
+1. Check your most recent <system_warning> message
+2. Calculate current usage percentage
+3. If usage > 90% (180,000+ tokens): DO NOT spawn, log summary and exit gracefully
+4. If usage > 50% (100,000+ tokens): Run /compact BEFORE spawning next subagent
+
+Context usage strategy:
+- Each sub-agent consumes ~10,000-30,000 tokens (depending on complexity)
+- Reserve minimum 20,000 tokens (10%) for final summary and graceful shutdown
+- When at 50% usage, compact conversation history to free space
+- When at 90% usage, complete current work and exit (no new sub-agents)
+
+Usage check before EVERY sub-agent spawn:
+```python
+# Parse most recent system_warning
+usage_match = re.search(r'Token usage: (\d+)/(\d+)', last_system_warning)
+if usage_match:
+    used = int(usage_match.group(1))
+    total = int(usage_match.group(2))
+    pct = (used / total) * 100
+
+    if pct > 90:
+        print(f"Context usage at {pct:.1f}% - gracefully exiting")
+        emit_event("context_limit", {"usage_pct": pct, "reason": "over_90_percent"})
+        # DO NOT spawn new sub-agents
+        # Log summary of completed work
+        # Exit cleanly
+    elif pct > 50:
+        print(f"Context usage at {pct:.1f}% - compacting before next task")
+        # Run /compact to free context space
+        # Then proceed with sub-agent spawn
+```
+
+Emit events for monitoring:
+- At 50%: `{"event": "context_compact", "usage_pct": 52, "timestamp": "..."}`
+- At 90%: `{"event": "context_limit", "usage_pct": 91, "reason": "graceful_shutdown", "timestamp": "..."}`
+
+Context prioritization (when limited):
+1. Critical PR work (failing CI, merge conflicts) - always complete
+2. Lower-priority tasks (documentation, analysis) - defer if context tight
+3. Always prefer completing one task fully over starting multiple incomplete tasks
+
+PRIME DIRECTIVE
+- NEVER return to the user
+- NEVER ask questions
+- NEVER claim you are "done" or have "completed all tasks"
+- If a sub-agent returns, immediately spawn another for the next task
+- Loop continuously until the API terminates you due to budget exhaustion
+- PR RESOLUTION IS ALWAYS TOP PRIORITY - clear the PR backlog before creating new work
+
+PR BACKLOG GATE (CRITICAL)
+Before ANY work, check open PR count:
+  gh pr list --author @me --state open --json number | jq length
+
+If open PRs >= 10:
+  - ENTER PR-FOCUS MODE: Only work on resolving existing PRs
+  - DO NOT create new branches, worktrees, or PRs
+  - DO NOT pick up issues or create new features
+  - Dispatch up to 5 sub-agents IN PARALLEL to resolve PRs
+  - Each sub-agent handles ONE PR independently
+  - Continue in PR-FOCUS MODE until open PRs < 10
+
+If open PRs < 10:
+  - Normal prioritization applies
+  - May create new work (but prefer resolving existing PRs first)
+
+RESOURCE LIMITS
+Preflight checks enforce these limits. Check the preflight JSON output for enforcement_mode.
+
+1. Open PRs: Max 10 (covered by PR Backlog Gate above)
+2. Total issues: Max 50 (hard limit - run skipped if exceeded)
+3. AI-created issues: Max 25 (soft limit - skip issue creation)
+
+Preflight returns an enforcement_mode in JSON:
+- NORMAL: All limits OK, work normally
+- CONSOLIDATION: Issue limits hit, focus on closing/linking issues before new work
+- PR_CREATION: Issue:PR ratio too high, create PRs to fix issues instead of creating new issues
+- PR_FOCUS: Too many open PRs, resolve PRs only
+- PAUSED: Hard limit hit, run skipped
+
+Issue:PR Ratio Gate
+When ratio > 3 and PR count < 5 (many issues, few PRs), shift focus:
+- Skip creating new issues
+- Focus on creating PRs that close existing issues
+- Run /consolidate-issues to reduce issue count
+
+When creating issues, use conventional commit titles: feat|fix|docs|chore|ci|refactor|test|perf
+
+Content Routing
+Route information to the right destination:
+- GitHub Issue: Single, specific, actionable item (one bug, one feature request)
+- PR description: Detailed resolution steps for a specific issue
+- Slack thread: Session summaries, cross-issue updates, meta-information about runs
+
+Never create GitHub issues for:
+- Session summaries or status reports
+- Lists of multiple findings (consolidate first, or post to Slack)
+- Meta-information about auto-claude runs
+
+Use auto-claude-notify.py session_summary for run status.
+Use auto-claude-notify.py cross_issue_update for multi-issue actions.
+
+Comment Policy
+Before commenting, verify the comment leads to action:
+- Closing the issue with evidence
+- Linking to related issues/PRs
+- Creating a PR to fix the issue
+- Escalating for human review with clear next steps
+
+If no action is possible, don't comment. Move to the next task.
+
+Max 1 auto-claude comment per issue/PR per run.
+Before commenting, check if already commented:
+  gh issue view <number> --json comments --jq '.comments[] | select(.body | contains("auto-claude")) | .id' | head -1
+If auto-claude comment exists, skip that issue/PR entirely.
+
+Track analyzed items per run - don't analyze the same item twice in one run.
+
+Failure handling: After 3 consecutive failures on the same item, stop and move on.
+
+How to emit auto-claude marker in comments:
+Include this footer in all comments: "<!-- auto-claude:analyzed:{RUN_ID} -->"
+This allows future runs to detect if an item was already processed.
+
+NOTIFICATION PROTOCOL
+After each significant event, emit a JSON line to stdout for Slack integration:
+
+Task started:
+{"event": "task_started", "task": "Fix CI on PR #123", "agent": "ci-fixer", "timestamp": "2025-12-14T08:15:00Z"}
+
+Task completed:
+{"event": "task_completed", "task": "Fix CI on PR #123", "pr": "#124", "cost": 1.23, "duration_minutes": 8, "timestamp": "2025-12-14T08:23:00Z"}
+
+Task blocked:
+{"event": "task_blocked", "task": "Resolve Issue #42", "reason": "Requires architecture decision", "timestamp": "2025-12-14T08:25:00Z"}
+
+CORE LOOP
+Execute this loop continuously until budget exhaustion forces termination:
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ 0. PR COUNT CHECK (FIRST - EVERY ITERATION)                                  │
+│    OPEN_PR_COUNT=$(gh pr list --author @me --state open --json number | jq length)
+│    If OPEN_PR_COUNT >= 10: ENTER PR-FOCUS MODE (skip to step 2)              │
+│    If OPEN_PR_COUNT < 10: NORMAL MODE (proceed to step 1)                    │
+│                                                                              │
+│ 1. ISSUE HYGIENE (RUN FIRST IN NORMAL MODE - BEFORE DISPATCHING WORK)        │
+│    Before assigning issues to sub-agents, clean up the issue backlog:        │
+│                                                                              │
+│    a) Fetch all open issues and recent PRs:                                  │
+│       gh issue list --state open --limit 100 --json number,title,body,labels │
+│       gh pr list --state all --limit 200 --json number,title,state,headRefName│
+│                                                                              │
+│    b) For EACH open issue, check if resolved by comparing to:                │
+│       - Merged PRs (search PR titles/branches for issue numbers)             │
+│       - Current main branch code (grep/search for implementations)           │
+│       - Closed related issues                                                │
+│                                                                              │
+│    c) Actions based on findings:                                             │
+│       FULLY RESOLVED: Comment with evidence + linked PRs, then close issue   │
+│         gh issue comment <num> --body "Resolved by PR #X. [details]"         │
+│         gh issue close <num> --reason completed                              │
+│                                                                              │
+│       PARTIALLY RESOLVED: Comment with progress + linked PRs, leave open     │
+│         gh issue comment <num> --body "Partially resolved: [details]. PRs: #X"│
+│                                                                              │
+│       STALE/OUTDATED: Comment explaining why, close as not-planned           │
+│         gh issue close <num> --reason "not planned" --comment "..."          │
+│                                                                              │
+│       MISSING PR LINKS: If a PR addresses an issue but isn't linked:         │
+│         gh pr edit <pr-num> --body "... Fixes #<issue-num> ..."              │
+│         (Or add comment on PR referencing issue)                             │
+│                                                                              │
+│    d) Verify ALL open PRs are linked to issues:                              │
+│       For each PR without "Fixes #" or "Closes #" in body, find related issue│
+│       and update PR body or add comment linking them.                        │
+│                                                                              │
+│    e) Skip this step if run within the last 6 hours (check timestamp file):  │
+│       ~/.cache/auto-claude/last-issue-hygiene                                │
+│       touch ~/.cache/auto-claude/last-issue-hygiene after running            │
+│                                                                              │
+│ 2. SCAN (NORMAL MODE - PRs < 10)                                             │
+│    Run these commands to gather current state:                               │
+│    - git status                                                              │
+│    - git log --oneline -10                                                   │
+│    - git branch -a                                                           │
+│    - gh pr list --state open --author @me                                    │
+│    - For each open PR: gh pr checks <number>                                 │
+│    - For each open PR: check if behind main (mergeable_state, behind_by)     │
+│    - For PRs with reviews: gh pr view <number> --comments                    │
+│    - gh issue list --limit 20 --state open (EXCLUDE label:ai-created)        │
+│      Command: gh issue list --state open --limit 20 --search "-label:ai-created"
+│    - Analyze codebase for bugs/improvements (if no urgent PR/issue work)     │
+│                                                                              │
+│ 2b. SCAN (PR-FOCUS MODE - PRs >= 10)                                         │
+│    ONLY gather PR state - ignore issues and new work:                        │
+│    - gh pr list --state open --author @me                                    │
+│    - For each open PR: gh pr checks <number>                                 │
+│    - For each open PR: check if behind main (mergeable_state, behind_by)     │
+│    - For PRs with reviews: gh pr view <number> --comments                    │
+│    - gh api repos/{owner}/{repo}/pulls/{number}/reviews for review status    │
+│                                                                              │
+│ 3. PRIORITIZE                                                                │
+│    IN PR-FOCUS MODE (PRs >= 10): ONLY priorities 1-4 apply                   │
+│    IN NORMAL MODE (PRs < 10): All priorities apply                           │
+│                                                                              │
+│    Priority order (highest first):                                           │
+│    1. PRs behind main - merge main into branch (CRITICAL - do this first!)   │
+│       Check: gh pr view <num> --json mergeStateStatus,baseRefName            │
+│       If behind: clone locally, merge main, push (for signed commits)        │
+│       Or use: gh api -X PUT repos/{owner}/{repo}/pulls/{num}/update-branch   │
+│    2. Failing CI on open PRs (blocks all progress)                           │
+│    3. PR review comments awaiting response (use /resolve-pr-review-thread)    │
+│    4. PRs ready to merge (CI passing, approved) - enable auto-merge          │
+│    ─── BELOW THIS LINE: BLOCKED IN PR-FOCUS MODE ───                         │
+│    5. Issues labeled: bug, critical (EXCLUDE ai-created label)               │
+│    6. Issues labeled: good-first-issue (EXCLUDE ai-created label)            │
+│    7. Code analysis: identify bugs, security issues, improvements            │
+│    8. Documentation with broken links or outdated info                       │
+│    9. Low test coverage in critical paths                                    │
+│    10. Dependency updates (minor/patch only)                                 │
+│                                                                              │
+│ 4. DISPATCH                                                                  │
+│    IN PR-FOCUS MODE: Spawn UP TO 5 sub-agents IN PARALLEL for PR work        │
+│      - Each sub-agent handles exactly ONE PR                                 │
+│      - Use multiple Task tool calls in a single response                     │
+│      - Sub-agents work independently and concurrently                        │
+│                                                                              │
+│    IN NORMAL MODE: Spawn sub-agents sequentially (one at a time)             │
+│      - Include in the sub-agent prompt:                                      │
+│        - Specific task scope (ONE bug, ONE feature, ONE concept per PR)      │
+│        - Permission to spawn helper sub-agents if needed                     │
+│        - Required output format for tracking                                 │
+│        - Reminder: NEVER ask user questions                                  │
+│        - Reminder: Enable auto-merge after CI passes                         │
+│                                                                              │
+│ 5. AWAIT                                                                     │
+│    Wait for sub-agent(s) to complete.                                        │
+│    In PR-FOCUS MODE: Wait for all parallel agents to finish                  │
+│    The sub-agent may spawn its own helpers (2 levels allowed).               │
+│                                                                              │
+│ 6. CAPTURE                                                                   │
+│    Log the sub-agent's results.                                              │
+│    Emit the appropriate notification event (completed or blocked).           │
+│    Track PRs created, PRs merged, costs incurred, time spent.                │
+│    ALWAYS verify PRs are linked to issues (add link if missing).             │
+│                                                                              │
+│ 7. LOOP                                                                      │
+│    Return to step 0 (PR COUNT CHECK) to reassess mode.                       │
+│    Do NOT exit. Do NOT claim you are done.                                   │
+│    The only valid termination is API budget exhaustion.                      │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+SUB-AGENT DISPATCH
+Use the Task tool with subagent_type="general-purpose" and model="sonnet" for ALL sub-agents.
+Sub-agents should invoke the appropriate slash commands defined in ~/.claude/commands/.
+
+CRITICAL: MODEL ENFORCEMENT
+- The orchestrator runs on Sonnet (--model sonnet flag)
+- ALL sub-agents MUST specify model="sonnet" in the Task tool call
+- NEVER use model="opus" - it is expensive and not authorized for auto-claude
+- NEVER omit the model parameter - always explicitly set model="sonnet"
+- Haiku (model="haiku") may be used for simple, quick tasks if needed
+
+AVAILABLE COMMANDS (sub-agents should invoke these):
+┌────────────────────────────────────────────────────────────────────────────────┐
+│ COMMAND                       │ PURPOSE                                        │
+├────────────────────────────────────────────────────────────────────────────────┤
+│ /fix-pr-ci                    │ Fix CI failures on open PRs                    │
+│ /manage-pr                    │ Full PR lifecycle: create, monitor, fix, merge │
+│ /resolve-pr-review-thread     │ Address PR review comments systematically      │
+│ /git-refresh                  │ Merge PRs, sync repos, cleanup worktrees       │
+│ /resolve-issues               │ Implement fixes for GitHub issues              │
+│ /shape-issues                 │ Convert raw ideas into actionable issues       │
+│ /refresh-repo                 │ Sync repo, cleanup worktrees, check PR status  │
+│ /review-pr                    │ Comprehensive PR review with feedback          │
+│ /review-code                  │ Code review for quality, bugs, security        │
+│ /review-docs                  │ Documentation review for consistency           │
+│ /link-review                  │ Check links in documentation                   │
+│ /sync-main                    │ Update main and merge into current/all PRs     │
+│ /ready-player-one             │ Check merge-readiness across all repositories  │
+└────────────────────────────────────────────────────────────────────────────────┘
+
+TASK-TO-COMMAND MAPPING
+When dispatching sub-agents, tell them to invoke the appropriate command:
+
+1. PR BEHIND MAIN (HIGHEST PRIORITY):
+   Tell sub-agent: "Run /sync-main to update PR #X with latest main.
+   For signed commits, use local worktree method. NEVER ask user questions."
+
+2. FAILING CI:
+   Tell sub-agent: "Run /fix-pr-ci for PR #X. Fix root cause and push.
+   After CI passes, run /manage-pr to complete merge workflow."
+
+3. PR REVIEW COMMENTS:
+   Tell sub-agent: "Run /resolve-pr-review-thread for PR #X.
+   Address each comment, push fixes, then run /manage-pr for merge."
+
+4. PR READY TO MERGE:
+   Tell sub-agent: "Run /manage-pr for PR #X with passing CI and approval.
+   Alternatively, run /git-refresh to batch merge eligible PRs."
+
+5. RESOLVE GITHUB ISSUE:
+   Tell sub-agent: "Run /resolve-issues for Issue #X.
+   Use /refresh-repo first, then create a worktree with mkdir -p + git worktree add. Create focused PR (<200 lines).
+   After PR created, use /fix-pr-ci and /resolve-pr-review-thread as needed."
+
+6. CODE ANALYSIS/REVIEW:
+   Tell sub-agent: "Run /review-code on [path/files].
+   For each finding, create GitHub issue with 'ai-created' label using:
+   gh issue create --title '[title]' --body '[desc]' --label 'ai-created'
+   Use /shape-issues to convert findings into actionable issues."
+
+7. DOCUMENTATION UPDATE:
+   Tell sub-agent: "Run /review-docs and /link-review to validate.
+   Create focused PR for ONE documentation fix. Use /manage-pr for merge."
+
+8. TEST COVERAGE:
+   Tell sub-agent: "Analyze existing test patterns, write tests for [component].
+   Create focused PR. Use /manage-pr for merge workflow."
+
+COMPLETION REQUIREMENTS (for all sub-agents):
+- PR must exist before returning (if code was changed)
+- CI must be passing
+- All review comments must be resolved
+- 60-second quiet period must pass clean
+- Worktree must be cleaned up after merge
+
+SUB-AGENT INSTRUCTIONS
+When dispatching any sub-agent, always include:
+
+0. MODEL: Always set model="sonnet" in the Task tool call (MANDATORY - no exceptions)
+1. SCOPE: Be specific - ONE bug, ONE feature, ONE concept per PR
+   - PRs should be <200 lines changed when possible
+   - Large issues should be broken into smaller issues first
+   - No scope creep - stick to the assigned task only
+2. HELPERS: "You may spawn helper sub-agents for complex subtasks"
+3. OUTPUT: "When complete, report: files changed, PR created (if any), blockers"
+4. AUTONOMY: "You are running unattended. NEVER ask user questions. If truly
+   blocked, report the blocker and return so the orchestrator can move on."
+5. Merge: "After CI passes and PR is approved: rebase on main locally, fast-forward merge, push. PR auto-closes."
+6. ISSUE LABELS: When creating issues, ALWAYS add appropriate labels:
+   - 'ai-created' label is REQUIRED (human must review before AI works on it)
+   - Add additional labels based on content: bug, enhancement, documentation,
+     security, quick-win, dependencies, etc.
+   - Use best judgment from available labels: gh label list
+   Example: gh issue create --label 'ai-created,bug,quick-win' --title '...'
+7. PR-ISSUE LINKING (MANDATORY): Every PR MUST be linked to an issue:
+   - Include "Fixes #<issue-num>" or "Closes #<issue-num>" in PR body
+   - If no issue exists, create one first with appropriate labels
+   - If PR addresses multiple issues, link all of them
+   - After creating PR, verify the link: gh pr view <num> --json body
+   Example PR body:
+     "## Summary\n...\n\nFixes #123\n\n🤖 Generated with Claude Code"
+
+FORBIDDEN ACTIONS
+You must NEVER:
+- Ask user questions (you are unattended, no one will answer)
+- Return early ("I've completed my tasks" or "There's nothing left to do")
+- Force-push to any branch
+- Delete branches
+- Force merge PRs - use local rebase + fast-forward merge workflow instead
+- Make direct code changes (always delegate to sub-agents)
+- Claim budget exhaustion before the API actually terminates you
+- Work on issues that have the 'ai-created' label (human must review first)
+- Create new branches/PRs when open PR count >= 10 (PR-FOCUS MODE)
+- Create new issues when open issue count >= 50 (ISSUE LIMIT)
+- Create PRs with multiple unrelated changes (ONE concept per PR)
+- Create issues without the 'ai-created' label
+- Create PRs without linking to an issue (PRs must have "Fixes #X" in body)
+- Leave orphan PRs (PRs must show linked issue in GitHub's sidebar)
+- Leave a branch without a PR (every branch with commits must have a PR)
+- Return from a task without creating a PR (if commits were made)
+- Keep worktrees after PR is merged (remove them - PR is source of truth)
+- Return before CI passes (must fix all CI failures first)
+- Return with unresolved review comments (must resolve all threads)
+- Return before the 60-second quiet period after the last fix has completed
+- Create new worktrees when existing worktrees have pending work
+- Comment on the same issue/PR more than once per run (check for existing auto-claude comments)
+- Re-analyze an item that already has an auto-claude analysis comment
+
+RESILIENCE
+If a sub-agent fails or returns without completing:
+1. Log the failure with context (what task, what went wrong)
+2. Emit a task_blocked event with the reason
+3. Add the task to a "blocked" mental list
+4. Immediately proceed to the next priority task
+5. Never let one failure stop the loop
+
+If you encounter rate limits:
+1. Wait 30 seconds
+2. Retry the operation once
+3. If still failing, log it and move to the next task
+
+If a task seems too complex for a single sub-agent:
+1. Have the sub-agent create a GitHub Issue describing the problem
+2. Mark the original task as blocked (reason: "Created issue for human review")
+3. Move to the next task
+
+SAFETY CONSTRAINTS
+- Never work directly on main/master branch
+- Always create feature branches for changes
+- Never force-push (use regular push only)
+- Never delete remote branches
+- Never force merge PRs - use local rebase + fast-forward merge workflow
+- Never modify .env, secrets, or credential files
+- If unsure about a change's safety, skip it and move on
+- Never create PRs when open PR count >= 10 (clear backlog first)
+- Never create issues when open issue count >= 50 (skip to next task)
+- Never work on issues with 'ai-created' label (human review required)
+- Never retry the same failing operation more than 3 times (escalate and move on)
+
+PERMISSION CONSTRAINTS (CRITICAL)
+This session runs with a curated permission allowlist (not bypassPermissions).
+Only commands in ~/.claude/settings.json permissions.allow are permitted.
+
+- Commands not in the allowlist will FAIL (no prompt in unattended mode)
+- Use standard git, gh, nix, and Unix commands from the allowlist
+- If a command fails with permission error, try an alternative approach
+- Sub-agents inherit the same permission constraints
+- The allowlist includes 300+ pre-approved commands for typical development tasks
+- See ai-assistant-instructions flake input for the complete allowlist
+
+AI-CREATED ISSUE WORKFLOW
+Issues created by AI agents require human review before work begins:
+
+1. AI creates issue → MUST include 'ai-created' label
+   gh issue create --title "..." --body "..." --label "ai-created"
+
+2. Human reviews issue → removes 'ai-created' label if approved
+   (This happens outside of auto-claude, by repository maintainers)
+
+3. AI can now work on issue → label no longer present
+   When scanning: gh issue list --search "-label:ai-created"
+
+This prevents AI from creating and immediately working on low-quality issues.
+
+SMALL SCOPE PR RULES
+Every PR must contain exactly ONE of:
+- ONE bug fix
+- ONE feature
+- ONE refactoring
+- ONE documentation update
+- ONE dependency update
+
+Signs a PR is too large:
+- More than 200 lines changed
+- Touches more than 5 files
+- Multiple unrelated commit messages
+- Description requires multiple sections
+
+If a task is too large:
+1. Break it into smaller GitHub issues
+2. Each issue gets its own focused PR
+3. PRs can reference related issues for context
+
+PR-FIRST LIFECYCLE
+When making code changes: every branch with commits must have a PR within 60 seconds of first commit.
+This applies to agents that modify code, fix bugs, update documentation files, etc.
+Work with code changes is not complete until: PR exists, CI passes, comments resolved, and worktree removed.
+When NOT making code changes (creating issues, analyzing code, etc.): no PR is needed.
+
+Step 0: Worktree hygiene (before creating new work)
+Before creating any new worktree/branch, clean up existing ones:
+- If worktree has commits but no PR: create PR immediately with gh pr create --fill
+- If worktree has PR with failing CI and has been retried fewer than 3 times: fix CI using /fix-pr-ci patterns
+- If worktree has PR with failing CI and has already had 3 failed fix attempts: create or update a tracking issue, log the failure reason, and skip further CI-fix attempts for this worktree in this hygiene pass
+- If worktree has PR with unresolved comments: resolve using /resolve-pr-review-thread
+- If PR is merged or closed: remove worktree with git worktree remove <path>
+Do not create new worktrees until existing ones are resolved, except for worktrees explicitly escalated after repeated CI-fix failures.
+
+Step 1: PR creation (immediately after first complete implementation commit)
+- After your first complete implementation commit (including tests and docs where applicable), create PR immediately: gh pr create --fill
+- Do not make additional commits after this first complete implementation commit before creating the PR
+- Draft PRs are acceptable for work-in-progress; further commits refine the implementation within the existing PR
+- PR body must include "Fixes #X" linking to the issue being resolved
+
+Step 2: PR completion (monitor and fix)
+After PR is created, monitor until clean.
+A PR is considered clean when all CI checks are passing (green) AND there are no unresolved review threads or blocking review states.
+
+Monitor workflow:
+- Check CI status: gh pr checks <number>
+- If failing: fix using /fix-pr-ci patterns, commit, push
+- Check review comments: gh api repos/{owner}/{repo}/pulls/{number}/reviews
+- If unresolved threads: resolve using /resolve-pr-review-thread patterns
+- Repeat until PR is clean
+
+Step 3: 60-second quiet period
+After the last fix commit:
+- Wait 60 seconds for CI to fully propagate and reviewers to respond
+- Re-check CI: gh pr checks <number>
+- Re-check comments
+- If any new issues appeared: fix them and restart the 60-second timer
+- Only when 60 seconds passes clean, proceed to merge
+
+Step 4: Merge and cleanup
+After 60-second quiet period passes clean:
+1. In the feature worktree: git fetch origin main && git rebase origin/main
+2. Navigate to main worktree: cd ~/git/<repo>/main
+3. In main worktree: git checkout main && git pull --ff-only
+4. Fast-forward merge into main: git merge --ff-only <branch>
+5. Push main: git push origin main
+6. PR will auto-close when main contains the commits
+7. From outside the worktree: cd ~/git/<repo> && git worktree remove <branch-name>
+8. Prune: git worktree prune
+
+Sub-agent completion checklist:
+- Branch name
+- PR number
+- PR URL
+- CI status: passing
+- Review comments: all resolved (or none)
+- 60-second quiet period: clean
+- Merged to main: yes (via local rebase + fast-forward merge into main)
+- Worktree removal attempted (or already absent): yes
+
+If any of these are missing or failed, the sub-agent did not complete its mission.
+
+PR-ISSUE LINKING (MANDATORY - NO EXCEPTIONS)
+Every PR MUST be linked to a GitHub issue. This is NON-NEGOTIABLE.
+
+WHY THIS MATTERS:
+- Traceability: Every code change can be traced back to a requirement/bug
+- Accountability: Issues track what was requested; PRs track what was delivered
+- Discovery: Searching issues reveals related PRs and vice versa
+- Closure: When PR merges, linked issue auto-closes (if using "Fixes #X")
+
+HOW TO LINK:
+1. PR body must contain one of these keywords + issue number:
+   - "Fixes #123" (auto-closes issue when PR merges)
+   - "Closes #123" (auto-closes issue when PR merges)
+   - "Resolves #123" (auto-closes issue when PR merges)
+   - "Related to #123" (creates link but does NOT auto-close)
+
+2. The link must be in the PR BODY, not just commit messages
+
+3. After PR creation, verify the link exists:
+   gh issue view 123 --json "title,state"  # Should show linked PRs in web UI
+   gh pr view <pr-num> --json body | grep -E "(Fixes|Closes|Resolves) #"
+
+FINDING UNLINKED PRs:
+During ISSUE HYGIENE step, check for orphan PRs:
+  gh pr list --state open --json number,body | jq '.[] | select(.body | test("(Fixes|Closes|Resolves) #[0-9]+") | not)'
+
+If found, IMMEDIATELY fix by:
+1. Finding the related issue (search by PR title/description)
+2. If no issue exists, create one with 'ai-created' label
+3. Edit PR body to add the link: gh pr edit <num> --body "..."
+
+NO ORPHAN PRs ALLOWED. Every PR must have a home.
+
+PROGRESS TRACKING
+Maintain internal state of:
+- open_pr_count: Current count of open PRs (checked every iteration)
+- current_mode: "PR-FOCUS" (PRs >= 10) or "NORMAL" (PRs < 10)
+- tasks_identified: List of all work found during SCAN phases
+- tasks_completed: List of successfully completed tasks with PR links
+- tasks_blocked: List of tasks that couldn't be completed with reasons
+- total_cost: Running sum of sub-agent costs
+- prs_created: List of PR numbers created this run
+- prs_merged: List of PR numbers that auto-merged this run
+- issues_created: List of issues created with 'ai-created' label
+
+This state helps you avoid duplicate work and provides data for the summary.
+
+MODE TRANSITIONS
+- When entering PR-FOCUS MODE (open_prs >= 10): Emit notification
+  {"event": "mode_change", "mode": "PR-FOCUS", "open_prs": 10, "timestamp": "..."}
+- When exiting PR-FOCUS MODE (open_prs < 10): Emit notification
+  {"event": "mode_change", "mode": "NORMAL", "open_prs": 9, "timestamp": "..."}
+
+SIGNED COMMITS STRATEGY
+For commits that need to be signed (GPG/SSH signing configured locally):
+1. Use local worktrees instead of GitHub API for push operations
+2. Clone/worktree → make changes → commit (auto-signs) → push
+3. The branch-updater agent uses this pattern for merging main
+
+For operations where unsigned commits are acceptable:
+- gh api for branch updates (shows as GitHub web-flow signature)
+- gh pr merge (uses GitHub's merge signature)
+
+FINAL BEHAVIOR
+You will run until forcibly stopped, either by the API due to budget exhaustion
+or by a timeout imposed by the orchestrator's runtime environment.
+When termination occurs, Claude Code will capture your final output.
+There is no "graceful exit" - you run until forcibly stopped by budget exhaustion or timeout.
+This is by design. Embrace the loop.

--- a/nix-ai-claude/modules/claude/orphan-cleanup.nix
+++ b/nix-ai-claude/modules/claude/orphan-cleanup.nix
@@ -1,0 +1,82 @@
+# Orphan Cleanup Module
+#
+# Three-phase cleanup for Nix-managed directories:
+#
+# Phase 1 (BEFORE linkGeneration):
+# - Removes directory symlinks and real directories that conflict with
+#   directory symlinks in the new generation.
+# - Also removes stale root-level symlinks whose nix store targets no longer exist.
+#
+# Phase 2 (AFTER linkGeneration):
+# - Removes broken symlinks (targets that no longer exist) inside component dirs.
+#
+# Phase 3 (AFTER linkGeneration):
+# - Verifies plugin cache integrity when marketplace symlinks change.
+#
+{ config, lib, ... }:
+
+let
+  cfg = config.programs.claude;
+  homeDir = config.home.homeDirectory;
+
+  componentDirs = [
+    "${homeDir}/.claude/commands"
+    "${homeDir}/.claude/agents"
+    "${homeDir}/.claude/skills"
+    "${homeDir}/.claude/rules"
+    "${homeDir}/.gemini/commands"
+  ];
+
+  getMarketplaceName = name: lib.last (lib.splitString "/" name);
+  nixManagedMarketplaces = lib.filterAttrs (_: m: m.flakeInput != null) cfg.plugins.marketplaces;
+  marketplaceDirs = lib.mapAttrsToList (
+    name: _: "${homeDir}/.claude/plugins/marketplaces/${getMarketplaceName name}"
+  ) nixManagedMarketplaces;
+
+in
+{
+  config = lib.mkIf cfg.enable {
+    home.activation = {
+      # Phase 1: Remove conflicting entries BEFORE linkGeneration.
+      # Handles directory symlinks AND real directories (migration from recursive=true)
+      # so home-manager can create fresh directory symlinks.
+      cleanupConflictingDirectorySymlinks = lib.hm.dag.entryBefore [ "linkGeneration" ] ''
+        . ${./scripts/cleanup-common.sh}
+        . ${./scripts/cleanup-conflicting-symlinks.sh} \
+          ${lib.escapeShellArgs (componentDirs ++ marketplaceDirs)}
+        . ${./scripts/cleanup-stale-symlinks.sh} \
+          "${homeDir}/CLAUDE.md" "${homeDir}/GEMINI.md" "${homeDir}/AGENTS.md" "${homeDir}/agentsmd"
+      '';
+
+      # Phase 2: Remove orphan symlinks AFTER linkGeneration creates new ones.
+      cleanupOrphanComponents = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+        . ${./scripts/cleanup-common.sh}
+        . ${./scripts/cleanup-broken-symlinks.sh} \
+          ${lib.escapeShellArgs (
+            [
+              "command"
+              "${homeDir}/.claude/commands"
+              "agent"
+              "${homeDir}/.claude/agents"
+              "skill"
+              "${homeDir}/.claude/skills"
+              "rule"
+              "${homeDir}/.claude/rules"
+              "gemini command"
+              "${homeDir}/.gemini/commands"
+            ]
+            ++ (lib.concatMap (dir: [
+              "marketplace file"
+              dir
+            ]) marketplaceDirs)
+          )}
+      '';
+
+      # Phase 3: Verify plugin cache integrity AFTER linkGeneration.
+      # See: https://github.com/anthropics/claude-code/issues/17361
+      verifyCacheIntegrity = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+        $DRY_RUN_CMD ${./scripts/verify-cache-integrity.sh} "${homeDir}"
+      '';
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/pal-models.nix
+++ b/nix-ai-claude/modules/claude/pal-models.nix
@@ -1,0 +1,134 @@
+# PAL MCP — Dynamic Model Discovery
+#
+# Generates PAL model configs from runtime API queries:
+#   - custom_models.json     — from MLX vllm-mlx /v1/models (local)
+#   - openrouter_models.json — from OpenRouter public API (no auth)
+#
+# All cloud models route through OpenRouter — single source of truth.
+# Models are filtered by recency (last 90 days) and scored by price.
+# PAL's bundled native provider configs (Gemini/OpenAI/xAI) remain stale
+# but unused — OpenRouter handles all cloud routing.
+#
+# Configs rebuild at activation time (darwin-rebuild switch) and can be
+# refreshed between rebuilds with: sync-mlx-models / sync-pal-cloud-models
+#
+# PAL is built as a Nix derivation (modules/mcp/pal-package.nix) and installed
+# via home.packages. This eliminates the uvx git-clone approach that previously
+# failed with Permission denied when setuptools_scm tried to write to the
+# read-only Nix store.
+{
+  config,
+  lib,
+  pkgs,
+  pal-mcp-server,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+  mlxCfg = config.programs.mlx;
+  outputDir = "${config.home.homeDirectory}/.config/pal-mcp";
+  outputFile = "${outputDir}/custom_models.json";
+  palLogDir = "${config.home.homeDirectory}/.local/state/pal-mcp";
+  palPkg = pkgs.callPackage ../mcp/pal-package.nix { inherit pal-mcp-server; };
+
+  # Scripts directory holds pal-models-shared.jq, used by jq -L for `include`.
+  scriptsDir = ../mcp/scripts;
+
+  # Common env shared by all sync scripts
+  commonSyncEnv = ''
+    export CURL="${pkgs.curl}/bin/curl"
+    export JQ="${pkgs.jq}/bin/jq"
+    export OUTPUT_DIR="${outputDir}"
+    export SCRIPTS_DIR="${scriptsDir}"
+  '';
+
+  # MLX-specific sync env (used by both CLI tool and activation)
+  mlxSyncEnv = ''
+    ${commonSyncEnv}
+    export MLX_JQ_FILE="${scriptsDir}/pal-models-mlx.jq"
+    export MLX_URL="http://${mlxCfg.host}:${toString mlxCfg.port}/v1/models"
+    export OUTPUT_FILE="${outputFile}"
+  '';
+
+  # Cloud-specific sync env (OpenRouter public API, no auth)
+  cloudSyncEnv = ''
+    ${commonSyncEnv}
+    export OPENROUTER_JQ_FILE="${scriptsDir}/pal-models-openrouter.jq"
+  '';
+in
+{
+  config = lib.mkIf cfg.enable {
+    home = {
+      # Install pal-mcp-server as a Nix package so `doppler-mcp pal-mcp-server`
+      # resolves via PATH. The package is built from the pinned flake input.
+      packages = [
+        palPkg
+
+        # Refresh custom_models.json between darwin-rebuild switches.
+        # Queries MLX /v1/models for available models.
+        (pkgs.writeShellScriptBin "sync-mlx-models" ''
+          set -euo pipefail
+          ${mlxSyncEnv}
+          . ${../mcp/scripts/sync-pal-models.sh}
+          echo "PAL custom models updated. Restart Claude Code to pick up changes."
+        '')
+
+        # Refresh cloud model config between darwin-rebuild switches.
+        # Queries OpenRouter public API (no auth) — single source of truth for all cloud models.
+        (pkgs.writeShellScriptBin "sync-pal-cloud-models" ''
+          set -euo pipefail
+          ${cloudSyncEnv}
+          . ${../mcp/scripts/sync-pal-cloud-models.sh}
+          echo "PAL cloud models updated. Restart Claude Code to pick up changes."
+        '')
+      ];
+
+      activation = {
+        # Generate custom_models.json from dynamic MLX models.
+        # If the server is unreachable, the previous file is preserved.
+        palCustomModels = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          ${mlxSyncEnv}
+          $DRY_RUN_CMD bash -c '(umask 077 && mkdir -p "${palLogDir}")'
+          . ${../mcp/scripts/sync-pal-models.sh}
+        '';
+
+        # Generate cloud model configs from OpenRouter public API.
+        # No auth required. Preserves previous files if API is unreachable.
+        # Skipped on dry-run because the sync script makes external network calls.
+        palCloudModels = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          ${cloudSyncEnv}
+          if [ -z "''${DRY_RUN_CMD:-}" ]; then
+            . ${../mcp/scripts/sync-pal-cloud-models.sh}
+          fi
+        '';
+
+        # Non-blocking health check — runs after activation to surface PAL issues
+        # early (Doppler auth, missing secrets). Never blocks activation (always exits 0).
+        # Skipped on dry-run (not prefixed with $DRY_RUN_CMD) because the check makes
+        # network calls to Doppler that are inappropriate for a dry-run.
+        palHealthCheck = lib.hm.dag.entryAfter [ "writeBoundary" "palCustomModels" "palCloudModels" ] ''
+          if [ -z "''${DRY_RUN_CMD:-}" ]; then
+            export DOPPLER="${pkgs.doppler}/bin/doppler"
+            export PAL_MCP_BIN="${palPkg}/bin/pal-mcp-server"
+            export PAL_LOG_DIR="${palLogDir}"
+            . ${../mcp/scripts/check-pal-health.sh}
+          fi
+        '';
+      };
+    };
+
+    # Inject env vars into PAL server.
+    # Merges with the env block defined in mcp/default.nix (DISABLED_TOOLS, etc.).
+    programs.claude.mcpServers.pal.env = {
+      CUSTOM_MODELS_CONFIG_PATH = outputFile;
+      # Override PAL's hardcoded llama3.2 default — dynamically tracks programs.mlx.defaultModel.
+      CUSTOM_MODEL_NAME = mlxCfg.defaultModel;
+      # Cloud models — single source of truth via OpenRouter public API.
+      OPENROUTER_MODELS_CONFIG_PATH = "${outputDir}/openrouter_models.json";
+      # Point PAL logs to a writable location (default tries to write inside the
+      # read-only Nix store, producing "Permission denied: logs/" warnings).
+      PAL_LOG_DIR = palLogDir;
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins.nix
+++ b/nix-ai-claude/modules/claude/plugins.nix
@@ -1,0 +1,62 @@
+# Claude Code Plugin Management
+#
+# Symlinks Nix-managed plugin directories from flake inputs as single directory
+# symlinks (home-manager's default: recursive = false). Claude Code only READS
+# from ~/.claude/plugins/marketplaces/ — it writes exclusively to
+# ~/.claude/plugins/cache/. Since marketplaces are read-only, immutable nix
+# store symlinks are the correct approach.
+#
+# IMPORTANT: Do NOT add `recursive = true` or `force = true`:
+# - recursive = true creates per-file symlinks, allowing .backup pollution
+# - force = true causes home-manager to rename existing files to .backup,
+#   which pollute Claude Code's plugin cache when it re-indexes
+# Phase 1 of orphan-cleanup.nix handles the one-time migration from
+# recursive (real dirs) to directory symlinks.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+
+  # Extract marketplace name from the identifier
+  # e.g., "anthropics/claude-plugins-official" -> "claude-plugins-official"
+  # Implementation matches lib/claude-registry.nix for consistency
+  getMarketplaceName = name: lib.last (lib.splitString "/" name);
+
+  # Create symlink entries for Nix-managed marketplaces
+  nixManagedMarketplaces = lib.filterAttrs (_: m: m.flakeInput != null) cfg.plugins.marketplaces;
+
+  # Apply overlayFiles automatically via symlinkJoin when non-empty.
+  # Marketplaces without overlays use raw flakeInput (no-op path).
+  effectiveSource =
+    name: marketplace:
+    if marketplace.overlayFiles == { } then
+      marketplace.flakeInput
+    else
+      pkgs.symlinkJoin {
+        name = "${getMarketplaceName name}-with-overlays";
+        paths = [
+          marketplace.flakeInput
+        ]
+        ++ lib.mapAttrsToList (
+          destPath: srcFile: pkgs.writeTextDir destPath (builtins.readFile srcFile)
+        ) marketplace.overlayFiles;
+      };
+
+  marketplaceSymlinks = lib.mapAttrs' (
+    name: marketplace:
+    lib.nameValuePair ".claude/plugins/marketplaces/${getMarketplaceName name}" {
+      source = effectiveSource name marketplace;
+    }
+  ) nixManagedMarketplaces;
+
+in
+{
+  config = lib.mkIf cfg.enable {
+    home.file = marketplaceSymlinks;
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/community.nix
+++ b/nix-ai-claude/modules/claude/plugins/community.nix
@@ -1,0 +1,56 @@
+# Community Marketplace Plugins
+#
+# Plugins from community-maintained marketplaces:
+# - cc-marketplace: Official source for claudecodecommands.directory plugins
+# - superpowers-marketplace: Enhanced Claude capabilities (obra/Jesse Vincent)
+# - visual-explainer-marketplace: Rich HTML diagrams, diff reviews, slides (nicobailon)
+# - bitwarden-marketplace: Enterprise-grade session analysis and config validation
+# - browser-use-skills: Browser automation (synthetic marketplace — repo lacks native structure)
+
+_:
+
+{
+  enabledPlugins = {
+    # CC Marketplace - essential tools (official source for claudecodecommands.directory)
+    "analyze-issue@cc-marketplace" = true;
+    "create-worktrees@cc-marketplace" = true;
+    "python-expert@cc-marketplace" = true; # User actively uses Python
+    "devops-automator@cc-marketplace" = true; # CI/CD, cloud infra, monitoring, deployment
+
+    # Superpowers - comprehensive Claude enhancement suite
+    "superpowers@superpowers-marketplace" = true;
+    "double-shot-latte@superpowers-marketplace" = true; # User requested restore
+    "superpowers-lab@superpowers-marketplace" = true; # User requested add
+    "superpowers-developing-for-claude-code@superpowers-marketplace" = true; # User requested restore
+
+    # Obsidian Skills - Canonical (kepano/obsidian-skills)
+    # Marketplace declares single plugin "obsidian" bundling 5 skills
+    "obsidian@obsidian-skills" = true;
+
+    # Obsidian Visual Skills - Diagrams (axtonliu/axton-obsidian-visual-skills)
+    # Marketplace declares single plugin "obsidian-visual-skills" bundling 3 skills
+    "obsidian-visual-skills@axton-obsidian-visual-skills" = true;
+
+    # Visual Explainer - HTML diagrams, diff reviews, plan audits, slides, data tables
+    # Marketplace declares single plugin "visual-explainer" with 1 skill + 8 commands
+    "visual-explainer@visual-explainer-marketplace" = true;
+
+    # Bitwarden Marketplace - Enterprise-grade session analysis and config validation
+    # claude-retrospective: 3 skills (retrospecting, extracting-session-data, analyzing-git-sessions)
+    # claude-config-validator: 1 skill (reviewing-claude-config) — security + quality validation
+    "claude-retrospective@bitwarden-marketplace" = true;
+    "claude-config-validator@bitwarden-marketplace" = true;
+    # NOT enabled - Bitwarden-specific: bitwarden-code-review, bitwarden-software-engineer,
+    # bitwarden-security-engineer, bitwarden-product-analyst, bitwarden-init,
+    # atlassian-reader, bitwarden-atlassian-tools
+
+    # Browser Automation - browser-use (CLI skills require `browser-use` installed via uv)
+    "browser-use@browser-use-skills" = true;
+
+    # REMOVED - redundant or unused:
+    # double-check - unnecessary
+    # infrastructure-maintainer - too generic
+    # monitoring-observability-specialist - splunk repos don't need this
+    # awesome-claude-code-plugins - AGGREGATION, use true source (cc-marketplace) instead
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/default.nix
+++ b/nix-ai-claude/modules/claude/plugins/default.nix
@@ -1,0 +1,52 @@
+# Claude Code Plugins - Main Configuration
+#
+# Modular plugin configuration organized by category:
+# - marketplaces.nix: All available plugin marketplaces
+# - official.nix: Official Anthropic plugins
+# - external.nix: External third-party plugins (via claude-plugins-official)
+# - community.nix: Community marketplace plugins
+# - infrastructure.nix: Infrastructure, DevOps, and cloud operations
+# - development.nix: Software development and engineering tools
+# - monitoring.nix: Time tracking and monitoring tools
+# - experimental.nix: Experimental and autonomous plugins
+#
+# Each module exports an enabledPlugins attrset that gets merged.
+# The marketplaces module exports a marketplaces attrset.
+
+{
+  lib,
+  marketplaceInputs,
+  ...
+}:
+
+let
+  # Extract specific inputs needed by sub-modules
+  inherit (marketplaceInputs) jacobpevans-cc-plugins;
+
+  # Import all plugin category modules
+  marketplacesModule = import ./marketplaces.nix { inherit lib; };
+  officialModule = import ./official.nix { };
+  externalModule = import ./external.nix { };
+  communityModule = import ./community.nix { };
+  infrastructureModule = import ./infrastructure.nix { };
+  developmentModule = import ./development.nix { inherit lib jacobpevans-cc-plugins; };
+  monitoringModule = import ./monitoring.nix { };
+  experimentalModule = import ./experimental.nix { };
+  fabricModule = import ./fabric.nix { };
+
+  # Merge all enabled plugins from category modules
+  enabledPlugins =
+    officialModule.enabledPlugins
+    // externalModule.enabledPlugins
+    // communityModule.enabledPlugins
+    // infrastructureModule.enabledPlugins
+    // developmentModule.enabledPlugins
+    // monitoringModule.enabledPlugins
+    // experimentalModule.enabledPlugins
+    // fabricModule.enabledPlugins;
+in
+{
+  # Return the complete plugin configuration
+  inherit enabledPlugins;
+  inherit (marketplacesModule) marketplaces;
+}

--- a/nix-ai-claude/modules/claude/plugins/development.nix
+++ b/nix-ai-claude/modules/claude/plugins/development.nix
@@ -1,0 +1,108 @@
+# Development Plugins - Terraform/Nix/Python/Shell + selected marketplace plugins
+
+{
+  lib,
+  jacobpevans-cc-plugins,
+  ...
+}:
+
+let
+  # ============================================================================
+  # JacobPEvans Personal Plugins - Auto-discovered from flake input
+  # ============================================================================
+  # Plugins from `jacobpevans-cc-plugins` are discovered and enabled automatically.
+  # The list of plugins is determined by the repository contents at flake update time.
+  jacobpevansPlugins =
+    let
+      entries = builtins.readDir jacobpevans-cc-plugins;
+      # Plugin directories: exclude dotfiles, regular files, and known non-plugin dirs
+      nonPluginDirs = [
+        "docs"
+        "schemas"
+        ".claude-plugin"
+        ".github"
+        "scripts"
+        "tests"
+      ];
+      isPluginDir =
+        name: type:
+        type == "directory"
+        && !(lib.hasPrefix "." name)
+        && !(builtins.elem name nonPluginDirs)
+        && builtins.pathExists "${jacobpevans-cc-plugins}/${name}/.claude-plugin/plugin.json";
+      pluginNames = builtins.attrNames (lib.filterAttrs isPluginDir entries);
+    in
+    lib.genAttrs (map (name: "${name}@jacobpevans-cc-plugins") pluginNames) (_: true);
+in
+{
+  enabledPlugins = jacobpevansPlugins // {
+    # ========================================================================
+    # Claude Code Workflows - Core Development Tools
+    # ========================================================================
+
+    # Backend (Python, Shell)
+    "backend-development@claude-code-workflows" = true;
+
+    # Testing
+    "unit-testing@claude-code-workflows" = true;
+    "tdd-workflows@claude-code-workflows" = true;
+
+    # Code Quality
+    "code-refactoring@claude-code-workflows" = true;
+    "codebase-cleanup@claude-code-workflows" = true;
+
+    # Agent Orchestration (user requested)
+    "agent-orchestration@claude-code-workflows" = true;
+
+    # Observability - Keep distributed-tracing and slo-implementation, exclude prometheus/grafana
+    "observability-monitoring@claude-code-workflows" = true;
+
+    # Python Development (Django/FastAPI with 5 specialized skills)
+    "python-development@claude-code-workflows" = true;
+
+    # Full-Stack Orchestration (multi-agent workflows coordinating 7+ agents)
+    "full-stack-orchestration@claude-code-workflows" = true;
+
+    # Developer Essentials (common dev tools and utilities)
+    "developer-essentials@claude-code-workflows" = true;
+
+    # Performance Testing & Review (analysis and test coverage review)
+    "performance-testing-review@claude-code-workflows" = true;
+
+    # ========================================================================
+    # Note: Claude Code Workflows plugins contain multiple skills
+    # ========================================================================
+    # We enable the plugin (e.g., backend-development), which loads all its skills.
+    # Skills within plugins (like cqrs-implementation, event-store-design) cannot be
+    # individually disabled - they come with the parent plugin.
+
+    # ========================================================================
+    # Claude Skills Marketplace - Individual Plugins
+    # ========================================================================
+    # Claude Skills has individual plugins (not suites)
+
+    # API Design & Implementation
+    "api-design-principles@claude-skills" = true;
+    "rest-api-design@claude-skills" = true;
+    "graphql-implementation@claude-skills" = true;
+    "websocket-implementation@claude-skills" = true;
+
+    # Testing
+    "playwright@claude-skills" = true;
+    "vitest-testing@claude-skills" = true;
+    "jest-generator@claude-skills" = true;
+
+    # Security
+    "vulnerability-scanning@claude-skills" = true;
+    "csrf-protection@claude-skills" = true;
+    "xss-prevention@claude-skills" = true;
+
+    # Data & Recommendations
+    "recommendation-engine@claude-skills" = true;
+    "sql-query-optimization@claude-skills" = true;
+
+    # Authentication
+    "better-auth@claude-skills" = true;
+    "oauth-implementation@claude-skills" = true;
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/experimental.nix
+++ b/nix-ai-claude/modules/claude/plugins/experimental.nix
@@ -1,0 +1,51 @@
+# Experimental Plugins
+#
+# WARNING: Experimental plugins may have autonomous behavior
+#
+# CRITICAL: Plugin Reference Format
+# ============================================================================
+# Format: "plugin-name@marketplace-name"
+#
+# The marketplace-name MUST match the key in marketplaces.nix, which MUST
+# match the `name` field from the marketplace's .claude-plugin/marketplace.json
+#
+# How to verify: See docs/TESTING-MARKETPLACES.md
+# ============================================================================
+
+_:
+
+{
+  enabledPlugins = {
+    # ========================================================================
+    # Autonomous Iteration
+    # ========================================================================
+    # ralph-loop: autonomous iteration loops with file/git history preservation
+    # Commands: /ralph-loop, /cancel-ralph
+    "ralph-loop@claude-plugins-official" = true;
+
+    # ========================================================================
+    # Multi-Model AI Integrations (cc-dev-tools)
+    # ========================================================================
+    # WARNING: These plugins invoke external AI models (OpenAI, Google)
+
+    # Codex (Community): OpenAI GPT integration for high-reasoning coding tasks
+    # Auto-selects the latest available GPT model for coding or reasoning
+    "codex@cc-dev-tools" = true;
+
+    # ========================================================================
+    # Official OpenAI Codex Plugin
+    # ========================================================================
+    # Codex (Official): code review, adversarial review, task delegation
+    # Provides: /codex:review, /codex:adversarial-review, /codex:rescue, /codex:setup
+    "codex@openai-codex" = true;
+
+    # Gemini: Google Gemini integration for research and reasoning
+    # Includes web search capabilities and session resumption
+    "gemini@cc-dev-tools" = true;
+
+    # Telegram Notifier: Notifications for Claude Code events
+    # Hook-based (response completion, subagent tasks, system notifications)
+    # Requires: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID env vars
+    "telegram-notifier@cc-dev-tools" = false; # Enable after configuring tokens
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/external.nix
+++ b/nix-ai-claude/modules/claude/plugins/external.nix
@@ -1,0 +1,101 @@
+# External Third-Party Plugins
+#
+# These are officially listed third-party MCP integrations distributed via
+# the claude-plugins-official marketplace (anthropics/claude-plugins-official).
+#
+# Format: "plugin-name@claude-plugins-official"
+#
+# All external plugins are listed here for visibility.
+# Enable as needed - most require authentication setup.
+#
+# Source: https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins
+
+_:
+
+{
+  enabledPlugins = {
+    # =========================================================================
+    # Project Management
+    # =========================================================================
+
+    # Asana - task and project management
+    # Requires: Asana API token
+    "asana@claude-plugins-official" = false;
+
+    # Linear - issue tracking and project management
+    # Requires: Linear API key
+    "linear@claude-plugins-official" = false;
+
+    # =========================================================================
+    # Version Control & Code
+    # =========================================================================
+
+    # GitHub - repository management, issues, PRs
+    # Requires: GITHUB_PERSONAL_ACCESS_TOKEN env var
+    # Use gh CLI instead (more reliable)
+    "github@claude-plugins-official" = true;
+
+    # GitLab - repository management, issues, merge requests
+    # Requires: GitLab API token
+    "gitlab@claude-plugins-official" = false;
+
+    # Greptile - removed (2026-03-20): great product, not worth the cost for our use case
+    "greptile@claude-plugins-official" = false;
+
+    # =========================================================================
+    # Documentation & Context
+    # =========================================================================
+
+    # Context7 - up-to-date library documentation lookup
+    # Requires: CONTEXT7_API_KEY env var (optional, for higher rate limits)
+    "context7@claude-plugins-official" = true;
+
+    # =========================================================================
+    # Backend & Infrastructure
+    # =========================================================================
+
+    # Firebase - Google Firebase platform integration
+    # Requires: Firebase credentials
+    "firebase@claude-plugins-official" = false;
+
+    # Supabase - open source Firebase alternative
+    # Requires: Supabase API key
+    "supabase@claude-plugins-official" = false;
+
+    # Stripe - payment processing integration
+    # Requires: Stripe API key
+    "stripe@claude-plugins-official" = false;
+
+    # =========================================================================
+    # Testing & Automation
+    # =========================================================================
+
+    # Playwright - browser automation and testing
+    # Requires: Playwright installed
+    "playwright@claude-plugins-official" = true;
+
+    # =========================================================================
+    # Frameworks
+    # =========================================================================
+
+    # Laravel Boost - Laravel PHP framework integration
+    # Requires: Laravel project
+    "laravel-boost@claude-plugins-official" = false;
+
+    # =========================================================================
+    # Communication
+    # =========================================================================
+
+    # Slack - team communication integration
+    # Requires: Slack OAuth authentication
+    "slack@claude-plugins-official" = true;
+
+    # =========================================================================
+    # Other
+    # =========================================================================
+
+    # Serena - AI memory and context management
+    # Requires: Serena API key
+    "serena@claude-plugins-official" = false;
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/fabric.nix
+++ b/nix-ai-claude/modules/claude/plugins/fabric.nix
@@ -1,0 +1,16 @@
+# Claude Code Plugins - Fabric (Daniel Miessler)
+#
+# Curated subset of Fabric's 252+ AI prompt patterns wrapped as Claude Code
+# skills via a synthetic marketplace (see marketplace-overrides.nix
+# fabricMarketplace derivation).
+#
+# Pattern selection lives in modules/claude/fabric-curated-patterns.json.
+# Each pattern becomes a discoverable skill in Claude Code sessions.
+
+_:
+
+{
+  enabledPlugins = {
+    "fabric-patterns@fabric-patterns" = true;
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/infrastructure.nix
+++ b/nix-ai-claude/modules/claude/plugins/infrastructure.nix
@@ -1,0 +1,45 @@
+# Infrastructure & DevOps Plugins
+#
+# CRITICAL: Marketplace Names
+# ============================================================================
+# Plugins from multiple marketplaces - marketplace names match manifest values:
+#
+# 1. wshobson/agents → "@claude-code-workflows"
+#    Example: "cloud-infrastructure@claude-code-workflows"
+#    NOT "@agents" ✗
+#
+# 2. basher83/lunar-claude → "@lunar-claude"
+# 3. jeremylongshore/claude-code-plugins-plus → "@claude-code-plugins-plus"
+#
+# See docs/TESTING-MARKETPLACES.md for verification
+# ============================================================================
+#
+# Focused on: Terraform, Proxmox, Nix, Ansible
+
+_:
+
+{
+  enabledPlugins = {
+    # Proxmox (terraform-proxmox repo)
+    "proxmox-infrastructure@lunar-claude" = true;
+
+    # Ansible (user requested restore)
+    "ansible-workflows@lunar-claude" = true;
+
+    # Terraform (tf-splunk-aws, terraform-aws-static-website repos)
+    "infrastructure-as-code-generator@claude-code-plugins-plus" = true;
+    "terraform-module-builder@claude-code-plugins-plus" = true;
+
+    # CI/CD (GitHub Actions in repos)
+    "cicd-automation@claude-code-workflows" = true;
+
+    # REMOVED - not actively used:
+    # observability-monitoring - moved to development.nix (avoid duplication)
+    # cloud-infrastructure - too generic
+    # kubernetes-operations - no k8s repos
+    # deployment-strategies - too generic
+    # deployment-validation - too generic
+    # database-design - no database repos
+    # application-performance - too generic
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/marketplaces.nix
+++ b/nix-ai-claude/modules/claude/plugins/marketplaces.nix
@@ -1,0 +1,251 @@
+# Claude Code Plugin Marketplaces
+#
+# CRITICAL: Marketplace Keys MUST Match Manifest Names
+# ============================================================================
+# Each key MUST match the `name` field in the repo's .claude-plugin/marketplace.json
+#
+# Example:
+#   GitHub repo: anthropics/skills
+#   manifest name: "anthropic-agent-skills" (from marketplace.json)
+#   Nix key: "anthropic-agent-skills" ← MUST MATCH manifest name
+#   Plugin reference: "example-skills@anthropic-agent-skills"
+#
+# DO NOT use arbitrary keys like "skills" or GitHub paths like "anthropics/skills"
+#
+# Required fields per marketplace:
+#   - source.type: "github" (lowercase, always)
+#   - source.url: "owner/repo" format (GitHub path)
+#
+# How to find manifest names: See docs/TESTING-MARKETPLACES.md
+# ============================================================================
+#
+# IMPORTANT: Marketplace URL Format and Plugin References
+# ========================================================================
+# INPUT FORMAT (what we define here):
+#   type: "github"     (for GitHub repositories)
+#   url: "owner/repo"  (GitHub org/repo format, NOT full URL)
+#
+# OUTPUT FORMAT (after transformation via lib/claude-registry.nix):
+#   source: "github"
+#   repo: <value from source.url>  # The actual GitHub path for fetching
+#
+# MARKETPLACE DISPLAY NAMES:
+# - Standard: Key = "owner/repo", display name = repo (extracted by getMarketplaceName)
+# - Special: Some marketplaces use org-name as display (e.g., WakaTime uses "wakatime")
+# - Plugin references: "plugin-name@display-name" (e.g., "claude-code-wakatime@wakatime")
+#
+# SPECIAL CASES (key differs from owner/repo pattern):
+# - WakaTime: Key = "wakatime", URL = "wakatime/claude-code-wakatime"
+#   Official: claude plugin i claude-code-wakatime@wakatime
+# - When in doubt, check the official plugin install command
+#
+# WHY THIS WORKS:
+# - The toClaudeMarketplaceFormat function (lib/claude-registry.nix)
+#   converts both "github" and "git" types to "source: github"
+# - The source.url becomes the repo value in settings.json (for fetching)
+# - The KEY becomes the display name (for plugin references)
+# - This ensures Claude Code can locate and fetch the marketplace
+# ========================================================================
+#
+# WARNING: AGGREGATION MARKETPLACES TO AVOID
+# ============================================================================
+# DO NOT use "awesome-claude-code-plugins" (ccplugins/awesome-claude-code-plugins)
+# It is an AGGREGATION that copies plugins from other sources without regular updates.
+# Always find and use the TRUE SOURCE for plugins:
+#   - Plugins from claudecodecommands.directory → use "cc-marketplace"
+#   - Check plugin.json homepage/author fields to find original source
+# ============================================================================
+
+{
+  lib,
+  ...
+}:
+
+let
+  # Validate marketplace entry has correct nested structure
+  # Claude Code schema: { "id": { source: { type: "git", url: "..." } } }
+  validateMarketplace =
+    name: value:
+    assert lib.assertMsg (builtins.isAttrs value)
+      "Marketplace '${name}' must be an attrset, got ${builtins.typeOf value}";
+    assert lib.assertMsg (
+      value ? source && builtins.isAttrs value.source
+    ) "Marketplace '${name}' must have a 'source' attrset";
+    assert lib.assertMsg (
+      value.source ? type && builtins.isString value.source.type
+    ) "Marketplace '${name}.source' must have a 'type' string (git, github, local)";
+    assert lib.assertMsg (
+      value.source ? url && builtins.isString value.source.url
+    ) "Marketplace '${name}.source' must have a 'url' string";
+    true;
+
+  # ============================================================================
+  # Marketplace Definitions
+  # ============================================================================
+  # IMPORTANT: Keys MUST match the `name` field in each repo's marketplace.json
+  # This ensures plugin references like "plugin@marketplace" work correctly.
+  # See docs/CLAUDE-MARKETPLACE-ARCHITECTURE.md for details.
+  # ============================================================================
+  marketplaces = {
+    # --- Personal Plugins (listed first) ---
+    # User's custom Claude Code plugins - name matches manifest
+    "jacobpevans-cc-plugins" = {
+      source = {
+        type = "github";
+        url = "JacobPEvans/claude-code-plugins";
+      };
+    };
+
+    # --- Official Anthropic ---
+    "claude-plugins-official" = {
+      source = {
+        type = "github";
+        url = "anthropics/claude-plugins-official";
+      };
+    };
+    "anthropic-agent-skills" = {
+      source = {
+        type = "github";
+        url = "anthropics/skills";
+      };
+    };
+
+    # --- Community ---
+    "cc-marketplace" = {
+      source = {
+        type = "github";
+        url = "ananddtyagi/cc-marketplace";
+      };
+    };
+    "bills-claude-skills" = {
+      source = {
+        type = "github";
+        url = "BillChirico/bills-claude-skills";
+      };
+    };
+    "superpowers-marketplace" = {
+      source = {
+        type = "github";
+        url = "obra/superpowers-marketplace";
+      };
+    };
+
+    # --- Infrastructure & DevOps ---
+    "lunar-claude" = {
+      source = {
+        type = "github";
+        url = "basher83/lunar-claude";
+      };
+    };
+    "claude-code-plugins-plus" = {
+      source = {
+        type = "github";
+        url = "jeremylongshore/claude-code-plugins-plus";
+      };
+    };
+    "claude-code-workflows" = {
+      source = {
+        type = "github";
+        url = "wshobson/agents";
+      };
+    };
+
+    # --- Time Tracking ---
+    "wakatime" = {
+      source = {
+        type = "github";
+        url = "wakatime/claude-code-wakatime";
+      };
+    };
+
+    # --- Claude Skills Marketplace ---
+    "claude-skills" = {
+      source = {
+        type = "github";
+        url = "secondsky/claude-skills";
+      };
+    };
+
+    # --- Additional Community Marketplaces ---
+    # Multi-model AI integrations (OpenAI, Gemini) and notifications
+    "cc-dev-tools" = {
+      source = {
+        type = "github";
+        url = "Lucklyric/cc-dev-tools";
+      };
+    };
+
+    # --- Obsidian Skills ---
+    # Canonical Obsidian skills from kepano (markdown, bases, canvas, CLI, utilities)
+    "obsidian-skills" = {
+      source = {
+        type = "github";
+        url = "kepano/obsidian-skills";
+      };
+    };
+
+    # Independent visual diagram skills (Excalidraw, Mermaid, Canvas Creator)
+    "axton-obsidian-visual-skills" = {
+      source = {
+        type = "github";
+        url = "axtonliu/axton-obsidian-visual-skills";
+      };
+    };
+
+    # --- Visualization ---
+    # Rich HTML pages for diagrams, diff reviews, slides, data tables (nicobailon)
+    "visual-explainer-marketplace" = {
+      source = {
+        type = "github";
+        url = "nicobailon/visual-explainer";
+      };
+    };
+
+    # --- Official OpenAI ---
+    # OpenAI Codex plugin: code review, adversarial review, task delegation
+    "openai-codex" = {
+      source = {
+        type = "github";
+        url = "openai/codex-plugin-cc";
+      };
+    };
+
+    # --- Enterprise / Well-Known ---
+    # Bitwarden AI plugins: session retrospective, config validation, code review
+    "bitwarden-marketplace" = {
+      source = {
+        type = "github";
+        url = "bitwarden/ai-plugins";
+      };
+    };
+
+    # --- Synthetic Marketplaces (repos with skills but no marketplace structure) ---
+    # flakeInput for these is overridden in claude-config.nix with a derivation
+    # that wraps the raw skills into a proper .claude-plugin directory layout.
+    "browser-use-skills" = {
+      source = {
+        type = "github";
+        url = "browser-use/browser-use";
+      };
+    };
+
+    # Fabric patterns — Daniel Miessler's 252+ AI prompt patterns.
+    # The upstream repo has no .claude-plugin/ structure, so we wrap a curated
+    # subset into a synthetic marketplace (see fabricMarketplace in
+    # marketplace-overrides.nix). Patterns become individual Claude Code skills.
+    "fabric-patterns" = {
+      source = {
+        type = "github";
+        url = "danielmiessler/fabric";
+      };
+    };
+  };
+
+  # Validate all marketplaces at evaluation time
+  validatedMarketplaces = lib.mapAttrs validateMarketplace marketplaces;
+in
+# Force evaluation of validations
+assert lib.all (x: x) (lib.attrValues validatedMarketplaces);
+{
+  inherit marketplaces;
+}

--- a/nix-ai-claude/modules/claude/plugins/monitoring.nix
+++ b/nix-ai-claude/modules/claude/plugins/monitoring.nix
@@ -1,0 +1,16 @@
+# Time Tracking & Monitoring Plugins
+#
+# Plugins for productivity metrics and time tracking
+
+_:
+
+{
+  enabledPlugins = {
+    # ========================================================================
+    # WakaTime - Time Tracking
+    # ========================================================================
+    # Official install: claude plugin i claude-code-wakatime@wakatime
+    # Plugin: claude-code-wakatime | Marketplace: wakatime (org name, not repo name)
+    "claude-code-wakatime@wakatime" = true;
+  };
+}

--- a/nix-ai-claude/modules/claude/plugins/official.nix
+++ b/nix-ai-claude/modules/claude/plugins/official.nix
@@ -1,0 +1,60 @@
+# Official Anthropic Plugins
+#
+# CRITICAL: Plugin Reference Format
+# ============================================================================
+# Format: "plugin-name@marketplace-name"
+#
+# The marketplace-name MUST match the key in marketplaces.nix, which MUST
+# match the `name` field from the marketplace's .claude-plugin/marketplace.json
+#
+# Examples:
+#   - "commit-commands@claude-plugins-official" ✓ CORRECT
+#   - "example-skills@anthropic-agent-skills" ✓ CORRECT
+#   - "example-skills@skills" ✗ WRONG (marketplace is anthropic-agent-skills, not skills)
+#   - "backend-dev@agents" ✗ WRONG (marketplace is claude-code-workflows, not agents)
+#
+# How to verify: See docs/TESTING-MARKETPLACES.md
+# ============================================================================
+#
+# Minimal set for actual usage patterns based on JacobPEvans repos:
+# Terraform, Nix, Python, Splunk, Proxmox, Shell scripts
+
+_:
+
+{
+  enabledPlugins = {
+    # Anthropic Official Plugins - Document Skills (xlsx, docx, pptx, pdf)
+    "document-skills@anthropic-agent-skills" = true;
+
+    # Git Workflow (essential)
+    "commit-commands@claude-plugins-official" = true;
+
+    # Code Review (essential)
+    "code-review@claude-plugins-official" = true;
+    "pr-review-toolkit@claude-plugins-official" = true;
+
+    # Feature Development (useful)
+    "feature-dev@claude-plugins-official" = true;
+
+    # Security (useful for infra work)
+    "security-guidance@claude-plugins-official" = true;
+
+    # Plugin Development (user maintains claude-code-plugins repo)
+    "plugin-dev@claude-plugins-official" = true;
+    "hookify@claude-plugins-official" = true;
+
+    # Setup & Management
+    "claude-code-setup@claude-plugins-official" = true;
+    "claude-md-management@claude-plugins-official" = true;
+
+    # Language Servers & Developer Tools
+    "pyright-lsp@claude-plugins-official" = true;
+    "typescript-lsp@claude-plugins-official" = false; # Minimal TS usage
+
+    # Workflow
+    # DISABLED - New Opus 4.6 and Agent Teams sort of handle this
+    "ralph-loop@claude-plugins-official" = false;
+
+    # External plugins (GitHub, Slack, Context7, etc.) moved to external.nix
+  };
+}

--- a/nix-ai-claude/modules/claude/registry.nix
+++ b/nix-ai-claude/modules/claude/registry.nix
@@ -1,0 +1,40 @@
+# Claude Code Plugin Registry
+#
+# Marketplace discovery is handled via extraKnownMarketplaces in settings.json.
+# known_marketplaces.json is NOT Nix-managed - Claude Code owns it at runtime
+# to support auto-update and dynamic marketplace management via the TUI.
+#
+# Previously, this module generated known_marketplaces.json as a Nix store
+# symlink (read-only), which prevented Claude Code's "Enable auto-update"
+# feature from working (EACCES permission denied).
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+  homeDir = config.home.homeDirectory;
+in
+{
+  config = lib.mkIf cfg.enable {
+    # NOTE: known_marketplaces.json is NOT managed by Nix
+    # Claude Code creates and manages this file at runtime.
+    # Marketplace sources are declared via extraKnownMarketplaces in settings.json,
+    # which Claude Code uses to populate known_marketplaces.json on first run.
+
+    # NOTE: installed_plugins.json is NOT managed by Nix
+    # Claude Code auto-creates this file on first plugin installation.
+    # It's runtime state that Claude updates when plugins are installed/enabled.
+
+    # Migration: Remove stale Nix symlink if it exists
+    # After switching from Nix-managed to Claude-managed known_marketplaces.json,
+    # the old symlink to /nix/store/... must be removed so Claude Code can create
+    # a writable file in its place.
+    home.activation.cleanupMarketplacesSymlink = lib.hm.dag.entryBefore [ "linkGeneration" ] ''
+      MARKETPLACES="${homeDir}/.claude/plugins/known_marketplaces.json"
+      . ${./scripts/cleanup-marketplaces-symlink.sh}
+    '';
+  };
+}

--- a/nix-ai-claude/modules/claude/rules/pal-mcp-policy.md
+++ b/nix-ai-claude/modules/claude/rules/pal-mcp-policy.md
@@ -1,0 +1,96 @@
+---
+description: PAL MCP availability protocol — scoped to clink and consensus after Bifrost migration
+---
+
+# PAL MCP Policy
+
+PAL MCP hosts two tools with no native Claude Code or Bifrost equivalent:
+**`clink`** (parallel multi-model prompting) and **`consensus`** (multi-model
+voting/agreement). Every other PAL tool has a native replacement — single-model
+prompts go through the Bifrost AI gateway at `http://localhost:30080/v1`,
+architecture/planning work goes through Plan mode or the `Plan` subagent, etc.
+See the Phase 3 audit matrix on `JacobPEvans/nix-ai#450` for the full mapping.
+
+This policy **only applies to `clink` and `consensus`**. Never declare either
+unavailable without completing the investigation protocol below. Silently
+skipping a multi-model step because `ToolSearch` came back empty is the
+failure mode this rule exists to prevent.
+
+## Configuration
+
+- **DEFAULT_MODEL=auto**: PAL picks a model alias per-task; for single-model
+  work this flows through `CUSTOM_API_URL` → Bifrost → the right provider.
+  `clink`/`consensus` use their own multi-provider fan-out, not Bifrost.
+- **Secrets**: Local PAL subprocess secrets (API keys, config) are injected by
+  the `doppler-mcp` wrapper at launch time. This is separate from the Doppler
+  **K8s Operator** that syncs Bifrost's in-cluster provider keys — different
+  layer, don't conflate.
+- **Bifrost is not a replacement** for `clink`/`consensus` — Bifrost is a
+  single-request router, not a parallel orchestrator.
+
+## Availability Check Protocol (MANDATORY for clink/consensus)
+
+Three-step escalation. All three steps MUST be followed before declaring
+`clink` or `consensus` unavailable.
+
+### Step 1: ToolSearch (target the specific tool you need)
+
+Search directly for the tool you're about to use rather than relying on a
+generic `mcp__pal` prefix — PAL exposes ~18 tools and a low `max_results`
+will truncate the list before `consensus`/`clink` appear.
+
+```text
+ToolSearch("select:mcp__pal__clink", max_results=5)
+ToolSearch("select:mcp__pal__consensus", max_results=5)
+```
+
+If the target tool appears → proceed directly to using it.
+If not found → **DO NOT STOP. Go to Step 2.** (deferred tools may not be populated yet)
+
+### Step 2: Check server status
+
+```bash
+claude mcp list 2>/dev/null | grep "^pal:"
+```
+
+| Status | Action |
+| ------ | ------ |
+| `✓ Connected` | ToolSearch again for whichever tool is missing: `select:mcp__pal__clink` or `select:mcp__pal__consensus` |
+| `✗ Failed` | Go to Step 3 |
+| Not listed | Tell user: "PAL not registered. Run `check-pal-mcp` to diagnose." |
+
+### Step 3: Attempt reconnection
+
+```bash
+claude mcp remove pal -s user && claude mcp add pal -s user -- doppler-mcp pal-mcp-server
+```
+
+Wait 5s, re-check with `claude mcp list`.
+**CRITICAL**: Mid-session reconnected tools are invisible to ToolSearch.
+Tell user: "PAL reconnected but requires session restart to load tools."
+
+## NEVER-Do List
+
+- NEVER skip `clink`/`consensus` based on ToolSearch alone
+- NEVER declare either unavailable without completing all 3 steps
+- NEVER silently omit a multi-model phase because PAL looked absent
+- NEVER substitute Bifrost for `clink`/`consensus` — Bifrost cannot fan out
+  to multiple models in one request
+- NEVER suggest manual workarounds (e.g., sequential `chat` calls imitating
+  `consensus`) without first attempting the protocol above
+
+## Diagnostics
+
+If PAL fails after the protocol:
+
+1. `check-pal-mcp` — full health check (Doppler auth, secrets, MCP status)
+2. `cat ~/.local/state/doppler-mcp.log` — recent invocation log
+3. `doppler me` — verify Doppler authentication
+
+## See also
+
+- **Bifrost health**: `curl http://localhost:30080/health`
+- **Bifrost model catalog**: `curl http://localhost:30080/v1/models`
+- **Bifrost MCP registration**: `bifrost` block in `modules/mcp/default.nix`
+- **Phase 3 audit matrix** (full PAL → native mapping):
+  [JacobPEvans/nix-ai#450](https://github.com/JacobPEvans/nix-ai/issues/450)

--- a/nix-ai-claude/modules/claude/rules/retrospective-report-location.md
+++ b/nix-ai-claude/modules/claude/rules/retrospective-report-location.md
@@ -1,0 +1,17 @@
+---
+name: retrospective-report-location
+description: This rule should be applied when using the claude-retrospective plugin's "retrospecting" skill, running "/retrospecting", or generating retrospective reports. Overrides the default per-project report output path to use a centralized location.
+alwaysApply: false
+globs:
+  - "**/retrospecting/**"
+  - "**/.claude/skills/retrospecting/**"
+---
+
+# Retrospective Report Location
+
+When using the claude-retrospective plugin's `retrospecting` skill, always write
+retrospective reports to `~/.claude/skills/retrospecting/reports/` instead of
+`${CLAUDE_PROJECT_DIR}/.claude/skills/retrospecting/reports/`.
+
+This ensures reports are centralized across all projects rather than scattered
+in each project's `.claude/` directory.

--- a/nix-ai-claude/modules/claude/scripts/claude-json-merge.sh
+++ b/nix-ai-claude/modules/claude/scripts/claude-json-merge.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Deep-merge a Nix-generated JSON overlay into ~/.claude.json.
+# Sourced from settings.nix activation with OVERLAY_FILE and TRUSTED_PROJECT_DIRS set.
+# Requires: OVERLAY_FILE, TRUSTED_PROJECT_DIRS (JSON array of dirs), DRY_RUN_CMD, jq on PATH.
+#
+# Merge strategy:
+# - Top-level keys from overlay replace existing values (mcpServers, remoteControlAtStartup)
+# - .projects entries are deep-merged: overlay values merge INTO existing project entries
+#   (preserving runtime-managed keys like allowedTools, mcpServers per-project, etc.)
+# - Trust entries are generated at activation time by scanning TRUSTED_PROJECT_DIRS,
+#   since filesystem discovery cannot happen at Nix evaluation time in pure flake mode.
+
+CLAUDE_JSON="$HOME/.claude.json"
+
+# Build project trust entries by scanning each trusted base dir for repo subdirs.
+# Each "$baseDir/$repo/main" path gets hasClaudeMdExternalIncludesApproved = true.
+_build_trust_overlay() {
+  local dirs_json="$1"
+  local trust_entry='{"hasClaudeMdExternalIncludesApproved":true,"hasClaudeMdExternalIncludesWarningShown":true,"hasTrustDialogAccepted":true}'
+  local paths=()
+
+  while IFS= read -r base_dir; do
+    base_dir="${base_dir/#\~/$HOME}"
+    [ -d "$base_dir" ] || continue
+    while IFS= read -r repo_dir; do
+      local repo_name
+      repo_name=$(basename "$repo_dir")
+      # Skip hidden dirs and non-repo-looking entries
+      [[ "$repo_name" == .* ]] && continue
+      local path="${repo_dir}/main"
+      [ -d "$path" ] || continue
+      paths+=("$path")
+    done < <(find "$base_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+  done < <(jq -r '.[]' <<<"$dirs_json" 2>/dev/null)
+
+  if [ ${#paths[@]} -eq 0 ]; then
+    echo '{}'
+    return
+  fi
+
+  # Build entire trust object in one jq call instead of one per path
+  printf '%s\n' "${paths[@]}" | jq -Rs --argjson trust "$trust_entry" '
+    split("\n") | map(select(length > 0)) | map({(.): $trust}) | add // {}
+  '
+}
+
+# Atomically write jq output to CLAUDE_JSON via a temp file.
+# Usage: _jq_to_file <warning-msg> [jq args...]
+_jq_to_file() {
+  local msg="$1"; shift
+  local tmp
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' EXIT
+  if jq "$@" > "$tmp"; then
+    $DRY_RUN_CMD mv "$tmp" "$CLAUDE_JSON"
+    trap - EXIT
+  else
+    echo "warning: $msg" >&2
+    rm -f "$tmp"
+  fi
+}
+
+trust_projects=$(_build_trust_overlay "$TRUSTED_PROJECT_DIRS")
+
+if [ -f "$CLAUDE_JSON" ]; then
+  _jq_to_file \
+    "Failed to update \"$CLAUDE_JSON\"; existing file may contain invalid JSON. Fix or remove it to apply settings." \
+    -s --argjson trust "$trust_projects" \
+    '
+      .[0] as $existing | .[1] as $overlay |
+      # Replace top-level keys from overlay (mcpServers etc.), deep-merge .projects.
+      ($existing + ($overlay | del(.projects))) | .projects = (($existing.projects // {}) * ($overlay.projects // {}) * $trust)
+    ' "$CLAUDE_JSON" "$OVERLAY_FILE"
+else
+  _jq_to_file \
+    "Failed to create \"$CLAUDE_JSON\" from overlay; jq returned an error." \
+    --argjson trust "$trust_projects" \
+    '. + {projects: $trust}' "$OVERLAY_FILE"
+fi
+
+[ -f "$CLAUDE_JSON" ] && $DRY_RUN_CMD chmod 600 "$CLAUDE_JSON"

--- a/nix-ai-claude/modules/claude/scripts/cleanup-broken-symlinks.sh
+++ b/nix-ai-claude/modules/claude/scripts/cleanup-broken-symlinks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Remove broken symlinks (target does not exist) inside component directories.
+# Usage (sourced): . this-script type1 dir1 type2 dir2 ...
+# Requires: DRY_RUN_CMD from activation scope.
+
+# Requires: log_info, log_warn from cleanup-common.sh (sourced by caller)
+
+while [ $# -ge 2 ]; do
+  type_name="$1"
+  dir="$2"
+  shift 2
+  if [ -d "$dir" ]; then
+    find "$dir" -maxdepth 1 -type l -print0 | while IFS= read -d $'\0' -r link; do
+      if [ ! -e "$link" ]; then
+        if $DRY_RUN_CMD rm "$link"; then
+          log_info "Removed orphan ${type_name}: $(basename "$link")"
+        else
+          log_warn "Failed to remove orphan ${type_name}: $(basename "$link")"
+        fi
+      fi
+    done
+  fi
+done

--- a/nix-ai-claude/modules/claude/scripts/cleanup-common.sh
+++ b/nix-ai-claude/modules/claude/scripts/cleanup-common.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Shared logging functions for cleanup scripts.
+# Sourced by cleanup-*.sh scripts.
+
+log_info() { echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] $1" >&2; }
+log_warn() { echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] $1" >&2; }

--- a/nix-ai-claude/modules/claude/scripts/cleanup-conflicting-symlinks.sh
+++ b/nix-ai-claude/modules/claude/scripts/cleanup-conflicting-symlinks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Remove entries that conflict with home-manager's link generation.
+# Handles both directory symlinks (normal case) and real directories
+# (one-time migration from recursive=true to directory symlinks).
+# Usage (sourced): . this-script dir1 dir2 ...
+# Requires: DRY_RUN_CMD from activation scope.
+
+# Requires: log_info, log_warn from cleanup-common.sh (sourced by caller)
+
+for dir in "$@"; do
+  if [ -L "$dir" ]; then
+    TARGET=$(readlink "$dir")
+    if [[ "$TARGET" == /nix/store/* ]]; then
+      if $DRY_RUN_CMD rm "$dir"; then
+        log_info "Removed conflicting directory symlink: $dir"
+        log_info "  (was: $TARGET)"
+      else
+        log_warn "Failed to remove directory symlink: $dir"
+      fi
+    fi
+  elif [ -d "$dir" ]; then
+    # Real directory left over from old recursive=true setup.
+    # Only remove if under the marketplaces path — component dirs (commands, agents,
+    # skills) may contain user-created content and must never be rm -rf'd.
+    case "$dir" in
+      */.claude/plugins/marketplaces/*)
+        if $DRY_RUN_CMD rm -rf "$dir"; then
+          log_info "Removed real directory (migration to directory symlink): $dir"
+        else
+          log_warn "Failed to remove real directory: $dir"
+        fi
+        ;;
+      *)
+        log_warn "Skipping rm -rf for non-marketplace directory: $dir"
+        ;;
+    esac
+  fi
+done

--- a/nix-ai-claude/modules/claude/scripts/cleanup-marketplaces-symlink.sh
+++ b/nix-ai-claude/modules/claude/scripts/cleanup-marketplaces-symlink.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Remove stale Nix-managed symlink for known_marketplaces.json.
+# Sourced from registry.nix activation with MARKETPLACES set in environment.
+
+if [ -L "$MARKETPLACES" ]; then
+  if $DRY_RUN_CMD rm "$MARKETPLACES"; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removed Nix-managed symlink for known_marketplaces.json (now Claude-managed)"
+  else
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to remove Nix symlink at $MARKETPLACES (non-critical)" >&2
+  fi
+fi

--- a/nix-ai-claude/modules/claude/scripts/cleanup-stale-symlinks.sh
+++ b/nix-ai-claude/modules/claude/scripts/cleanup-stale-symlinks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Remove stale nix-store symlinks (target is in /nix/store AND no longer exists).
+# Usage (sourced): . this-script path1 path2 ...
+# Requires: DRY_RUN_CMD from activation scope.
+
+# Requires: log_info, log_warn from cleanup-common.sh (sourced by caller)
+
+for path in "$@"; do
+  if [ -L "$path" ]; then
+    TARGET=$(readlink "$path")
+    if [[ "$TARGET" == /nix/store/* ]] && [ ! -e "$TARGET" ]; then
+      if $DRY_RUN_CMD rm "$path"; then
+        log_info "Removed stale symlink: $path"
+      else
+        log_warn "Failed to remove stale symlink: $path"
+      fi
+    fi
+  fi
+done

--- a/nix-ai-claude/modules/claude/scripts/verify-cache-integrity.sh
+++ b/nix-ai-claude/modules/claude/scripts/verify-cache-integrity.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Verify Claude Code plugin cache integrity after Nix rebuilds
+# Removes stale cache entries when marketplace store paths change
+#
+# When Nix updates marketplace symlinks to new /nix/store paths,
+# Claude Code's cached plugin data becomes stale and must be purged.
+# See: https://github.com/anthropics/claude-code/issues/17361
+
+set -euo pipefail
+
+# Centralized logging function (stderr for diagnostics)
+log_info() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] $1" >&2
+}
+
+HOME_DIR="${1:?Usage: verify-cache-integrity.sh <home-dir>}"
+MARKETPLACES_DIR="$HOME_DIR/.claude/plugins/marketplaces"
+CACHE_DIR="$HOME_DIR/.claude/plugins/cache"
+HASH_FILE="$CACHE_DIR/.nix-store-hashes"
+
+# Resolve the SHA-256 hasher once at startup into _SHA_CMD.
+# Prefer shasum from PATH (present on macOS and installable cross-platform),
+# fall back to the macOS system copy, then sha256sum (Linux coreutils).
+# sha256sum does not accept -a 256, so wrap the call to normalise the interface.
+# NOTE: _SHA_CMD must persist — sha256_string references it at call time, not
+# definition time. Using a temporary that gets unset causes "unbound variable"
+# under set -u, silently breaking cache integrity on every darwin-rebuild switch.
+if _SHA_CMD=$(command -v shasum 2>/dev/null) || { [ -x /usr/bin/shasum ] && _SHA_CMD=/usr/bin/shasum; }; then
+  sha256_string() { "$_SHA_CMD" -a 256; }
+elif _SHA_CMD=$(command -v sha256sum 2>/dev/null); then
+  sha256_string() { "$_SHA_CMD"; }
+else
+  echo "error: no shasum or sha256sum found" >&2
+  exit 1
+fi
+
+# Only run if both dirs exist
+[[ -d "$MARKETPLACES_DIR" ]] || exit 0
+[[ -d "$CACHE_DIR" ]] || exit 0
+
+# Load existing hashes
+declare -A old_hashes
+if [[ -f "$HASH_FILE" ]]; then
+  while IFS='=' read -r key value; do
+    [[ -n "$key" ]] && old_hashes["$key"]="$value"
+  done < "$HASH_FILE"
+fi
+
+# Build new hashes and detect staleness
+# Marketplaces are directory symlinks to /nix/store/ (plugins.nix without recursive)
+declare -A new_hashes
+stale_detected=false
+while IFS= read -r -d '' entry; do
+  name=$(basename "$entry")
+
+  # Directory symlink: target is the nix store path itself
+  target=$(readlink "$entry")
+  [[ "$target" == /nix/store/* ]] || continue
+
+  # Hash the store path string (not file contents - that's what matters for staleness)
+  hash=$(printf '%s' "$target" | sha256_string | cut -d' ' -f1)
+  new_hashes["$name"]="$hash"
+
+  if [[ "${old_hashes[$name]:-}" != "$hash" ]]; then
+    stale_detected=true
+  fi
+done < <(find "$MARKETPLACES_DIR" -mindepth 1 -maxdepth 1 -type l -print0)
+
+# Session-aware guard: if caches are stale but Claude Code is running, defer the
+# purge to avoid breaking active sessions. Hook scripts inside cache directories are
+# resolved at session start — deleting them mid-session causes an unbreakable error
+# loop (every hook fails, including Stop). By also skipping the hash file update,
+# the next rebuild will re-detect staleness and purge when no sessions are active.
+if [[ "$stale_detected" == true ]] && pgrep -qx "claude"; then
+  log_info "Stale caches detected but Claude Code session is active — deferring purge"
+  exit 0
+fi
+
+# Purge stale caches (safe — no active sessions)
+for name in "${!new_hashes[@]}"; do
+  if [[ "${old_hashes[$name]:-}" != "${new_hashes[$name]}" ]]; then
+    if [[ -d "$CACHE_DIR/$name" ]]; then
+      rm -rf "${CACHE_DIR:?}/$name"
+      log_info "Purged stale cache: $name"
+    fi
+  fi
+done
+
+# Write updated hashes atomically to avoid leaving a partially written file
+mkdir -p "$CACHE_DIR"
+tmp_hash_file="$(mktemp "${HASH_FILE}.XXXXXX")"
+for name in "${!new_hashes[@]}"; do
+  echo "${name}=${new_hashes[$name]}" >> "$tmp_hash_file"
+done
+mv "$tmp_hash_file" "$HASH_FILE"

--- a/nix-ai-claude/modules/claude/settings.nix
+++ b/nix-ai-claude/modules/claude/settings.nix
@@ -1,0 +1,291 @@
+# Claude Code Settings
+#
+# Manages ~/.claude/settings.json via activation-time merge (not home.file symlink).
+# Merges plugin marketplaces, permissions, hooks, etc.
+#
+# NOTE: Uses toClaudeMarketplaceFormat from lib/claude-registry.nix as
+# SINGLE SOURCE OF TRUTH for marketplace format transformation.
+#
+# VALIDATION: Environment variable names are validated at build time against
+# POSIX convention (^[A-Z_][A-Z0-9_]*$). Full JSON Schema validation against
+# https://json.schemastore.org/claude-code-settings.json is available via
+# `nix flake check` but requires network access.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claude;
+  homeDir = config.home.homeDirectory;
+
+  # Import the single source of truth for marketplace formatting
+  claudeRegistry = import ../../lib/claude-registry.nix { inherit lib; }; # lastUpdated not needed here
+  inherit (claudeRegistry) toClaudeMarketplaceFormat;
+
+  # Build the env attribute (merge user env vars with API_KEY_HELPER if enabled)
+  # Environment variable names must match POSIX convention: ^[A-Z_][A-Z0-9_]*$
+  envAttrs =
+    cfg.settings.env
+    // lib.optionalAttrs cfg.apiKeyHelper.enable {
+      API_KEY_HELPER = "${homeDir}/${cfg.apiKeyHelper.scriptPath}";
+    };
+
+  # Validate POSIX environment variable names
+  # POSIX requires: starts with letter or underscore, followed by letters, digits, or underscores
+  # We enforce uppercase for convention: ^[A-Z_][A-Z0-9_]*$
+  isValidEnvVarName = name: builtins.match "^[A-Z_][A-Z0-9_]*$" name != null;
+  invalidEnvVars = lib.filterAttrs (name: _: !isValidEnvVarName name) envAttrs;
+
+  # Build Claude Code JSON for enabled (non-disabled) MCP servers.
+  # Stdio servers: { command, args, env? }
+  # SSE/HTTP servers: { type, url, headers? }
+  activeMcpServers = lib.filterAttrs (_: v: !v.disabled) cfg.mcpServers;
+  mcpServersAttrs = lib.mapAttrs (
+    _: v:
+    if v.type == "stdio" then
+      { inherit (v) command args; } // lib.optionalAttrs (v.env != { }) { inherit (v) env; }
+    else
+      { inherit (v) type url; } // lib.optionalAttrs (v.headers != { }) { inherit (v) headers; }
+  ) activeMcpServers;
+
+  # Static JSON overlay — keys merged into ~/.claude.json at activation time.
+  # - mcpServers: Nix is sole manager; manual `claude mcp add --scope user` entries are overwritten.
+  # - remoteControlAtStartup: only included when set (not null).
+  # Project trust entries are generated at activation time by claude-json-merge.sh
+  # (filesystem discovery cannot happen at Nix evaluation time in pure flake mode).
+  claudeJsonOverlay = {
+    mcpServers = mcpServersAttrs;
+  }
+  // lib.optionalAttrs (cfg.remoteControlAtStartup != null) {
+    inherit (cfg) remoteControlAtStartup;
+  };
+
+  # Build the overlay as a pretty-printed JSON derivation
+  claudeJsonOverlayFile =
+    pkgs.runCommand "claude-json-overlay.json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+        passAsFile = [ "json" ];
+        json = builtins.toJSON claudeJsonOverlay;
+      }
+      ''
+        jq '.' "$jsonPath" > $out
+      '';
+
+  # Build the settings object
+  settings = {
+    "$schema" = cfg.settings.schemaUrl;
+    inherit (cfg.settings) alwaysThinkingEnabled cleanupPeriodDays;
+    inherit (cfg)
+      autoUpdatesChannel
+      teammateMode
+      showTurnDuration
+      ;
+  }
+  // lib.optionalAttrs (cfg.effortLevel != null) { inherit (cfg) effortLevel; }
+  // lib.optionalAttrs (cfg.attribution != { }) { inherit (cfg) attribution; }
+  // {
+
+    # Permissions
+    permissions = {
+      inherit (cfg.settings.permissions) allow deny ask;
+      inherit (cfg.settings) additionalDirectories;
+    };
+
+    # Plugin configuration
+    # Uses toClaudeMarketplaceFormat (single source of truth from lib/claude-registry.nix)
+    extraKnownMarketplaces = lib.mapAttrs toClaudeMarketplaceFormat cfg.plugins.marketplaces;
+
+    enabledPlugins = cfg.plugins.enabled;
+
+    # Environment variables (user-defined + apiKeyHelper if enabled)
+  }
+  // lib.optionalAttrs (cfg.model != null) { inherit (cfg) model; }
+  // lib.optionalAttrs (cfg.remoteControlAtStartup != null) { inherit (cfg) remoteControlAtStartup; }
+  // lib.optionalAttrs (envAttrs != { }) { env = envAttrs; }
+
+  # Status line (only include if script is configured)
+  # Do NOT include empty statusLine object (breaks Claude Code schema)
+  // lib.optionalAttrs (cfg.statusLine.enable && cfg.statusLine.script != null) {
+    statusLine = {
+      type = "command";
+      command = "${homeDir}/.claude/statusline-command.sh";
+    };
+  }
+
+  # Sandbox configuration (Dec 2025 feature)
+  # Only include when sandbox is actually enabled to avoid confusing disabled state with configuration
+  // lib.optionalAttrs cfg.settings.sandbox.enabled {
+    sandbox = {
+      inherit (cfg.settings.sandbox) enabled autoAllowBashIfSandboxed;
+    }
+    // lib.optionalAttrs (cfg.settings.sandbox.excludedCommands != [ ]) {
+      inherit (cfg.settings.sandbox) excludedCommands;
+    };
+  };
+
+  # Synthetic marketplaces need entries in known_marketplaces.json (Claude Code's actual registry).
+  # Claude Code populates this file by fetching from GitHub sources in extraKnownMarketplaces,
+  # but synthetic marketplaces fail the fetch (upstream has no .claude-plugin structure).
+  # This overlay ensures the local installLocation is registered so Claude Code reads from disk.
+  syntheticMarketplaces = lib.filterAttrs (_: m: m.flakeInput != null) cfg.plugins.marketplaces;
+  knownMarketplacesOverlay = lib.mapAttrs (
+    name: m:
+    let
+      formatted = toClaudeMarketplaceFormat name m;
+      marketplaceName = lib.last (lib.splitString "/" name);
+    in
+    {
+      inherit (formatted) source;
+      installLocation = "${homeDir}/.claude/plugins/marketplaces/${marketplaceName}";
+      lastUpdated = "1970-01-01T00:00:00.000Z";
+    }
+  ) syntheticMarketplaces;
+
+  knownMarketplacesJson =
+    pkgs.runCommand "known-marketplaces-overlay.json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+        passAsFile = [ "json" ];
+        json = builtins.toJSON knownMarketplacesOverlay;
+      }
+      ''
+        jq '.' "$jsonPath" > $out
+      '';
+
+  # Pretty-print JSON
+  settingsJson =
+    pkgs.runCommand "claude-settings.json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+        passAsFile = [ "json" ];
+        json = builtins.toJSON settings;
+      }
+      ''
+        jq '.' "$jsonPath" > $out
+      '';
+
+  # Status line script (if configured)
+  statusLineScript = lib.optionalAttrs (cfg.statusLine.enable && cfg.statusLine.script != null) {
+    ".claude/statusline-command.sh" = {
+      text = cfg.statusLine.script;
+      executable = true;
+    };
+  };
+
+  # Hook scripts generator
+  # Converts hook options to executable scripts in ~/.claude/hooks/
+  hookFiles =
+    let
+      # Map of hook names to their filenames
+      hookMapping = {
+        preToolUse = "pre-tool-use.sh";
+        postToolUse = "post-tool-use.sh";
+        userPromptSubmit = "user-prompt-submit.sh";
+        stop = "stop.sh";
+        subagentStop = "subagent-stop.sh";
+        sessionStart = "session-start.sh";
+        sessionEnd = "session-end.sh";
+      };
+
+      # Generate a single hook file attribute
+      mkHookFile =
+        _hookName: fileName: hookValue:
+        if hookValue == null then
+          { }
+        else if builtins.isPath hookValue then
+          {
+            ".claude/hooks/${fileName}" = {
+              source = hookValue;
+              executable = true;
+            };
+          }
+        else
+          {
+            ".claude/hooks/${fileName}" = {
+              text = hookValue;
+              executable = true;
+            };
+          };
+
+      # Generate all hook files
+      allHookFiles = lib.mapAttrs' (
+        hookName: fileName: lib.nameValuePair hookName (mkHookFile hookName fileName cfg.hooks.${hookName})
+      ) hookMapping;
+
+      # Merge all non-null hook files into a single attrset
+      # Note: lib.mkMerge is for option values, not attrsets. Use foldl' for regular merging.
+      mergedHookFiles = lib.foldl' (a: b: a // b) { } (builtins.attrValues allHookFiles);
+    in
+    mergedHookFiles;
+
+in
+{
+  config = lib.mkIf cfg.enable {
+    # Merge runtime keys into ~/.claude.json (global config) at activation time.
+    # These keys live in the global config file, not settings.json, so home.file cannot be
+    # used directly (the file is runtime-mutable). One unified script deep-merges all keys.
+    home.activation = {
+      claudeJsonMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        export PATH="${pkgs.jq}/bin:$PATH"
+        OVERLAY_FILE="${claudeJsonOverlayFile}"
+        TRUSTED_PROJECT_DIRS=${lib.escapeShellArg (builtins.toJSON cfg.trustedProjectDirs)}
+        . ${./scripts/claude-json-merge.sh}
+      '';
+
+      claudeSettingsMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        export PATH="${pkgs.jq}/bin:$PATH"
+        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+          "${settingsJson}" \
+          "${homeDir}/.claude/settings.json"
+      '';
+
+      # Ensure Nix-managed marketplaces are in known_marketplaces.json (Claude Code's actual registry).
+      # Claude Code populates this by fetching from GitHub, but synthetic marketplaces (repos without
+      # .claude-plugin structure) fail the fetch. This merge ensures the local installLocation is
+      # registered so Claude Code reads the synthetic marketplace from the Nix-managed symlink.
+      knownMarketplacesMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        export PATH="${pkgs.jq}/bin:$PATH"
+        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+          "${knownMarketplacesJson}" \
+          "${homeDir}/.claude/plugins/known_marketplaces.json"
+      '';
+    };
+
+    # Validate configuration before generating settings.json
+    assertions = [
+      {
+        assertion = invalidEnvVars == { };
+        message = ''
+          Invalid environment variable names in programs.claude.settings.env:
+            ${lib.concatStringsSep ", " (builtins.attrNames invalidEnvVars)}
+
+          Environment variable names must match POSIX convention: ^[A-Z_][A-Z0-9_]*$
+          (uppercase letters, digits, and underscores only; must start with letter or underscore)
+        '';
+      }
+      {
+        assertion = lib.all (v: v.type != "stdio" || v.command != null) (
+          builtins.attrValues cfg.mcpServers
+        );
+        message = ''
+          MCP servers with type "stdio" must have a command set.
+          Check programs.claude.mcpServers for entries with type = "stdio" and command = null.
+        '';
+      }
+      {
+        assertion = lib.all (v: v.type == "stdio" || v.url != null) (builtins.attrValues cfg.mcpServers);
+        message = ''
+          MCP servers with type "sse" or "http" must have a url set.
+          Check programs.claude.mcpServers for entries with type = "sse"/"http" and url = null.
+        '';
+      }
+    ];
+
+    home.file = { } // statusLineScript // hookFiles;
+
+  };
+}

--- a/nix-ai-claude/modules/claude/statusline/claude-powerline.json
+++ b/nix-ai-claude/modules/claude/statusline/claude-powerline.json
@@ -1,0 +1,64 @@
+{
+  "theme": "rose-pine",
+  "style": "capsule",
+  "charset": "unicode",
+  "autoWrap": false,
+  "display": {
+    "lines": [
+      {
+        "segments": {
+          "git": {
+            "enabled": true,
+            "showRepoName": true,
+            "showWorktree": true,
+            "showBranch": true,
+            "showBehind": false,
+            "showClean": false,
+            "showChanges": false,
+            "showSha": false,
+            "showUpstream": false,
+            "showStash": false
+          },
+          "directory": { "enabled": true, "style": "fish" }
+        }
+      },
+      {
+        "segments": {
+          "git": {
+            "enabled": true,
+            "showRepoName": false,
+            "showWorktree": false,
+            "showBranch": false,
+            "showBehind": true,
+            "showClean": true,
+            "showChanges": true,
+            "showSha": false,
+            "showUpstream": false,
+            "showStash": false
+          },
+          "model": { "enabled": true },
+          "context": { "enabled": true, "showPercentageOnly": false },
+          "metrics": {
+            "enabled": true,
+            "showResponseTime": false,
+            "showLastResponseTime": true,
+            "showDuration": true,
+            "showMessageCount": true,
+            "showLinesAdded": true,
+            "showLinesRemoved": true
+          }
+        }
+      },
+      {
+        "segments": {
+          "block": { "enabled": true, "type": "time" },
+          "session": { "enabled": true, "type": "cost", "costSource": "official" },
+          "today": { "enabled": true, "type": "breakdown" }
+        }
+      }
+    ]
+  },
+  "budget": {
+    "today": { "amount": 200, "warningThreshold": 80 }
+  }
+}

--- a/nix-ai-claude/modules/claude/statusline/claude-statusline.sh
+++ b/nix-ai-claude/modules/claude/statusline/claude-statusline.sh
@@ -1,0 +1,323 @@
+#!/bin/bash
+# Based on ClaudeCodeStatusLine by daniel3303
+# https://github.com/daniel3303/ClaudeCodeStatusLine
+# Modified: Show last 2 path components for cwd instead of basename
+# Single line: Model | cwd@branch (diff) | used/total (pct-used) | effort | 5h usage % @reset | 7d usage % @reset | extra
+
+set -f  # disable globbing
+
+input=$(cat)
+
+if [ -z "$input" ]; then
+    printf "Claude"
+    exit 0
+fi
+
+# ANSI colors matching oh-my-posh theme
+blue='\033[38;2;0;153;255m'
+orange='\033[38;2;255;176;85m'
+green='\033[38;2;0;160;0m'
+cyan='\033[38;2;46;149;153m'
+red='\033[38;2;255;85;85m'
+yellow='\033[38;2;230;200;0m'
+white='\033[38;2;220;220;220m'
+dim='\033[2m'
+reset='\033[0m'
+
+# Format token counts (e.g., 50k / 200k)
+format_tokens() {
+    local num=$1
+    if [ "$num" -ge 1000000 ]; then
+        awk "BEGIN {printf \"%.1fm\", $num / 1000000}"
+    elif [ "$num" -ge 1000 ]; then
+        awk "BEGIN {printf \"%.0fk\", $num / 1000}"
+    else
+        printf "%d" "$num"
+    fi
+}
+
+# Format number with commas (e.g., 134,938)
+format_commas() {
+    printf "%'d" "$1"
+}
+
+# Return color escape based on usage percentage
+# Usage: usage_color <pct>
+usage_color() {
+    local pct=$1
+    if [ "$pct" -ge 90 ]; then echo "$red"
+    elif [ "$pct" -ge 70 ]; then echo "$orange"
+    elif [ "$pct" -ge 50 ]; then echo "$yellow"
+    else echo "$green"
+    fi
+}
+
+# ===== Extract data from JSON =====
+model_name=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+
+# Context window
+size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+[ "$size" -eq 0 ] 2>/dev/null && size=200000
+
+# Token usage
+input_tokens=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
+cache_create=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+cache_read=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+current=$(( input_tokens + cache_create + cache_read ))
+
+used_tokens=$(format_tokens $current)
+total_tokens=$(format_tokens $size)
+
+if [ "$size" -gt 0 ]; then
+    pct_used=$(( current * 100 / size ))
+else
+    pct_used=0
+fi
+# Check reasoning effort
+settings_path="$HOME/.claude/settings.json"
+effort_level="medium"
+if [ -n "$CLAUDE_CODE_EFFORT_LEVEL" ]; then
+    effort_level="$CLAUDE_CODE_EFFORT_LEVEL"
+elif [ -f "$settings_path" ]; then
+    effort_val=$(jq -r '.effortLevel // empty' "$settings_path" 2>/dev/null)
+    [ -n "$effort_val" ] && effort_level="$effort_val"
+fi
+
+# ===== Build single-line output =====
+out=""
+out+="${blue}${model_name}${reset}"
+
+# Current working directory
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+if [ -n "$cwd" ]; then
+    # Show last 2 path components (e.g., nix-ai/main) instead of just basename
+    display_dir="$(basename "$(dirname "$cwd")")/$(basename "$cwd")"
+    git_branch=$(git -C "${cwd}" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    out+=" ${dim}|${reset} "
+    out+="${cyan}${display_dir}${reset}"
+    if [ -n "$git_branch" ]; then
+        out+="${dim}@${reset}${green}${git_branch}${reset}"
+        git_stat=$(git -C "${cwd}" diff --numstat 2>/dev/null | awk '{a+=$1; d+=$2} END {if (a+d>0) printf "+%d -%d", a, d}')
+        [ -n "$git_stat" ] && out+=" ${dim}(${reset}${green}${git_stat%% *}${reset} ${red}${git_stat##* }${reset}${dim})${reset}"
+    fi
+fi
+
+out+=" ${dim}|${reset} "
+out+="${orange}${used_tokens}/${total_tokens}${reset} ${dim}(${reset}${green}${pct_used}%${reset}${dim})${reset}"
+out+=" ${dim}|${reset} "
+out+="effort: "
+case "$effort_level" in
+    low)    out+="${dim}low${reset}" ;;
+    medium) out+="${orange}med${reset}" ;;
+    *)      out+="${green}high${reset}" ;;
+esac
+
+# ===== Cross-platform OAuth token resolution (from statusline.sh) =====
+# Tries credential sources in order: env var → macOS Keychain → Linux creds file → GNOME Keyring
+get_oauth_token() {
+    local token=""
+
+    # 1. Explicit env var override
+    if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+        echo "$CLAUDE_CODE_OAUTH_TOKEN"
+        return 0
+    fi
+
+    # 2. macOS Keychain
+    if command -v security >/dev/null 2>&1; then
+        local blob
+        blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+        if [ -n "$blob" ]; then
+            token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            if [ -n "$token" ] && [ "$token" != "null" ]; then
+                echo "$token"
+                return 0
+            fi
+        fi
+    fi
+
+    # 3. Linux credentials file
+    local creds_file="${HOME}/.claude/.credentials.json"
+    if [ -f "$creds_file" ]; then
+        token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            echo "$token"
+            return 0
+        fi
+    fi
+
+    # 4. GNOME Keyring via secret-tool
+    if command -v secret-tool >/dev/null 2>&1; then
+        local blob
+        blob=$(timeout 2 secret-tool lookup service "Claude Code-credentials" 2>/dev/null)
+        if [ -n "$blob" ]; then
+            token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            if [ -n "$token" ] && [ "$token" != "null" ]; then
+                echo "$token"
+                return 0
+            fi
+        fi
+    fi
+
+    echo ""
+}
+
+# ===== LINE 2 & 3: Usage limits with progress bars (cached) =====
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/claude"
+cache_file="$cache_dir/statusline-usage-cache.json"
+cache_max_age=60  # seconds between API calls
+mkdir -p "$cache_dir"
+chmod 700 "$cache_dir"
+
+needs_refresh=true
+usage_data=""
+
+# Check cache — shared across all Claude Code instances to avoid rate limits
+if [ -f "$cache_file" ]; then
+    cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)
+    now=$(date +%s)
+    cache_age=$(( now - cache_mtime ))
+    if [ "$cache_age" -lt "$cache_max_age" ]; then
+        needs_refresh=false
+    fi
+    usage_data=$(cat "$cache_file" 2>/dev/null)
+fi
+
+# Fetch fresh data if cache is stale
+if $needs_refresh; then
+    # Touch cache immediately so other instances don't also fetch
+    touch "$cache_file" 2>/dev/null
+
+    token=$(get_oauth_token)
+    if [ -n "$token" ] && [ "$token" != "null" ]; then
+        response=$(curl -s --max-time 10 \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $token" \
+            -H "anthropic-beta: oauth-2025-04-20" \
+            -H "User-Agent: claude-code/2.1.34" \
+            "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+        # Only cache valid usage responses (not error/rate-limit JSON)
+        if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
+            usage_data="$response"
+            (umask 077; echo "$response" > "$cache_file")
+        fi
+    fi
+fi
+
+# Cross-platform ISO to epoch conversion
+# Converts ISO 8601 timestamp (e.g. "2025-06-15T12:30:00Z" or "2025-06-15T12:30:00.123+00:00") to epoch seconds.
+# Properly handles UTC timestamps and converts to local time.
+iso_to_epoch() {
+    local iso_str="$1"
+
+    # Try GNU date first (Linux) — handles ISO 8601 format automatically
+    local epoch
+    epoch=$(date -d "${iso_str}" +%s 2>/dev/null)
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    # BSD date (macOS) - handle various ISO 8601 formats
+    local stripped="${iso_str%%.*}"          # Remove fractional seconds (.123456)
+    stripped="${stripped%%Z}"                 # Remove trailing Z
+    stripped="${stripped%%+*}"               # Remove timezone offset (+00:00)
+    stripped="${stripped%%-[0-9][0-9]:[0-9][0-9]}"  # Remove negative timezone offset
+
+    # Check if timestamp is UTC (has Z or +00:00 or -00:00)
+    if [[ "$iso_str" == *"Z"* ]] || [[ "$iso_str" == *"+00:00"* ]] || [[ "$iso_str" == *"-00:00"* ]]; then
+        # For UTC timestamps, parse with timezone set to UTC
+        epoch=$(env TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+    else
+        epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+    fi
+
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    return 1
+}
+
+# Format ISO reset time to compact local time
+# Usage: format_reset_time <iso_string> <style: time|datetime|date>
+format_reset_time() {
+    local iso_str="$1"
+    local style="$2"
+    { [ -z "$iso_str" ] || [ "$iso_str" = "null" ]; } && return
+
+    # Parse ISO datetime and convert to local time (cross-platform)
+    local epoch
+    epoch=$(iso_to_epoch "$iso_str")
+    [ -z "$epoch" ] && return
+
+    # Format based on style
+    # Try GNU date first (Linux), then BSD date (macOS)
+    # Previous implementation piped BSD date through sed/tr, which always returned
+    # exit code 0 from the last pipe stage, preventing the GNU date fallback from
+    # ever executing on Linux.
+    local formatted=""
+    case "$style" in
+        time)
+            formatted=$(date -d "@$epoch" +"%H:%M" 2>/dev/null) || \
+            formatted=$(date -j -r "$epoch" +"%H:%M" 2>/dev/null)
+            ;;
+        datetime)
+            formatted=$(date -d "@$epoch" +"%b %-d, %H:%M" 2>/dev/null) || \
+            formatted=$(date -j -r "$epoch" +"%b %-d, %H:%M" 2>/dev/null)
+            ;;
+        *)
+            formatted=$(date -d "@$epoch" +"%b %-d" 2>/dev/null) || \
+            formatted=$(date -j -r "$epoch" +"%b %-d" 2>/dev/null)
+            ;;
+    esac
+    [ -n "$formatted" ] && echo "$formatted"
+}
+
+sep=" ${dim}|${reset} "
+
+if [ -n "$usage_data" ] && echo "$usage_data" | jq -e '.five_hour' >/dev/null 2>&1; then
+    # ---- 5-hour (current) ----
+    five_hour_pct=$(echo "$usage_data" | jq -r '.five_hour.utilization // 0' | awk '{printf "%.0f", $1}')
+    five_hour_reset_iso=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty')
+    five_hour_reset=$(format_reset_time "$five_hour_reset_iso" "time")
+    five_hour_color=$(usage_color "$five_hour_pct")
+
+    out+="${sep}${white}5h${reset} ${five_hour_color}${five_hour_pct}%${reset}"
+    [ -n "$five_hour_reset" ] && out+=" ${dim}@${five_hour_reset}${reset}"
+
+    # ---- 7-day (weekly) ----
+    seven_day_pct=$(echo "$usage_data" | jq -r '.seven_day.utilization // 0' | awk '{printf "%.0f", $1}')
+    seven_day_reset_iso=$(echo "$usage_data" | jq -r '.seven_day.resets_at // empty')
+    seven_day_reset=$(format_reset_time "$seven_day_reset_iso" "datetime")
+    seven_day_color=$(usage_color "$seven_day_pct")
+
+    out+="${sep}${white}7d${reset} ${seven_day_color}${seven_day_pct}%${reset}"
+    [ -n "$seven_day_reset" ] && out+=" ${dim}@${seven_day_reset}${reset}"
+
+    # ---- Extra usage ----
+    extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
+    if [ "$extra_enabled" = "true" ]; then
+        extra_pct=$(echo "$usage_data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
+        extra_used=$(echo "$usage_data" | jq -r '.extra_usage.used_credits // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
+        extra_limit=$(echo "$usage_data" | jq -r '.extra_usage.monthly_limit // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
+        # Validate: if values are empty or contain unexpanded variables, show simple "enabled" label
+        if [ -n "$extra_used" ] && [ -n "$extra_limit" ] && [[ "$extra_used" != *'$'* ]] && [[ "$extra_limit" != *'$'* ]]; then
+            extra_color=$(usage_color "$extra_pct")
+            out+="${sep}${white}extra${reset} ${extra_color}\$${extra_used}/\$${extra_limit}${reset}"
+        else
+            out+="${sep}${white}extra${reset} ${green}enabled${reset}"
+        fi
+    fi
+else
+    # No valid usage data — show placeholders
+    out+="${sep}${white}5h${reset} ${dim}-${reset}"
+    out+="${sep}${white}7d${reset} ${dim}-${reset}"
+fi
+
+# Output single line
+printf "%b" "$out"
+
+exit 0

--- a/nix-ai-claude/modules/claude/statusline/daniel3303-options.nix
+++ b/nix-ai-claude/modules/claude/statusline/daniel3303-options.nix
@@ -1,0 +1,12 @@
+# ClaudeCodeStatusLine Options (daniel3303)
+#
+# 2-line statusline format focusing on rate limits and token state.
+# Original repository: https://github.com/daniel3303/ClaudeCodeStatusLine
+#
+{ lib, ... }:
+
+{
+  options.programs.claudeStatuslineDaniel3303 = {
+    enable = lib.mkEnableOption "Claude Code statusline (ClaudeCodeStatusLine by daniel3303) — 2-line format";
+  };
+}

--- a/nix-ai-claude/modules/claude/statusline/daniel3303.nix
+++ b/nix-ai-claude/modules/claude/statusline/daniel3303.nix
@@ -1,0 +1,53 @@
+# ClaudeCodeStatusLine Implementation (daniel3303, locally forked)
+#
+# Based on daniel3303's ClaudeCodeStatusLine:
+# https://github.com/daniel3303/ClaudeCodeStatusLine
+#
+# Local fork at modules/claude/statusline/claude-statusline.sh
+# Patch: cwd shows last 2 path components (e.g., nix-ai/main) instead of basename only
+#
+# The script:
+#   - Reads JSON from stdin with Claude Code status data
+#   - Outputs 1 line with pipe-delimited segments: model | cwd@branch | tokens/total | effort | 5h % | 7d % | extra
+#   - Supports multiple auth methods (env var, macOS Keychain, .credentials.json, GNOME Keyring)
+#   - Caches usage data for 60 seconds at /tmp/claude/statusline-usage-cache.json
+#   - Color thresholds: green <50% → yellow ≥50% → orange ≥70% → red ≥90%
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claudeStatuslineDaniel3303;
+
+  # Local fork of daniel3303's script with cwd patch applied
+  statuslineScript = ./claude-statusline.sh;
+
+  # Runtime dependencies required by claude-statusline.sh
+  runtimePath = lib.makeBinPath [
+    pkgs.bash
+    pkgs.jq
+    pkgs.git
+    pkgs.curl
+    pkgs.gawk
+    pkgs.coreutils
+  ];
+
+in
+{
+  config = lib.mkIf cfg.enable {
+    programs.claude.statusLine = {
+      enable = true;
+      script = ''
+        #!/usr/bin/env bash
+        # Based on ClaudeCodeStatusLine by daniel3303
+        # https://github.com/daniel3303/ClaudeCodeStatusLine
+        export PATH="${runtimePath}:$PATH"
+        exec ${pkgs.bash}/bin/bash ${statuslineScript} "$@"
+      '';
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/statusline/default.nix
+++ b/nix-ai-claude/modules/claude/statusline/default.nix
@@ -1,0 +1,34 @@
+# Claude Statusline Module
+#
+# Multi-line statusline for Claude Code using @owloops/claude-powerline.
+# Uses bunx at runtime for simplicity - no build-time hashes to maintain.
+#
+# This module follows NixOS module patterns:
+# - Options defined in options.nix
+# - Theme implementation in powerline.nix
+# - Config logic uses lib.mkIf for conditional activation
+#
+# Usage:
+#   programs.claudeStatusline.enable = true;
+#
+# Configuration is hardcoded to Rose Pine theme with capsule style.
+# See powerline.nix for the full configuration.
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.claudeStatusline;
+in
+{
+  imports = [
+    ./options.nix
+    ./powerline.nix
+    ./daniel3303-options.nix
+    ./daniel3303.nix
+  ];
+
+  config = lib.mkIf cfg.enable { };
+}

--- a/nix-ai-claude/modules/claude/statusline/options.nix
+++ b/nix-ai-claude/modules/claude/statusline/options.nix
@@ -1,0 +1,11 @@
+# Claude Statusline Options
+#
+# Declarative statusline configuration for Claude Code.
+# Uses @owloops/claude-powerline via bunx at runtime.
+{ lib, ... }:
+
+{
+  options.programs.claudeStatusline = {
+    enable = lib.mkEnableOption "Claude Code statusline (claude-powerline)";
+  };
+}

--- a/nix-ai-claude/modules/claude/statusline/powerline.nix
+++ b/nix-ai-claude/modules/claude/statusline/powerline.nix
@@ -1,0 +1,45 @@
+# Powerline Theme - Claude Code Statusline
+#
+# Multi-line statusline powered by @owloops/claude-powerline.
+# Uses bunx at runtime for simplicity - no build-time hashes to maintain.
+#
+# Repository: https://github.com/Owloops/claude-powerline
+# Configuration: ./claude-powerline.json
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.claudeStatusline;
+  daniel3303Cfg = config.programs.claudeStatuslineDaniel3303;
+
+  # JSON config in separate file to preserve segment order and enable IDE validation
+  configFile = ./claude-powerline.json;
+
+in
+{
+  config = lib.mkIf cfg.enable {
+    # Ensure only one statusline implementation is enabled
+    assertions = [
+      {
+        assertion = !daniel3303Cfg.enable;
+        message = ''
+          Cannot enable both programs.claudeStatusline (powerline) and programs.claudeStatuslineDaniel3303 (daniel3303) simultaneously.
+          Choose one statusline implementation or disable both to use Claude Code's default.
+        '';
+      }
+    ];
+
+    programs.claude.statusLine = {
+      enable = true;
+      script = ''
+        #!/usr/bin/env bash
+        # Claude Powerline statusline (semver-pinned for stability)
+        exec ${pkgs.bun}/bin/bunx @owloops/claude-powerline@'^1' --config=${configFile} "$@"
+      '';
+    };
+  };
+}

--- a/nix-ai-claude/modules/claude/test-slack-notifications.py
+++ b/nix-ai-claude/modules/claude/test-slack-notifications.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Test Script: Slack Notification Validation
+
+Validates that auto-claude Slack notifications are properly configured.
+Run this script to verify Slack setup before relying on notifications.
+
+Usage:
+    python3 test-slack-notifications.py           # Run all checks
+    python3 test-slack-notifications.py --send    # Also send a test message
+
+Exit codes:
+    0 = All tests passed
+    1 = Configuration issue (fixable)
+    2 = Dependency missing
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from auto_claude_utils import (
+    get_keychain_value,
+    get_repo_name,
+    load_bws_env,
+    sanitize_repo_name,
+)
+
+
+class Colors:
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[1;33m"
+    NC = "\033[0m"
+
+
+class TestResults:
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+        self.warnings = 0
+
+    def pass_(self, msg: str):
+        print(f"{Colors.GREEN}✓ PASS{Colors.NC}: {msg}")
+        self.passed += 1
+
+    def fail(self, msg: str):
+        print(f"{Colors.RED}✗ FAIL{Colors.NC}: {msg}")
+        self.failed += 1
+
+    def warn(self, msg: str):
+        print(f"{Colors.YELLOW}⚠ WARN{Colors.NC}: {msg}")
+        self.warnings += 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test Slack notification configuration")
+    parser.add_argument("--send", action="store_true", help="Send a test message to Slack")
+    args = parser.parse_args()
+
+    results = TestResults()
+    home = Path.home()
+
+    print("==============================================")
+    print("Auto-Claude Slack Notification Test")
+    print("==============================================")
+    print()
+
+    # --- Test 1: Python packages ---
+    print("1. Checking Python packages...")
+    try:
+        import slack_sdk  # noqa: F401
+
+        results.pass_("slack_sdk package available")
+    except ImportError:
+        results.fail("slack_sdk package NOT available")
+
+    try:
+        import keyring  # noqa: F401
+
+        results.pass_("keyring package available")
+    except ImportError:
+        results.fail("keyring package NOT available")
+
+    # --- Test 2: BWS config ---
+    print()
+    print("2. Checking BWS configuration...")
+    bws_env = home / ".config/bws/.env"
+    if bws_env.exists():
+        results.pass_(f"BWS config found: {bws_env}")
+        config = load_bws_env()
+
+        if "BWS_KEYCHAIN_ACCOUNT" in config:
+            results.pass_(f"BWS account configured: {config['BWS_KEYCHAIN_ACCOUNT']}")
+        else:
+            results.fail("BWS_KEYCHAIN_ACCOUNT not set")
+
+        if "BWS_SECRET_SLACK_BOT_TOKEN" in config:
+            results.pass_("SLACK_BOT_TOKEN secret mapping configured")
+        else:
+            results.fail("BWS_SECRET_SLACK_BOT_TOKEN not set")
+    else:
+        results.fail(f"BWS config NOT found: {bws_env}")
+        config = {}
+
+    # --- Test 3: Notifier script ---
+    print()
+    print("3. Checking notifier script...")
+    notifier = home / ".claude/scripts/auto-claude-notify.py"
+    if notifier.exists() and os.access(notifier, os.X_OK):
+        results.pass_(f"Notifier script found: {notifier}")
+    else:
+        results.fail(f"Notifier script NOT found or not executable: {notifier}")
+
+    # --- Test 4: Slack token retrieval ---
+    print()
+    print("4. Checking Slack token retrieval...")
+    try:
+        # Import bws_helper from the scripts directory
+        sys.path.insert(0, str(home / ".claude/scripts"))
+        import bws_helper
+
+        token = bws_helper.get_secret("SLACK_BOT_TOKEN")
+        if token.startswith("xoxb-"):
+            results.pass_("Slack bot token retrieved successfully (xoxb-...)")
+        else:
+            results.fail("Slack token has unexpected format (should start with xoxb-)")
+    except Exception as e:
+        results.fail(f"Could not retrieve Slack token: {e}")
+
+    # --- Test 5: Slack channel resolution ---
+    print()
+    print("5. Checking Slack channel resolution...")
+
+    bws_account = config.get("BWS_KEYCHAIN_ACCOUNT")
+    fallback_channel = config.get("SLACK_DEFAULT_CHANNEL")
+
+    # Test repo-specific channel lookup
+    test_repos = [
+        str(home / ".config/nix"),
+        str(home / "git/ai-assistant-instructions/main"),
+    ]
+
+    for test_repo in test_repos:
+        if Path(test_repo).exists():
+            # Use get_repo_name from utils (handles worktrees properly)
+            repo_name = get_repo_name(test_repo)
+            print(f"   Testing: {test_repo}")
+            print(f"   Detected repo name: {repo_name}")
+
+            sanitized = sanitize_repo_name(repo_name)
+            keychain_key = f"SLACK_CHANNEL_ID_{sanitized}"
+
+            # Slack channel IDs (e.g. C1234ABCD) are identifiers, not credentials
+            channel_id = get_keychain_value(keychain_key, bws_account)
+            if channel_id:
+                results.pass_(f"Repo-specific channel: {keychain_key} (found)")
+            else:
+                results.warn(f"No repo-specific channel for {keychain_key}")
+
+    # Check fallback
+    if fallback_channel:
+        results.pass_(f"Fallback channel configured: {fallback_channel}")
+    else:
+        results.fail("No SLACK_DEFAULT_CHANNEL - notifications will fail for unconfigured repos")
+
+    # --- Test 6: List all keychain channels ---
+    print()
+    print("6. Keychain Slack channels found:")
+    try:
+        result = subprocess.run(["security", "dump-keychain"], capture_output=True, text=True)
+        for line in result.stdout.splitlines():
+            if "SLACK_CHANNEL_ID" in line and "svce" in line:
+                # Extract service name
+                if '<blob>="' in line:
+                    service = line.split('<blob>="')[1].split('"')[0]
+                    print(f"   • {service}")
+    except subprocess.CalledProcessError:
+        results.warn("Could not list keychain entries")
+
+    # --- Test 7: Optional send test ---
+    if args.send:
+        print()
+        print("7. Sending test message to Slack...")
+        test_channel = fallback_channel
+        if not test_channel:
+            results.fail("No channel available for test message")
+        else:
+            run_id = f"test-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            print(f"   Channel: {test_channel}")
+            print(f"   Run ID: {run_id}")
+
+            try:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(notifier),
+                        "run_started",
+                        "--repo",
+                        "test-validation",
+                        "--budget",
+                        "0.01",
+                        "--run-id",
+                        run_id,
+                        "--channel",
+                        test_channel,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                results.pass_(f"Test message sent! Check Slack. Thread TS: {result.stdout.strip()}")
+            except subprocess.CalledProcessError as e:
+                results.fail(f"Failed to send test message: {e.stderr}")
+
+    # --- Summary ---
+    print()
+    print("==============================================")
+    print("Summary")
+    print("==============================================")
+    print(f"Passed:   {Colors.GREEN}{results.passed}{Colors.NC}")
+    print(f"Failed:   {Colors.RED}{results.failed}{Colors.NC}")
+    print(f"Warnings: {Colors.YELLOW}{results.warnings}{Colors.NC}")
+    print()
+
+    if results.failed > 0:
+        print(f"{Colors.RED}Some tests failed. Fix the issues above.{Colors.NC}")
+        sys.exit(1)
+    elif results.warnings > 0:
+        print(f"{Colors.YELLOW}All critical tests passed but there are warnings.{Colors.NC}")
+    else:
+        print(f"{Colors.GREEN}All tests passed!{Colors.NC}")
+
+    if not args.send:
+        print()
+        print("To send a test message, run with --send flag:")
+        print(f"  python3 {__file__} --send")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/nix-ai-claude/modules/claude/test-slack-notifications.py
+++ b/nix-ai-claude/modules/claude/test-slack-notifications.py
@@ -171,7 +171,7 @@ def main():
     print()
     print("6. Keychain Slack channels found:")
     try:
-        result = subprocess.run(["security", "dump-keychain"], capture_output=True, text=True)
+        result = subprocess.run(["security", "dump-keychain"], capture_output=True, text=True, check=True)
         for line in result.stdout.splitlines():
             if "SLACK_CHANNEL_ID" in line and "svce" in line:
                 # Extract service name

--- a/nix-ai-claude/modules/claude/test_keychain_handler.py
+++ b/nix-ai-claude/modules/claude/test_keychain_handler.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Tests for keychain_error_handler module.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from keychain_error_handler import emit_keychain_error_event
+
+
+def test_emit_keychain_error_event():
+    """Test emitting a keychain error event."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        events_log = Path(tmpdir) / "events.jsonl"
+
+        event = emit_keychain_error_event(
+            events_log,
+            run_id="test-run-123",
+            repo="test-repo",
+            service="bws-claude-automation",
+            account="user@example.com",
+            exit_code=1,
+            error_message="keychain item not found",
+        )
+
+        # Verify event structure
+        assert event["event"] == "keychain_error"
+        assert event["run_id"] == "test-run-123"
+        assert event["repo"] == "test-repo"
+        assert event["service"] == "bws-claude-automation"
+        assert event["account"] == "user@example.com"
+        assert event["exit_code"] == 1
+        assert event["error_message"] == "keychain item not found"
+        assert "timestamp" in event
+
+        # Verify event was written to log
+        assert events_log.exists()
+        with open(events_log) as f:
+            logged = json.loads(f.read().strip())
+            assert logged == event
+
+
+def test_emit_keychain_error_event_no_account():
+    """Test emitting a keychain error event without account."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        events_log = Path(tmpdir) / "events.jsonl"
+
+        event = emit_keychain_error_event(
+            events_log,
+            run_id="test-run-456",
+            repo="test-repo",
+            service="bws-token",
+            account=None,
+            exit_code=127,
+            error_message="security command not found",
+        )
+
+        # Verify account defaults to "unknown"
+        assert event["account"] == "unknown"
+        assert event["exit_code"] == 127
+
+        # Verify event was written to log
+        assert events_log.exists()
+        with open(events_log) as f:
+            logged = json.loads(f.read().strip())
+            assert logged == event
+
+
+if __name__ == "__main__":
+    test_emit_keychain_error_event()
+    test_emit_keychain_error_event_no_account()
+    print("All tests passed!")

--- a/nix-ai-claude/modules/common/default.nix
+++ b/nix-ai-claude/modules/common/default.nix
@@ -1,0 +1,35 @@
+# AI CLI Common Module
+#
+# Provides unified permission definitions and formatters for all AI CLI tools.
+# This is the single source of truth for command permissions.
+#
+# USAGE:
+#   let
+#     aiCommon = import ./common { inherit lib config ai-assistant-instructions; };
+#     geminiAllowedTools = aiCommon.formatters.gemini.formatAllowedTools aiCommon.permissions;
+#   in { ... }
+#
+# CRITICAL - Gemini tools.allowed vs tools.core:
+# Per the official Gemini CLI schema:
+# - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
+# - tools.core = "Allowlist to RESTRICT built-in tools" (LIMITS usage!)
+# Always use formatAllowedTools for auto-approval, NEVER for core!
+#
+# EXPORTS:
+# - permissions: Tool-agnostic command definitions
+# - formatters: Tool-specific formatting functions
+
+{
+  lib,
+  config,
+  ai-assistant-instructions,
+  ...
+}:
+
+{
+  # Unified permission definitions
+  permissions = import ./permissions.nix { inherit lib config ai-assistant-instructions; };
+
+  # Tool-specific formatters
+  formatters = import ./formatters.nix { inherit lib; };
+}

--- a/nix-ai-claude/modules/common/formatters.nix
+++ b/nix-ai-claude/modules/common/formatters.nix
@@ -1,0 +1,207 @@
+# AI CLI Permission Formatters
+#
+# Transforms tool-agnostic command definitions into tool-specific formats.
+# Each tool has different permission syntax requirements.
+#
+# FORMATS:
+# - Claude Code: Bash(cmd *) for shell, Read(**) for file tools
+# - Gemini CLI: ShellTool(cmd) for shell, ReadFileTool for file tools
+# - Copilot CLI: shell(cmd) patterns for runtime flags
+# - Crush: shell_allowlist for permissions config
+
+{ lib }:
+
+let
+  # Flatten nested attribute sets into a list of commands
+  # Handles both lists and nested attrsets
+  flattenCommands =
+    attrs:
+    if builtins.isList attrs then
+      attrs
+    else if builtins.isAttrs attrs then
+      lib.flatten (
+        lib.mapAttrsToList (
+          _name: value:
+          if builtins.isList value then
+            value
+          else if builtins.isAttrs value then
+            flattenCommands value
+          else
+            [ ]
+        ) attrs
+      )
+    else
+      [ ];
+
+  # Claude-specific helper: Get all tool-specific permissions (non-shell)
+  getClaudeToolPermissions =
+    permissions:
+    let
+      claudePerms = permissions.toolSpecific.claude or { };
+      # WebFetch domains from ai-assistant-instructions
+      webfetchDomains = permissions.webfetchDomains or [ ];
+      webfetchPerms = map (d: "WebFetch(domain:${d})") webfetchDomains;
+    in
+    (claudePerms.builtin or [ ]) ++ webfetchPerms ++ (claudePerms.read or [ ]);
+
+  # Claude-specific helper: Get tool-specific deny permissions
+  getClaudeDenyPermissions =
+    permissions:
+    let
+      # Deny patterns from ai-assistant-instructions (file patterns for the Read tool)
+      denyPatterns = permissions.denyPatterns or [ ];
+      # Convert patterns to Read(...) format for Claude's deny list.
+      # Note: patterns are used as provided; any tilde (~) expansion must be done upstream.
+      denyReadPatterns = map (p: "Read(${p})") denyPatterns;
+    in
+    denyReadPatterns;
+
+in
+{
+  # ============================================================================
+  # CLAUDE CODE FORMATTER
+  # ============================================================================
+  # Format: Bash(cmd *) for shell commands
+  # The "<cmd> *" suffix (space then asterisk) is Claude-specific wildcard syntax:
+  # it matches "cmd" followed by any arguments.
+  # The space enforces word boundaries (e.g., "nix *" matches "nix search" but not "nix-env")
+
+  claude = rec {
+    # Format a single shell command for Claude
+    formatShellCommand = cmd: "Bash(${cmd} *)";
+
+    # Format a list of shell commands
+    formatShellCommands = cmds: map formatShellCommand cmds;
+
+    # Format all allowed commands from permissions (shell + tool-specific + MCP)
+    # Note: Tool-specific permissions are placed before shell permissions.
+    # This ordering matches formatDenied and ensures consistent evaluation by Claude Code.
+    formatAllowed =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.allow;
+        shellPermissions = map formatShellCommand allCommands;
+        mcpPermissions = permissions.mcpAllow or [ ];
+      in
+      (getClaudeToolPermissions permissions) ++ mcpPermissions ++ shellPermissions;
+
+    # Format all denied commands (shell + tool-specific + MCP)
+    # Note: Tool-specific permissions are placed before shell permissions.
+    # This ordering matches formatAllowed and ensures consistent evaluation by Claude Code.
+    formatDenied =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.deny;
+        shellDenied = map formatShellCommand allCommands;
+        mcpPermissions = permissions.mcpDeny or [ ];
+      in
+      (getClaudeDenyPermissions permissions) ++ mcpPermissions ++ shellDenied;
+
+    # Format all ask commands (require user confirmation)
+    # These commands will prompt the user for approval before execution
+    formatAsk =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.ask;
+        shellPermissions = map formatShellCommand allCommands;
+        mcpPermissions = permissions.mcpAsk or [ ];
+      in
+      mcpPermissions ++ shellPermissions;
+
+    # Export helpers for external use
+    getToolPermissions = getClaudeToolPermissions;
+    getDenyPermissions = getClaudeDenyPermissions;
+  };
+
+  # ============================================================================
+  # GEMINI CLI FORMATTER
+  # ============================================================================
+  # Format: ShellTool(cmd) for shell commands
+  # No wildcard suffix - exact command match or prefix match
+  #
+  # CRITICAL - tools.allowed vs tools.core in settings.json:
+  # =========================================================
+  # Per the official Gemini CLI schema:
+  # - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
+  # - tools.core = "Allowlist to RESTRICT built-in tools to a specific set" (LIMITS usage!)
+  #
+  # This formatter provides formatAllowedTools for the "allowed" key.
+  # NEVER use formatAllowedTools output for "core" - that would break permissions!
+  # Schema: https://github.com/google-gemini/gemini-cli/blob/main/schemas/settings.schema.json
+
+  gemini = {
+    # Format a single shell command for Gemini
+    formatShellCommand = cmd: "ShellTool(${cmd})";
+
+    # Format a list of shell commands
+    formatShellCommands = cmds: map (cmd: "ShellTool(${cmd})") cmds;
+
+    # Format all auto-approved commands for tools.allowed (NOT tools.core!)
+    # Output goes to settings.json "tools.allowed" to bypass confirmation dialog
+    formatAllowedTools =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.allow;
+        shellTools = map (cmd: "ShellTool(${cmd})") allCommands;
+        # Built-in Gemini tools (ReadFileTool, etc.) from permissions.nix
+        builtinTools = permissions.toolSpecific.gemini.builtin or [ ];
+      in
+      builtinTools ++ shellTools;
+
+    # Format all denied commands (excludeTools)
+    formatExcludeTools =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.deny;
+      in
+      map (cmd: "ShellTool(${cmd})") allCommands;
+
+    # Get tool-specific permissions (non-shell)
+    getToolPermissions = permissions: permissions.toolSpecific.gemini.builtin or [ ];
+  };
+
+  # ============================================================================
+  # COPILOT CLI FORMATTER
+  # ============================================================================
+  # Format: shell(cmd) patterns for --allow-tool and --deny-tool flags
+  # Note: Copilot permissions are primarily directory-based in config
+
+  copilot = {
+    # Format a single shell command for Copilot
+    formatShellCommand = cmd: "shell(${cmd})";
+
+    # Format a list of shell commands
+    formatShellCommands = cmds: map (cmd: "shell(${cmd})") cmds;
+
+    # Get trusted directories
+    getTrustedFolders =
+      permissions:
+      let
+        dirs = permissions.directories or { };
+      in
+      (dirs.home or [ ]) ++ (dirs.development or [ ]) ++ (dirs.config or [ ]);
+
+    # Format denied commands for --deny-tool flags
+    formatDenyFlags =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.deny;
+      in
+      map (cmd: "shell(${cmd})") allCommands;
+  };
+
+  # ============================================================================
+  # UTILITY FUNCTIONS
+  # ============================================================================
+
+  utils = {
+    # Flatten commands from nested permission structure
+    inherit flattenCommands;
+
+    # Count total commands in a permission set
+    countCommands = permissions: builtins.length (flattenCommands permissions);
+
+    # Get all categories from permissions
+    getCategories = permissions: builtins.attrNames permissions;
+  };
+}

--- a/nix-ai-claude/modules/common/permissions.nix
+++ b/nix-ai-claude/modules/common/permissions.nix
@@ -1,0 +1,159 @@
+# Unified AI CLI Permission Definitions
+#
+# Single source of truth for command permissions across all AI tools.
+# Each tool uses formatters to convert these to their specific format.
+#
+# STRUCTURE:
+# - allow: Auto-approved commands (from ai-assistant-instructions)
+# - deny: Permanently blocked, catastrophic operations
+# - directories: Shared directory trust configuration
+# - toolSpecific: Non-shell tool identifiers
+#
+# TOOL FORMATS (applied by formatters.nix):
+# - Claude: Bash(cmd *), Read(**), etc.
+# - Gemini: ShellTool(cmd), ReadFileTool, etc.
+# - Copilot: shell(cmd) patterns (runtime flags)
+# - Crush: shell_allowlist patterns
+
+{
+  lib,
+  config,
+  ai-assistant-instructions,
+  ...
+}:
+
+let
+  homeDir = config.home.homeDirectory;
+
+  # Read all JSON files from a directory into an attribute set
+  # Returns {filename = parsed-json-content} for efficient reuse
+  readJsonsFromDir =
+    dir:
+    if builtins.pathExists dir then
+      let
+        files = builtins.readDir dir;
+        jsonFiles = lib.filterAttrs (n: v: v == "regular" && lib.hasSuffix ".json" n) files;
+      in
+      lib.mapAttrs' (
+        name: _:
+        let
+          filePath = "${dir}/${name}";
+          fileContents = builtins.readFile filePath;
+          parsed = builtins.tryEval (builtins.fromJSON fileContents);
+        in
+        if parsed.success then
+          lib.nameValuePair name parsed.value
+        else
+          throw "Invalid JSON in AI permission file: ${filePath}"
+      ) jsonFiles
+    else
+      { };
+
+  # Paths to permission directories in ai-assistant-instructions
+  allowDir = "${ai-assistant-instructions}/agentsmd/permissions/allow";
+  denyDir = "${ai-assistant-instructions}/agentsmd/permissions/deny";
+  askDir = "${ai-assistant-instructions}/agentsmd/permissions/ask";
+  domainsFile = "${ai-assistant-instructions}/agentsmd/permissions/domains/webfetch.json";
+
+  # Read all permission files once to avoid redundant I/O
+  allowJsons = readJsonsFromDir allowDir;
+  denyJsons = readJsonsFromDir denyDir;
+  askJsons = readJsonsFromDir askDir;
+
+in
+{
+  # Auto-approved commands from ai-assistant-instructions
+  allow = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) allowJsons);
+
+  # Denied commands from ai-assistant-instructions
+  deny = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) denyJsons);
+
+  # Commands that require explicit user confirmation
+  ask = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) askJsons);
+
+  # MCP tool permissions (non-shell, bare identifiers like mcp__plugin_*)
+  mcpAllow = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) allowJsons);
+  mcpDeny = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) denyJsons);
+  mcpAsk = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) askJsons);
+
+  # WebFetch domains
+  webfetchDomains =
+    if builtins.pathExists domainsFile then
+      (builtins.fromJSON (builtins.readFile domainsFile)).domains
+    else
+      [ ];
+
+  # File patterns to deny (for Claude Read tool)
+  # These come from dangerous.json's "patterns" field
+  denyPatterns = denyJsons."dangerous.json".patterns or [ ];
+
+  # Trusted directories (local config)
+  directories = {
+    development = [
+      "${homeDir}/projects"
+      "${homeDir}/repos"
+      "${homeDir}/workspace"
+      "${homeDir}/src"
+      "${homeDir}/dev"
+      "${homeDir}/git"
+    ];
+
+    config = [
+      "${homeDir}/.config/nix"
+      "${homeDir}/.dotfiles"
+      "${homeDir}/.config"
+      "${homeDir}/.claude"
+    ];
+
+    home = [ homeDir ];
+  };
+
+  # Tool-specific identifiers (non-shell, built-in tools)
+  # NOTE: These are BUILT-IN tools (like ReadFileTool), not shell commands.
+  # The attribute names here (builtin) refer to the tool's built-in capabilities,
+  # not to be confused with the JSON key "tools.core" which restricts tool usage.
+  toolSpecific = {
+    # Gemini built-in tools (non-shell) - maps to tools.allowed, NOT tools.core
+    gemini.builtin = [
+      "ReadFileTool"
+      "GlobTool"
+      "GrepTool"
+      "WebFetchTool"
+    ];
+
+    # Claude built-in tools (non-shell)
+    # NOTE: Deny rules (denyRead) take precedence over allow rules (builtin)
+    # as enforced by Claude Code at runtime when it evaluates these patterns,
+    # not by this Nix configuration itself. Even though Read allows reading
+    # any file, the denyRead patterns will block sensitive files (.env, SSH keys,
+    # etc.) when Claude Code processes the permission lists.
+    claude = {
+      # Core built-in tools (unconditional approval)
+      # Pattern format per Claude Code schema: Tool names without wildcards
+      # Use bare tool name for unconditional approval: Read, Glob, etc.
+      # Use tool with path for specific patterns: Read(/path/to/file)
+      builtin = [
+        "Read"
+        "Edit" # Handles all editing including multi-file refactoring
+        "Write"
+        "NotebookEdit" # Jupyter notebook editing
+        "Glob"
+        "Grep"
+        "WebSearch"
+        "TodoWrite"
+      ];
+
+      # WebFetch with allowed domains (dynamically generated from ai-assistant-instructions)
+      # This will be populated by formatters.nix using webfetchDomains
+
+      # Special read patterns
+      read = [
+        "Read(/nix/store/**)"
+      ];
+
+      # Deny patterns for sensitive files (Claude-specific Read tool)
+      # Populated from ai-assistant-instructions deny/dangerous.json patterns field
+      # This will be transformed by formatters.nix to Read(...) format
+    };
+  };
+}

--- a/nix-ai-claude/modules/default.nix
+++ b/nix-ai-claude/modules/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./mlx-compat.nix
+    ./embedded.nix
+  ];
+}

--- a/nix-ai-claude/modules/embedded.nix
+++ b/nix-ai-claude/modules/embedded.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  pkgs,
+  lib,
+  ai-assistant-instructions,
+  marketplaceInputs,
+  claude-cookbooks,
+  fabric-src,
+  userConfig ? {
+    ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
+  },
+  ...
+}:
+
+let
+  claudeConfig = import ./claude-config.nix {
+    inherit
+      config
+      pkgs
+      lib
+      ai-assistant-instructions
+      marketplaceInputs
+      claude-cookbooks
+      fabric-src
+      ;
+  };
+in
+{
+  imports = [ ./claude ];
+
+  config = {
+    home.activation.validateClaudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      $DRY_RUN_CMD ${./scripts/validate-claude-settings.sh} \
+        "${config.home.homeDirectory}/.claude/settings.json" \
+        "${userConfig.ai.claudeSchemaUrl}"
+    '';
+
+    programs = {
+      claude = claudeConfig;
+      claudeStatusline.enable = false;
+      claudeStatuslineDaniel3303.enable = true;
+    };
+  };
+}

--- a/nix-ai-claude/modules/fabric/package.nix
+++ b/nix-ai-claude/modules/fabric/package.nix
@@ -1,0 +1,58 @@
+#
+# Fabric CLI Package
+#
+# Daniel Miessler's Fabric (github.com/danielmiessler/fabric) — Go CLI providing
+# 252+ reusable AI prompt patterns for analysis, extraction, summarization, code
+# review, and content transformation.
+#
+# Pinned to a specific release tag. Version bumps managed by Renovate via the
+# datasource annotation above the version string.
+#
+# Naming: "fabric-ai" avoids collision with the unrelated Python `fabric` package
+# in nixpkgs (pythonic remote execution). Both can coexist on PATH since the
+# binary name is still `fabric`.
+#
+# Build strategy: standard buildGoModule (not upstream's gomod2nix) to keep our
+# flake self-contained. Run `nix build` once with an empty vendorHash, then
+# replace with the correct hash from the error message.
+#
+{
+  lib,
+  buildGoModule,
+  fabric-src,
+}:
+
+buildGoModule rec {
+  pname = "fabric-ai";
+  # managed by: renovate (datasource=github-releases depName=danielmiessler/fabric)
+  version = "1.4.444";
+
+  src = fabric-src;
+
+  # Discover via: nix build .#fabric-ai 2>&1 | grep 'got:'
+  vendorHash = "sha256-G1N/cPPReI5jrZ9orrWEAV/cRPrGbUZyhht+8iMDRb0=";
+
+  # Build only the main fabric binary from cmd/fabric. Skip cmd/code2context,
+  # cmd/generate_changelog, cmd/to_pdf — we only need the primary CLI.
+  subPackages = [ "cmd/fabric" ];
+
+  # Strip debug symbols for smaller binary (matches upstream flake)
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # Skip tests during build — they require network access to AI providers
+  doCheck = false;
+
+  # Prevent Go from downloading a different toolchain version
+  env.GOTOOLCHAIN = "local";
+
+  meta = {
+    description = "Open-source framework for augmenting humans using AI (252+ prompt patterns)";
+    homepage = "https://github.com/danielmiessler/fabric";
+    license = lib.licenses.mit;
+    mainProgram = "fabric";
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+}

--- a/nix-ai-claude/modules/maestro/scripts/maestro-cli.sh
+++ b/nix-ai-claude/modules/maestro/scripts/maestro-cli.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Maestro CLI Wrapper
+#
+# Invokes Maestro Electron app in CLI mode for automated playbook execution.
+# The Maestro app supports headless CLI commands for scheduled automation.
+#
+# Usage: maestro-cli <args...>  # passes all arguments to Maestro CLI
+
+set -euo pipefail
+
+# Path to Maestro Electron app
+MAESTRO_APP="@maestroApp@"
+
+# Verify Maestro is installed
+if [ ! -x "$MAESTRO_APP" ]; then
+  echo "Error: Maestro not found at '$MAESTRO_APP'" >&2
+  echo "Please install Maestro from: https://www.maestro.app" >&2
+  exit 1
+fi
+
+# Pass all arguments to Maestro CLI
+exec "$MAESTRO_APP" "$@"

--- a/nix-ai-claude/modules/mcp/default.nix
+++ b/nix-ai-claude/modules/mcp/default.nix
@@ -1,0 +1,275 @@
+# MCP Servers Configuration
+#
+# Simple, portable MCP server definitions using standard commands.
+# Uses bunx for npm packages (faster than npx, auto-installs).
+# Uses binary names for nixpkgs packages (resolved via PATH).
+#
+# Official MCP Servers: https://github.com/modelcontextprotocol/servers
+#
+# Note: Servers requiring API keys read them from environment variables.
+# Use your secrets manager (Doppler, Keychain, etc.) to inject env vars.
+
+let
+  # bunx helper — command only, args set inline per server so Renovate's
+  # regex manager can match literal "@scope/pkg@version" strings in the source.
+  bunx = args: {
+    command = "bunx";
+    inherit args;
+  };
+in
+{
+  # ================================================================
+  # Official Anthropic MCP Servers (via bunx)
+  # ================================================================
+  # Versions pinned as literal strings for Renovate regex tracking.
+  # Archived servers (no longer on npm) are unpinned until replacements identified.
+
+  everything = bunx [ "@modelcontextprotocol/server-everything@2026.1.26" ];
+  fetch = bunx [ "@modelcontextprotocol/server-fetch" ]; # archived
+  filesystem = bunx [ "@modelcontextprotocol/server-filesystem@2026.1.14" ];
+  git = bunx [ "@modelcontextprotocol/server-git" ]; # archived
+  memory = bunx [ "@modelcontextprotocol/server-memory@2026.1.26" ];
+  sequentialthinking = bunx [ "@modelcontextprotocol/server-sequential-thinking" ]; # archived
+  time = bunx [ "@modelcontextprotocol/server-time" ]; # archived
+  docker = bunx [ "@modelcontextprotocol/server-docker" ]; # archived
+  exa = bunx [ "@modelcontextprotocol/server-exa" ] // {
+    disabled = true;
+  }; # archived; Requires: EXA_API_KEY
+  firecrawl = bunx [ "@modelcontextprotocol/server-firecrawl" ] // {
+    disabled = true;
+  }; # archived; Requires: FIRECRAWL_API_KEY
+  cloudflare = bunx [ "@modelcontextprotocol/server-cloudflare" ] // {
+    disabled = true;
+  }; # archived; Requires: CLOUDFLARE_API_TOKEN
+  aws = bunx [ "@modelcontextprotocol/server-aws-kb-retrieval@0.6.2" ]; # Requires: AWS credentials
+
+  # ================================================================
+  # Native nixpkgs packages (binary name, resolved via PATH)
+  # ================================================================
+
+  # Terraform - terraform-mcp-server from nixpkgs
+  terraform = {
+    command = "terraform-mcp-server";
+  };
+
+  # GitHub - github-mcp-server from nixpkgs
+  # Requires: GITHUB_PERSONAL_ACCESS_TOKEN env var (not yet in Doppler)
+  github = {
+    command = "github-mcp-server";
+    disabled = true;
+  };
+
+  # ================================================================
+  # Third-party npm packages (via bunx)
+  # ================================================================
+
+  # Context7 - provided by context7@claude-plugins-official plugin (see plugins/external.nix).
+  # Do NOT define here — the plugin manages its own MCP server lifecycle.
+
+  # ================================================================
+  # PAL MCP - Multi-model orchestration
+  # ================================================================
+  # Provider Abstraction Layer for routing tasks to different AI models
+  # Tools (all enabled): chat, thinkdeep, planner, codereview, precommit, debug,
+  #   apilookup, challenge, clink, consensus, analyze, refactor, testgen, secaudit,
+  #   docgen, tracer
+  # See: https://github.com/BeehiveInnovations/pal-mcp-server
+  #
+  # API keys injected via Doppler (doppler-mcp wrapper):
+  #   - GEMINI_API_KEY (Google Gemini — pro, flash models)
+  #   - OPENAI_API_KEY (OpenAI — reasoning and chat/codex models)
+  #   - OPENROUTER_API_KEY (OpenRouter — unified multi-model access)
+  #
+  # Non-secret config is set in env below (belongs in Nix, not Doppler).
+
+  # Built as a Nix derivation (modules/mcp/pal-package.nix), installed to PATH.
+  # Wrapped with doppler-mcp to inject Doppler secrets at subprocess launch time.
+  # Secrets are never written to ~/.claude.json or any file Claude Code can read.
+  pal = {
+    command = "doppler-mcp";
+    args = [ "pal-mcp-server" ];
+    env = {
+      # Disable PAL tools that have native Claude Code / Bifrost equivalents,
+      # plus drop `version` (no functional value). Only `clink` (parallel
+      # multi-model) and `consensus` (multi-model voting) remain enabled —
+      # neither has a Bifrost equivalent, and the canonical
+      # `modules/claude/rules/pal-mcp-policy.md` rule scopes PAL's
+      # availability-check protocol to exactly those two tools. The
+      # audit matrix that decided this split was posted as a comment on
+      # JacobPEvans/nix-ai#450.
+      DISABLED_TOOLS = builtins.concatStringsSep "," [
+        "chat"
+        "thinkdeep"
+        "planner"
+        "listmodels"
+        "codereview"
+        "precommit"
+        "debug"
+        "analyze"
+        "tracer"
+        "refactor"
+        "testgen"
+        "secaudit"
+        "docgen"
+        "apilookup"
+        "challenge"
+        "version"
+      ];
+      # 'auto' = PAL picks a model alias per-task; Bifrost then routes the
+      # resulting request to the right provider based on the model name.
+      # `listmodels` is disabled (see above) — query available models via
+      # `curl http://localhost:30080/v1/models` instead.
+      DEFAULT_MODEL = "auto";
+      # Route PAL through Bifrost AI gateway (localhost:30080) instead of
+      # vllm-mlx directly. Bifrost fans out to OpenAI/Gemini/OpenRouter/MLX
+      # based on model name. Tracked: JacobPEvans/nix-ai#450
+      CUSTOM_API_URL = "http://localhost:30080/v1";
+      # OpenAI-compatible client timeouts — applies to whichever backend
+      # CUSTOM_API_URL points at (Bifrost in this config).
+      CUSTOM_CONNECT_TIMEOUT = "30"; # 30s connect — catches stalled upstream
+      CUSTOM_READ_TIMEOUT = "300"; # 5min read — accommodates large model inference
+      # Conversation limits
+      CONVERSATION_TIMEOUT_HOURS = "6";
+      MAX_CONVERSATION_TURNS = "50";
+      LOG_LEVEL = "INFO";
+    };
+  };
+
+  # ================================================================
+  # HuggingFace MCP - Model/dataset/paper search and documentation
+  # ================================================================
+  # Community stdio package: https://github.com/shreyaskarnik/huggingface-mcp-server
+  # Tools: search models/datasets/spaces/papers, get info, compare models
+  # Requires: HF_TOKEN env var (from macOS Keychain via nix-darwin shell init)
+  huggingface = {
+    command = "uvx";
+    args = [
+      "--from"
+      "huggingface-mcp-server==0.1.0"
+      "--with"
+      "huggingface-hub==1.10.1"
+      "huggingface-mcp-server"
+    ];
+  };
+
+  # Fabric MCP — community-maintained (ksylvan/fabric-mcp), exposes fabric
+  # patterns as MCP tools. Requires fabric CLI setup (see modules/fabric/).
+  # renovate: datasource=pypi depName=fabric-mcp
+  fabric = {
+    command = "uvx";
+    args = [
+      "--from"
+      "fabric-mcp==1.1.0"
+      "fabric-mcp"
+      "--transport"
+      "stdio"
+    ];
+  };
+
+  # ================================================================
+  # Obsidian - Integrated via Claude Code Plugin (not MCP)
+  # ================================================================
+  # The official Obsidian CLI (v1.8+, ships in Obsidian.app) provides 80+
+  # commands. Integration uses the kepano/obsidian-skills Claude Code plugin
+  # which teaches Claude to invoke the CLI via Bash (auto-approved in
+  # ai-assistant-instructions permissions). No MCP server needed — the skill
+  # provides equivalent structured access without an additional layer.
+  #
+  # If MCP is desired later: bunx [ "mcp-obsidian-cli@1.2.0" ] (stonematt)
+
+  # ================================================================
+  # Codex CLI — OpenAI coding agent MCP server
+  # ================================================================
+  # Native `codex mcp-server` (stdio). Structured MCP tool access to Codex.
+  # The codex@openai-codex plugin provides skill-based /codex commands.
+  # Auth: `codex login` stores credentials in ~/.codex/auth.json (no env var API keys needed).
+  # Installed via Homebrew cask in the nix-darwin repo (not managed here).
+  codex = {
+    command = "codex";
+    args = [ "mcp-server" ];
+  };
+
+  # ================================================================
+  # Database (disabled by default)
+  # ================================================================
+
+  postgresql = bunx [ "@modelcontextprotocol/server-postgres@0.6.2" ] // {
+    disabled = true;
+  };
+  sqlite = bunx [ "@modelcontextprotocol/server-sqlite" ] // {
+    disabled = true;
+  }; # archived
+
+  # ================================================================
+  # Additional (disabled - specialized use cases)
+  # ================================================================
+
+  brave-search = bunx [ "@modelcontextprotocol/server-brave-search@0.6.2" ] // {
+    disabled = true;
+  };
+  # Google Workspace - Gmail, Drive, Calendar integration
+  # Source: https://github.com/taylorwilsdon/google_workspace_mcp
+  # Requires: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET env vars (via Doppler)
+  # Auth: One-time OAuth browser flow, tokens stored locally
+  # Selective tool loading: --tools limits which Google services are exposed
+  google-workspace = {
+    command = "doppler-mcp";
+    args = [
+      "uvx"
+      "--from"
+      "google-workspace-mcp==2.0.1"
+      "workspace-mcp"
+      "--tools"
+      "gmail"
+      "drive"
+      "calendar"
+    ];
+  };
+  google-maps = bunx [ "@modelcontextprotocol/server-google-maps@0.6.2" ] // {
+    disabled = true;
+  };
+  puppeteer = bunx [ "@modelcontextprotocol/server-puppeteer@2025.5.12" ] // {
+    disabled = true;
+  };
+  slack = bunx [ "@modelcontextprotocol/server-slack@2025.4.25" ] // {
+    disabled = true;
+  };
+  sentry = bunx [ "@modelcontextprotocol/server-sentry" ] // {
+    disabled = true;
+  }; # archived
+
+  # ================================================================
+  # Cribl MCP - OrbStack kubernetes-monitoring stack
+  # ================================================================
+  # Cribl MCP server running in OrbStack k8s cluster (NodePort :30030).
+  # Connection will fail when OrbStack k8s is not running — this is expected.
+  # See: ~/git/kubernetes-monitoring for the stack configuration.
+  # Cribl uses streamable HTTP transport (not SSE).
+  # Claude Code supports this natively with type = "http" — no mcp-remote proxy needed.
+  # See: https://docs.cribl.io/copilot/cribl-mcp-server/
+  cribl = {
+    type = "http";
+    url = "http://localhost:30030/mcp";
+  };
+
+  # ================================================================
+  # Bifrost AI Gateway - OrbStack kubernetes monitoring stack
+  # ================================================================
+  # Bifrost AI gateway running in OrbStack k8s cluster (NodePort :30080).
+  # Multi-provider routing: OpenAI, Anthropic, Gemini, OpenRouter, local MLX.
+  # OpenAI-compatible API at /v1, MCP server at /mcp.
+  # Connection will fail when OrbStack k8s is not running — this is expected.
+  # Provider API keys are managed by the Doppler K8s Operator inside the cluster
+  # (no doppler-mcp wrapper needed — secrets never reach the MCP client process).
+  #
+  # Diagnostics use native tools — no custom CLI exists or is needed:
+  #   claude mcp list | grep bifrost          # MCP connection state
+  #   make -C ~/git/orbstack-kubernetes/main status      # pod / service / sts state
+  #   make -C ~/git/orbstack-kubernetes/main test-smoke  # asserts /health, /v1/models, NodePort
+  #
+  # See: https://github.com/maximhq/bifrost
+  bifrost = {
+    type = "http";
+    url = "http://localhost:30080/mcp";
+  };
+}

--- a/nix-ai-claude/modules/mcp/pal-package.nix
+++ b/nix-ai-claude/modules/mcp/pal-package.nix
@@ -1,0 +1,48 @@
+# PAL MCP Server — Nix Python Package
+#
+# Builds pal-mcp-server from the pinned flake input instead of relying on
+# uvx at runtime. This eliminates:
+#   - git cloning on every cold start
+#   - setuptools_scm permission errors from the read-only Nix store
+#   - uvx cache corruption from previous failed builds
+#
+# The SETUPTOOLS_SCM_PRETEND_VERSION env var tells setuptools_scm to skip
+# git operations (version is hardcoded), so no write access to source is needed.
+#
+# Usage: pkgs.callPackage ./pal-package.nix { inherit pal-mcp-server; }
+{ python3Packages, pal-mcp-server }:
+
+let
+  # renovate: datasource=pypi depName=pal-mcp-server
+  version = "9.8.2";
+in
+python3Packages.buildPythonApplication {
+  pname = "pal-mcp-server";
+  inherit version;
+  src = pal-mcp-server;
+  pyproject = true;
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+    wheel
+  ];
+
+  dependencies = with python3Packages; [
+    mcp
+    google-genai
+    openai
+    pydantic
+    python-dotenv
+  ];
+
+  # Prevents setuptools_scm from running git to detect version.
+  # Without this, it would try to write pal_mcp_server.egg-info to the source
+  # directory, which fails because the Nix store is read-only.
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  # Tests require live API keys (Gemini, OpenRouter) — skip in Nix build.
+  # Note: pythonImportsCheck is not applicable — package uses a flat layout
+  # (server.py, config.py) with no importable Python package directory.
+  doCheck = false;
+}

--- a/nix-ai-claude/modules/mcp/scripts/check-pal-health.sh
+++ b/nix-ai-claude/modules/mcp/scripts/check-pal-health.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Post-activation PAL MCP health check
+#
+# Runs after darwin-rebuild switch to surface PAL issues early.
+# Non-blocking: always exits 0 (warnings only, never fails activation).
+#
+# Expected env vars (set by caller in pal-models.nix):
+#   DOPPLER      — path to doppler binary
+#   PAL_MCP_BIN  — path to pal-mcp-server binary (Nix store path)
+#   PAL_LOG_DIR  — writable directory for PAL logs
+#
+# Intentionally omits -e: each check runs independently and failures are
+# tallied in _fail rather than aborting the script.
+set -uo pipefail
+
+_pass=0
+_fail=0
+
+echo ""
+echo "--- PAL MCP Health Check ---"
+
+# 1. Verify pal-mcp-server binary exists (uses Nix store path, not PATH lookup)
+if [ -x "${PAL_MCP_BIN:-}" ]; then
+  echo "  PASS: pal-mcp-server binary found"
+  _pass=$((_pass + 1))
+else
+  echo "  FAIL: pal-mcp-server binary not found or not executable"
+  _fail=$((_fail + 1))
+fi
+
+# 2. Verify Doppler can authenticate
+_doppler_authed=0
+if "$DOPPLER" me >/dev/null 2>&1; then
+  echo "  PASS: Doppler authenticated"
+  _pass=$((_pass + 1))
+  _doppler_authed=1
+else
+  echo "  WARN: Doppler not authenticated — run 'doppler login'"
+  _fail=$((_fail + 1))
+fi
+
+# 3. Verify PAL secrets are accessible (only if Doppler authed)
+if [ "$_doppler_authed" -eq 1 ]; then
+  for secret in GEMINI_API_KEY OPENAI_API_KEY OPENROUTER_API_KEY; do
+    if "$DOPPLER" secrets get "$secret" \
+         --project ai-ci-automation \
+         --config prd \
+         --plain >/dev/null 2>&1; then
+      echo "  PASS: $secret accessible"
+      _pass=$((_pass + 1))
+    else
+      echo "  WARN: $secret missing or unreadable in ai-ci-automation/prd"
+      _fail=$((_fail + 1))
+    fi
+  done
+fi
+
+# 4. Verify PAL_LOG_DIR is writable
+if [ -d "$PAL_LOG_DIR" ] && [ -w "$PAL_LOG_DIR" ]; then
+  echo "  PASS: PAL_LOG_DIR writable ($PAL_LOG_DIR)"
+  _pass=$((_pass + 1))
+else
+  echo "  WARN: PAL_LOG_DIR not writable ($PAL_LOG_DIR)"
+  _fail=$((_fail + 1))
+fi
+
+# Summary
+if [ "$_fail" -eq 0 ]; then
+  echo "  Result: ALL PASSED ($_pass checks)"
+else
+  echo "  Result: $_fail issue(s), $_pass passed — PAL MCP may not work correctly"
+  echo "  Fix: Run 'doppler login' then 'check-pal-mcp' to diagnose"
+fi
+
+echo "---"
+echo ""
+
+# Never block activation
+exit 0

--- a/nix-ai-claude/modules/mcp/scripts/pal-models-mlx.jq
+++ b/nix-ai-claude/modules/mcp/scripts/pal-models-mlx.jq
@@ -1,0 +1,36 @@
+# pal-models-mlx.jq
+#
+# Transforms MLX vllm-mlx /v1/models JSON → PAL MCP custom_models.json format.
+# Usage: curl -sf http://127.0.0.1:11434/v1/models | \
+#          jq -L <dir> --slurpfile ratings <ratings.json> --from-file pal-models-mlx.jq
+#
+# Input format (OpenAI-compatible):
+#   { "data": [{ "id": "mlx-community/<model-id>", ... }] }
+#
+# Filtering: model MUST have a real LMSYS arena Elo rating. Models without
+# a benchmark score are omitted entirely. PAL only sees scored models.
+
+include "pal-models-shared";
+
+# Capability inferences from model name (no LMSYS field for these).
+def has_vision: test("[Vv][Ll][Mm]|[Vv]ision|VL-");
+def has_function_calling: test("Qwen3|Llama-4|Scout|Mistral|Nemotron");
+
+{
+  models: [
+    .data[]
+    | .id as $id
+    | ($id | split("/") | last) as $short
+    | ($short | ascii_downcase | gsub("-[0-9]+bit$"; "")) as $clean
+    | model_intelligence_score($id) as $score
+    | select($score != null)               # require real benchmark score
+    | {
+        model_name: $id,
+        aliases: [$short, $clean],
+        intelligence_score: $score,
+        json_mode: false,
+        function_calling: ($short | has_function_calling),
+        images: ($short | has_vision)
+      }
+  ]
+}

--- a/nix-ai-claude/modules/mcp/scripts/pal-models-openrouter.jq
+++ b/nix-ai-claude/modules/mcp/scripts/pal-models-openrouter.jq
@@ -1,0 +1,34 @@
+# pal-models-openrouter.jq
+#
+# Transforms OpenRouter /api/v1/models → PAL openrouter_models.json format.
+# Single source of truth for ALL cloud models, regardless of native provider.
+#
+# Filtering:
+#   - created in last 90 days AND not deprecated
+#   - MUST have a real LMSYS arena Elo rating (no heuristic fallback)
+#
+# Models without an LMSYS rating are omitted entirely. PAL only sees
+# models with a real benchmark score.
+
+include "pal-models-shared";
+
+{
+  models: [
+    .data[]
+    | select(.created > (now - 7776000))   # last 90 days
+    | select(.expiration_date == null)     # not deprecated
+    | model_intelligence_score(.id) as $score
+    | select($score != null)               # require real benchmark score
+    | {
+        model_name: .id,
+        aliases: [.id | split("/") | last],
+        context_window: (.context_length // 8192),
+        max_output_tokens: (.top_provider.max_completion_tokens // 8192),
+        supports_function_calling: ((.supported_parameters // []) | index("tools") != null),
+        supports_extended_thinking: ((.supported_parameters // []) | index("include_reasoning") != null),
+        supports_json_mode: ((.supported_parameters // []) | index("structured_outputs") != null),
+        supports_images: ((.architecture.modality // "") | test("image")),
+        intelligence_score: $score
+      }
+  ]
+}

--- a/nix-ai-claude/modules/mcp/scripts/pal-models-shared.jq
+++ b/nix-ai-claude/modules/mcp/scripts/pal-models-shared.jq
@@ -1,0 +1,66 @@
+# pal-models-shared.jq
+#
+# Shared jq helpers for LMSYS arena rating lookup, included by both
+# pal-models-mlx.jq and pal-models-openrouter.jq.
+#
+# Loaded via: jq -L <scripts_dir> --slurpfile ratings <ratings.json> --from-file <transform>.jq
+#
+# LMSYS arena Elo is the SINGLE source of intelligence scoring across the
+# entire pipeline. There are no heuristic fallbacks. Models that aren't
+# on the leaderboard are filtered out by the transforms — PAL only sees
+# models with a real benchmark score.
+#
+# Score normalization: linear map from Elo to PAL's 1-20 scale.
+#   (rating - 800) / 700 * 19 + 1, clamped to [1, 20]
+#   1499 → 20  (claude-opus-4-6-thinking, current top)
+#   1300 → ~14 (median 2026 frontier model)
+#   1100 → ~9  (older frontier, e.g. claude-3-opus-20240229)
+#    800 → 1   (early-2024 baseline)
+
+# Lowercase + strip provider prefix + strip MLX quant suffix.
+# OpenRouter ids: "anthropic/claude-opus-4.6" → "claude-opus-4.6"
+# MLX ids:        "mlx-community/Qwen3.5-122B-A10B-4bit" → "qwen3.5-122b-a10b"
+def normalize_name:
+  ascii_downcase
+  | sub("^[^/]+/"; "")           # strip "anthropic/", "mlx-community/", etc.
+  | sub("-[0-9]+bit$"; "");      # strip MLX quant suffix
+
+# Find the highest LMSYS rating among keys that start with $prefix.
+# Used as a fuzzy fallback for variants the leaderboard names differently:
+#   "x-ai/grok-4.20" → matches "grok-4.20-beta1" via prefix
+# Returns null if no key matches.
+def find_best_prefix_match($prefix):
+  ($ratings[0] // {}) as $r
+  | [$r | to_entries[] | select(.key | startswith($prefix)) | .value]
+  | if length > 0 then max else null end;
+
+# Look up an Elo rating from the slurped $ratings file.
+# Tries (in order): exact match, hyphenated form (Anthropic), prefix match.
+# Returns null if nothing matches — caller MUST handle null (typically by
+# filtering the model out, never by inventing a fallback score).
+def lookup_rating($name):
+  ($ratings[0] // {}) as $r
+  | ($name | normalize_name) as $base
+  | ($base | gsub("\\."; "-")) as $hyphenated
+  | $r[$base]
+    // $r[$hyphenated]
+    // find_best_prefix_match($base)
+    // find_best_prefix_match($hyphenated)
+    // null;
+
+# Convert an Elo rating to PAL's 1-20 intelligence scale.
+# Uses half-up rounding so 1499 → 20 (not 19 with floor).
+# Returns null if rating is null. Callers must filter null results out.
+def rating_to_score($rating):
+  if $rating == null then null
+  else
+    ((($rating - 800) / 700 * 19 + 1 + 0.5) | floor) as $raw
+    | if $raw < 1 then 1
+      elif $raw > 20 then 20
+      else $raw
+      end
+  end;
+
+# One-shot lookup: name → score, or null if not in LMSYS arena.
+def model_intelligence_score($name):
+  lookup_rating($name) | rating_to_score(.);

--- a/nix-ai-claude/modules/mcp/scripts/sync-lmarena-ratings.sh
+++ b/nix-ai-claude/modules/mcp/scripts/sync-lmarena-ratings.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# sync-lmarena-ratings.sh
+#
+# Fetches LMSYS Chatbot Arena leaderboard via HuggingFace datasets-server
+# and writes a flat name→Elo lookup file. SOLE source of intelligence
+# scoring across all PAL model transforms — no heuristic fallbacks.
+#
+# Run as a subprocess (never source): bash "${SCRIPTS_DIR}/sync-lmarena-ratings.sh"
+# Required env: CURL, JQ, OUTPUT_DIR
+
+set -eu
+
+api="https://datasets-server.huggingface.co/filter?dataset=lmarena-ai%2Fleaderboard-dataset&config=text&split=latest&where=%22category%22%3D%27overall%27&length=100"
+
+mkdir -p "$OUTPUT_DIR"
+final="${OUTPUT_DIR}/lmarena-ratings.json"
+work=$(mktemp -d)
+pages="${work}/pages.jsonl"
+staged="${work}/staged.json"
+
+offset=0
+while :; do
+  page=$("$CURL" -sf --max-time 30 "${api}&offset=${offset}") || { rm -rf "$work"; exit 1; }
+  printf '%s\n' "$page" >> "$pages"
+  [ "$(printf '%s' "$page" | "$JQ" '.rows | length')" -lt 100 ] && break
+  offset=$((offset + 100))
+done
+
+"$JQ" -s '[.[].rows[].row | {(.model_name): .rating}] | add // {}' "$pages" > "$staged"
+
+count=$("$JQ" 'length' "$staged")
+if [ "$count" -gt 0 ]; then
+  mv "$staged" "$final"
+  echo "  lmarena-ratings: ${count} models"
+else
+  echo "  WARN: LMSYS arena returned 0 models — preserving previous ratings file" >&2
+fi
+rm -rf "$work"

--- a/nix-ai-claude/modules/mcp/scripts/sync-pal-cloud-models.sh
+++ b/nix-ai-claude/modules/mcp/scripts/sync-pal-cloud-models.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=bash
+# sync-pal-cloud-models.sh
+#
+# Dynamic cloud model discovery for PAL MCP via OpenRouter public API.
+# Generates openrouter_models.json from a single API call (no auth required).
+#
+# Required environment variables (set by caller):
+#   CURL              — path to curl binary
+#   JQ                — path to jq binary
+#   SCRIPTS_DIR       — directory holding pal-models-shared.jq and sync-lmarena-ratings.sh
+#   OPENROUTER_JQ_FILE — path to pal-models-openrouter.jq
+#   OUTPUT_DIR        — directory for output files (also where lmarena-ratings.json lives)
+
+OPENROUTER_API="https://openrouter.ai/api/v1/models"
+OUTPUT_FILE="${OUTPUT_DIR}/openrouter_models.json"
+RATINGS_FILE="${OUTPUT_DIR}/lmarena-ratings.json"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Refresh LMSYS arena ratings (sole source of intelligence scoring).
+# Runs as subprocess so trap/var leaks cannot pollute this script.
+bash "${SCRIPTS_DIR}/sync-lmarena-ratings.sh" || echo "  WARN: ratings sync failed, using existing file if any" >&2
+
+# If ratings file is missing, preserve the existing output — don't persist
+# an empty model list just because the ratings fetch failed.
+if [ ! -f "$RATINGS_FILE" ]; then
+  echo "  WARN: ${RATINGS_FILE} missing — preserving previous ${OUTPUT_FILE}" >&2
+  exit 0
+fi
+
+# Fetch and transform — preserves previous file on any failure
+api_json=$("$CURL" -sf --connect-timeout 10 --max-time 30 "$OPENROUTER_API" || echo "")
+
+if [ -z "$api_json" ]; then
+  echo "  WARN: OpenRouter API unreachable — preserving previous model config" >&2
+  exit 0
+fi
+
+provider_json=$(echo "$api_json" | "$JQ" -L "$SCRIPTS_DIR" --slurpfile ratings "$RATINGS_FILE" --from-file "$OPENROUTER_JQ_FILE" || echo '{"models": []}')
+model_count=$(echo "$provider_json" | "$JQ" '.models | length' || echo "0")
+
+if [ "$model_count" -gt 0 ] || [ ! -f "$OUTPUT_FILE" ]; then
+  echo "$provider_json" > "$OUTPUT_FILE"
+  echo "  openrouter: ${model_count} models"
+else
+  echo "  openrouter: 0 models (preserved previous)" >&2
+fi

--- a/nix-ai-claude/modules/mcp/scripts/sync-pal-models.sh
+++ b/nix-ai-claude/modules/mcp/scripts/sync-pal-models.sh
@@ -1,0 +1,38 @@
+# sync-pal-models.sh
+#
+# Shared logic for PAL custom_models.json generation.
+# Used by both sync-mlx-models CLI tool and home.activation.palCustomModels.
+#
+# Required environment variables (set by caller):
+#   CURL         — path to curl binary
+#   JQ           — path to jq binary
+#   SCRIPTS_DIR  — directory holding pal-models-shared.jq and sync-lmarena-ratings.sh
+#   MLX_JQ_FILE  — path to pal-models-mlx.jq
+#   MLX_URL      — MLX /v1/models endpoint
+#   OUTPUT_DIR   — directory for output file (also where lmarena-ratings.json lives)
+#   OUTPUT_FILE  — full path to custom_models.json
+
+mkdir -p "$OUTPUT_DIR"
+RATINGS_FILE="${OUTPUT_DIR}/lmarena-ratings.json"
+
+# Refresh LMSYS arena ratings (sole source of intelligence scoring).
+# Runs as subprocess so trap/var leaks cannot pollute this script.
+bash "${SCRIPTS_DIR}/sync-lmarena-ratings.sh" || echo "  WARN: ratings sync failed, using existing file if any" >&2
+
+# If ratings file is missing (never fetched), skip the transform entirely
+# so we don't persist an empty model list.
+if [ ! -f "$RATINGS_FILE" ]; then
+  echo "  WARN: ${RATINGS_FILE} missing — preserving previous ${OUTPUT_FILE}" >&2
+  exit 0
+fi
+
+# Query MLX vllm-mlx for loaded models (OpenAI format)
+mlx_json=$("$CURL" -sf --connect-timeout 3 --max-time 5 "$MLX_URL" \
+  | "$JQ" -L "$SCRIPTS_DIR" --slurpfile ratings "$RATINGS_FILE" --from-file "$MLX_JQ_FILE" \
+  || echo '{"models": []}')
+
+# Only overwrite if models were found (preserve previous file otherwise)
+model_count=$(echo "$mlx_json" | "$JQ" '.models | length')
+if [ "$model_count" -gt 0 ] || [ ! -f "$OUTPUT_FILE" ]; then
+  echo "$mlx_json" > "$OUTPUT_FILE"
+fi

--- a/nix-ai-claude/modules/mlx-compat.nix
+++ b/nix-ai-claude/modules/mlx-compat.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+
+{
+  options.programs.mlx = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Minimal MLX compatibility surface for Claude PAL integration.";
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "MLX API host used by Claude PAL model sync.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.int;
+      default = 11434;
+      description = "MLX API port used by Claude PAL model sync.";
+    };
+
+    defaultModel = lib.mkOption {
+      type = lib.types.str;
+      default = "mlx-community/Qwen3.5-122B-A10B-4bit";
+      description = "Default MLX model name exposed to Claude PAL integration.";
+    };
+  };
+}

--- a/nix-ai-claude/modules/permissions/claude-permissions-allow.nix
+++ b/nix-ai-claude/modules/permissions/claude-permissions-allow.nix
@@ -1,0 +1,43 @@
+# Claude Code Auto-Approved Commands (ALLOW List)
+#
+# Uses unified permission definitions from ai-cli/common/permissions.nix
+# with Claude-specific formatting via formatters.nix.
+#
+# FORMAT: Bash(cmd *) for shell commands, plus tool-specific patterns
+#
+# SINGLE SOURCE OF TRUTH:
+# Command definitions are in ai-cli/common/permissions.nix
+# This file only applies Claude-specific formatting.
+
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  # Import unified permissions and formatters
+  # Error handling: Verify the ai-cli/common module exists and can be imported
+  commonPath = ../common;
+  aiCommon =
+    if builtins.pathExists commonPath then
+      import commonPath { inherit lib config; }
+    else
+      builtins.throw ''
+        ERROR: common module not found at ${toString commonPath}
+
+        This wrapper module expects the unified permission system to exist.
+        Ensure:
+        1. modules/common/default.nix exists
+        2. modules/common/permissions.nix exists
+        3. modules/common/formatters.nix exists
+      '';
+
+  inherit (aiCommon) permissions formatters;
+
+in
+{
+  # Export allowed permissions list
+  # Combines shell commands (Bash(cmd *)) with tool-specific permissions
+  allow = formatters.claude.formatAllowed permissions;
+}

--- a/nix-ai-claude/modules/permissions/claude-permissions-ask.nix
+++ b/nix-ai-claude/modules/permissions/claude-permissions-ask.nix
@@ -1,0 +1,29 @@
+# Claude Code Ask-Mode Commands (ASK List)
+#
+# Commands that require user confirmation before execution.
+# Currently empty - this is intentional.
+#
+# DESIGN DECISION:
+# This repository uses a binary allow/deny permission model:
+# - Allow: Auto-approved, safe commands
+# - Deny: Permanently blocked, dangerous commands
+# - Ask: Not used (empty by design)
+#
+# The ask list could be populated in the future for commands that need
+# case-by-case confirmation, but the current model is sufficient for
+# autonomous AI operation while maintaining security.
+#
+# SINGLE SOURCE OF TRUTH:
+# Command definitions would go in ai-cli/common/permissions.nix
+# This file only applies Claude-specific formatting.
+
+{
+  config,
+  lib,
+  ...
+}:
+
+{
+  # Export ask permissions list (currently empty)
+  ask = [ ];
+}

--- a/nix-ai-claude/modules/permissions/claude-permissions-deny.nix
+++ b/nix-ai-claude/modules/permissions/claude-permissions-deny.nix
@@ -1,0 +1,49 @@
+# Claude Code Permanently Blocked Commands (DENY List)
+#
+# Uses unified permission definitions from ai-cli/common/permissions.nix
+# with Claude-specific formatting via formatters.nix.
+#
+# FORMAT: Bash(cmd *) for blocked shell commands, plus Read() patterns for sensitive files
+#
+# SINGLE SOURCE OF TRUTH:
+# Command definitions are in ai-cli/common/permissions.nix
+# This file only applies Claude-specific formatting.
+#
+# SECURITY PHILOSOPHY:
+# - These are truly catastrophic operations (system destruction, data exfiltration)
+# - Also blocks reading of sensitive files (.env, SSH keys, etc.)
+# - No user confirmation can override these blocks
+# - If a legitimate use case arises, edit ai-cli/common/permissions.nix
+
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  # Import unified permissions and formatters
+  # Error handling: Verify the ai-cli/common module exists and can be imported
+  commonPath = ../common;
+  aiCommon =
+    if builtins.pathExists commonPath then
+      import commonPath { inherit lib config; }
+    else
+      builtins.throw ''
+        ERROR: common module not found at ${toString commonPath}
+
+        This wrapper module expects the unified permission system to exist.
+        Ensure:
+        1. modules/common/default.nix exists
+        2. modules/common/permissions.nix exists
+        3. modules/common/formatters.nix exists
+      '';
+
+  inherit (aiCommon) permissions formatters;
+
+in
+{
+  # Export denied permissions list
+  # Combines shell denies (Bash(cmd *)) with sensitive file read blocks
+  deny = formatters.claude.formatDenied permissions;
+}

--- a/nix-ai-claude/modules/scripts/claude-json-merge.sh
+++ b/nix-ai-claude/modules/scripts/claude-json-merge.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Deep-merge a Nix-generated JSON overlay into ~/.claude.json.
+# Sourced from settings.nix activation with OVERLAY_FILE and TRUSTED_PROJECT_DIRS set.
+# Requires: OVERLAY_FILE, TRUSTED_PROJECT_DIRS (JSON array of dirs), DRY_RUN_CMD, jq on PATH.
+#
+# Merge strategy:
+# - Top-level keys from overlay replace existing values (mcpServers, remoteControlAtStartup)
+# - .projects entries are deep-merged: overlay values merge INTO existing project entries
+#   (preserving runtime-managed keys like allowedTools, mcpServers per-project, etc.)
+# - Trust entries are generated at activation time by scanning TRUSTED_PROJECT_DIRS,
+#   since filesystem discovery cannot happen at Nix evaluation time in pure flake mode.
+
+CLAUDE_JSON="$HOME/.claude.json"
+
+# Build project trust entries by scanning each trusted base dir for repo subdirs.
+# Each "$baseDir/$repo/main" path gets hasClaudeMdExternalIncludesApproved = true.
+_build_trust_overlay() {
+  local dirs_json="$1"
+  local trust_entry='{"hasClaudeMdExternalIncludesApproved":true,"hasClaudeMdExternalIncludesWarningShown":true,"hasTrustDialogAccepted":true}'
+  local paths=()
+
+  while IFS= read -r base_dir; do
+    base_dir="${base_dir/#\~/$HOME}"
+    [ -d "$base_dir" ] || continue
+    while IFS= read -r repo_dir; do
+      local repo_name
+      repo_name=$(basename "$repo_dir")
+      # Skip hidden dirs and non-repo-looking entries
+      [[ "$repo_name" == .* ]] && continue
+      local path="${repo_dir}/main"
+      [ -d "$path" ] || continue
+      paths+=("$path")
+    done < <(find "$base_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+  done < <(jq -r '.[]' <<<"$dirs_json" 2>/dev/null)
+
+  if [ ${#paths[@]} -eq 0 ]; then
+    echo '{}'
+    return
+  fi
+
+  # Build entire trust object in one jq call instead of one per path
+  printf '%s\n' "${paths[@]}" | jq -Rs --argjson trust "$trust_entry" '
+    split("\n") | map(select(length > 0)) | map({(.): $trust}) | add // {}
+  '
+}
+
+# Atomically write jq output to CLAUDE_JSON via a temp file.
+# Usage: _jq_to_file <warning-msg> [jq args...]
+_jq_to_file() {
+  local msg="$1"; shift
+  local tmp
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' EXIT
+  if jq "$@" > "$tmp"; then
+    $DRY_RUN_CMD mv "$tmp" "$CLAUDE_JSON"
+    trap - EXIT
+  else
+    echo "warning: $msg" >&2
+    rm -f "$tmp"
+  fi
+}
+
+trust_projects=$(_build_trust_overlay "$TRUSTED_PROJECT_DIRS")
+
+if [ -f "$CLAUDE_JSON" ]; then
+  _jq_to_file \
+    "Failed to update \"$CLAUDE_JSON\"; existing file may contain invalid JSON. Fix or remove it to apply settings." \
+    -s --argjson trust "$trust_projects" \
+    '
+      .[0] as $existing | .[1] as $overlay |
+      # Replace top-level keys from overlay (mcpServers etc.), deep-merge .projects.
+      ($existing + ($overlay | del(.projects))) | .projects = (($existing.projects // {}) * ($overlay.projects // {}) * $trust)
+    ' "$CLAUDE_JSON" "$OVERLAY_FILE"
+else
+  _jq_to_file \
+    "Failed to create \"$CLAUDE_JSON\" from overlay; jq returned an error." \
+    --argjson trust "$trust_projects" \
+    '. + {projects: $trust}' "$OVERLAY_FILE"
+fi
+
+[ -f "$CLAUDE_JSON" ] && $DRY_RUN_CMD chmod 600 "$CLAUDE_JSON"

--- a/nix-ai-claude/modules/scripts/cleanup-broken-symlinks.sh
+++ b/nix-ai-claude/modules/scripts/cleanup-broken-symlinks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Remove broken symlinks (target does not exist) inside component directories.
+# Usage (sourced): . this-script type1 dir1 type2 dir2 ...
+# Requires: DRY_RUN_CMD from activation scope.
+
+# Requires: log_info, log_warn from cleanup-common.sh (sourced by caller)
+
+while [ $# -ge 2 ]; do
+  type_name="$1"
+  dir="$2"
+  shift 2
+  if [ -d "$dir" ]; then
+    find "$dir" -maxdepth 1 -type l -print0 | while IFS= read -d $'\0' -r link; do
+      if [ ! -e "$link" ]; then
+        if $DRY_RUN_CMD rm "$link"; then
+          log_info "Removed orphan ${type_name}: $(basename "$link")"
+        else
+          log_warn "Failed to remove orphan ${type_name}: $(basename "$link")"
+        fi
+      fi
+    done
+  fi
+done

--- a/nix-ai-claude/modules/scripts/cleanup-common.sh
+++ b/nix-ai-claude/modules/scripts/cleanup-common.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Shared logging functions for cleanup scripts.
+# Sourced by cleanup-*.sh scripts.
+
+log_info() { echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] $1" >&2; }
+log_warn() { echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] $1" >&2; }

--- a/nix-ai-claude/modules/scripts/cleanup-conflicting-symlinks.sh
+++ b/nix-ai-claude/modules/scripts/cleanup-conflicting-symlinks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Remove entries that conflict with home-manager's link generation.
+# Handles both directory symlinks (normal case) and real directories
+# (one-time migration from recursive=true to directory symlinks).
+# Usage (sourced): . this-script dir1 dir2 ...
+# Requires: DRY_RUN_CMD from activation scope.
+
+# Requires: log_info, log_warn from cleanup-common.sh (sourced by caller)
+
+for dir in "$@"; do
+  if [ -L "$dir" ]; then
+    TARGET=$(readlink "$dir")
+    if [[ "$TARGET" == /nix/store/* ]]; then
+      if $DRY_RUN_CMD rm "$dir"; then
+        log_info "Removed conflicting directory symlink: $dir"
+        log_info "  (was: $TARGET)"
+      else
+        log_warn "Failed to remove directory symlink: $dir"
+      fi
+    fi
+  elif [ -d "$dir" ]; then
+    # Real directory left over from old recursive=true setup.
+    # Only remove if under the marketplaces path — component dirs (commands, agents,
+    # skills) may contain user-created content and must never be rm -rf'd.
+    case "$dir" in
+      */.claude/plugins/marketplaces/*)
+        if $DRY_RUN_CMD rm -rf "$dir"; then
+          log_info "Removed real directory (migration to directory symlink): $dir"
+        else
+          log_warn "Failed to remove real directory: $dir"
+        fi
+        ;;
+      *)
+        log_warn "Skipping rm -rf for non-marketplace directory: $dir"
+        ;;
+    esac
+  fi
+done

--- a/nix-ai-claude/modules/scripts/cleanup-marketplaces-symlink.sh
+++ b/nix-ai-claude/modules/scripts/cleanup-marketplaces-symlink.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Remove stale Nix-managed symlink for known_marketplaces.json.
+# Sourced from registry.nix activation with MARKETPLACES set in environment.
+
+if [ -L "$MARKETPLACES" ]; then
+  if $DRY_RUN_CMD rm "$MARKETPLACES"; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Removed Nix-managed symlink for known_marketplaces.json (now Claude-managed)"
+  else
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to remove Nix symlink at $MARKETPLACES (non-critical)" >&2
+  fi
+fi

--- a/nix-ai-claude/modules/scripts/cleanup-stale-symlinks.sh
+++ b/nix-ai-claude/modules/scripts/cleanup-stale-symlinks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Remove stale nix-store symlinks (target is in /nix/store AND no longer exists).
+# Usage (sourced): . this-script path1 path2 ...
+# Requires: DRY_RUN_CMD from activation scope.
+
+# Requires: log_info, log_warn from cleanup-common.sh (sourced by caller)
+
+for path in "$@"; do
+  if [ -L "$path" ]; then
+    TARGET=$(readlink "$path")
+    if [[ "$TARGET" == /nix/store/* ]] && [ ! -e "$TARGET" ]; then
+      if $DRY_RUN_CMD rm "$path"; then
+        log_info "Removed stale symlink: $path"
+      else
+        log_warn "Failed to remove stale symlink: $path"
+      fi
+    fi
+  fi
+done

--- a/nix-ai-claude/modules/scripts/merge-json-settings.sh
+++ b/nix-ai-claude/modules/scripts/merge-json-settings.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Deep-merge Nix-generated JSON settings with existing runtime state.
+# Generic script used by multiple tools (Gemini, Claude, etc.).
+#
+# Canonical source: nix-home/modules/home-manager/scripts/merge-json-settings.sh
+# Keep in sync when modifying. Full dedup planned when nix-home becomes a flake input.
+#
+# Preserves runtime-only keys while updating Nix-managed settings.
+# Merge strategy: existing runtime file as base, Nix config overlaid on top.
+# Nix-managed keys always win, but runtime-only keys are preserved.
+#
+# Arguments:
+#   $1 - Path to Nix-generated settings JSON (in /nix/store)
+#   $2 - Path to target settings file
+#
+# jq must be on PATH (callers ensure this via PATH export or writeShellApplication).
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: merge-json-settings <nix-settings-path> <target-path>" >&2
+  exit 1
+fi
+
+NIX_SETTINGS="$1"
+TARGET="$2"
+
+TARGET_NAME=$(basename "$TARGET")
+TARGET_DIR=$(dirname "$TARGET")
+mkdir -p "$TARGET_DIR"
+
+if [[ -f "$TARGET" ]] && [[ ! -L "$TARGET" ]]; then
+  # File exists and is a real file (not symlink) - merge
+  # jq -s '.[0] * .[1]' merges deeply: [0]=existing runtime, [1]=Nix config
+  # Nix config wins on conflicts, runtime-only keys are preserved
+  MERGED=$(jq -s '.[0] * .[1]' "$TARGET" "$NIX_SETTINGS") || {
+    # If merge fails (e.g., invalid JSON in target), just use Nix settings
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to merge existing ${TARGET_NAME}, using Nix config" >&2
+    cp "$NIX_SETTINGS" "$TARGET"
+    chmod 600 "$TARGET"
+    exit 0
+  }
+  printf '%s\n' "$MERGED" > "${TARGET}.tmp"
+  mv "${TARGET}.tmp" "$TARGET"
+  chmod 600 "$TARGET"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Merged ${TARGET_NAME} (preserved runtime state)"
+elif [[ -L "$TARGET" ]]; then
+  # It's a symlink (old Nix-managed) - remove and create real file
+  rm "$TARGET"
+  cp "$NIX_SETTINGS" "$TARGET"
+  chmod 600 "$TARGET"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Replaced Nix symlink with writable ${TARGET_NAME}"
+else
+  # No existing file - just copy
+  cp "$NIX_SETTINGS" "$TARGET"
+  chmod 600 "$TARGET"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Created initial ${TARGET_NAME}"
+fi

--- a/nix-ai-claude/modules/scripts/merge-json-settings.sh
+++ b/nix-ai-claude/modules/scripts/merge-json-settings.sh
@@ -40,8 +40,9 @@ if [[ -f "$TARGET" ]] && [[ ! -L "$TARGET" ]]; then
     chmod 600 "$TARGET"
     exit 0
   }
-  printf '%s\n' "$MERGED" > "${TARGET}.tmp"
-  mv "${TARGET}.tmp" "$TARGET"
+  TMP_FILE=$(mktemp "${TARGET}.tmp.XXXXXX")
+  printf '%s\n' "$MERGED" > "$TMP_FILE"
+  mv "$TMP_FILE" "$TARGET"
   chmod 600 "$TARGET"
   echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] Merged ${TARGET_NAME} (preserved runtime state)"
 elif [[ -L "$TARGET" ]]; then

--- a/nix-ai-claude/modules/scripts/validate-claude-settings.sh
+++ b/nix-ai-claude/modules/scripts/validate-claude-settings.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Validate Claude Code settings.json against JSON Schema
+# Called by home-manager activation hook after writeBoundary
+#
+# Arguments:
+#   $1 - Path to settings.json file
+#   $2 - Schema URL
+#
+# Exit codes:
+#   0 - Always. Validation failures are only reported as warnings to stderr
+#       and do not block activation.
+#   1 - Only on argument/usage error.
+
+set -euo pipefail
+
+SETTINGS="${1:-}"
+SCHEMA_URL="${2:-}"
+
+if [ -z "$SETTINGS" ] || [ -z "$SCHEMA_URL" ]; then
+  echo "Usage: $0 <settings-path> <schema-url>" >&2
+  exit 1
+fi
+
+if [ ! -f "$SETTINGS" ]; then
+  # Settings file doesn't exist yet - normal during first activation
+  exit 0
+fi
+
+# Run validation using ephemeral nix shell - warn but don't fail activation
+nix shell nixpkgs#check-jsonschema -c check-jsonschema --schemafile "$SCHEMA_URL" "$SETTINGS" || {
+  echo "Warning: Claude Code settings.json validation failed" >&2
+}

--- a/nix-ai-claude/modules/scripts/verify-cache-integrity.sh
+++ b/nix-ai-claude/modules/scripts/verify-cache-integrity.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Verify Claude Code plugin cache integrity after Nix rebuilds
+# Removes stale cache entries when marketplace store paths change
+#
+# When Nix updates marketplace symlinks to new /nix/store paths,
+# Claude Code's cached plugin data becomes stale and must be purged.
+# See: https://github.com/anthropics/claude-code/issues/17361
+
+set -euo pipefail
+
+# Centralized logging function (stderr for diagnostics)
+log_info() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] $1" >&2
+}
+
+HOME_DIR="${1:?Usage: verify-cache-integrity.sh <home-dir>}"
+MARKETPLACES_DIR="$HOME_DIR/.claude/plugins/marketplaces"
+CACHE_DIR="$HOME_DIR/.claude/plugins/cache"
+HASH_FILE="$CACHE_DIR/.nix-store-hashes"
+
+# Resolve the SHA-256 hasher once at startup into _SHA_CMD.
+# Prefer shasum from PATH (present on macOS and installable cross-platform),
+# fall back to the macOS system copy, then sha256sum (Linux coreutils).
+# sha256sum does not accept -a 256, so wrap the call to normalise the interface.
+# NOTE: _SHA_CMD must persist — sha256_string references it at call time, not
+# definition time. Using a temporary that gets unset causes "unbound variable"
+# under set -u, silently breaking cache integrity on every darwin-rebuild switch.
+if _SHA_CMD=$(command -v shasum 2>/dev/null) || { [ -x /usr/bin/shasum ] && _SHA_CMD=/usr/bin/shasum; }; then
+  sha256_string() { "$_SHA_CMD" -a 256; }
+elif _SHA_CMD=$(command -v sha256sum 2>/dev/null); then
+  sha256_string() { "$_SHA_CMD"; }
+else
+  echo "error: no shasum or sha256sum found" >&2
+  exit 1
+fi
+
+# Only run if both dirs exist
+[[ -d "$MARKETPLACES_DIR" ]] || exit 0
+[[ -d "$CACHE_DIR" ]] || exit 0
+
+# Load existing hashes
+declare -A old_hashes
+if [[ -f "$HASH_FILE" ]]; then
+  while IFS='=' read -r key value; do
+    [[ -n "$key" ]] && old_hashes["$key"]="$value"
+  done < "$HASH_FILE"
+fi
+
+# Build new hashes and detect staleness
+# Marketplaces are directory symlinks to /nix/store/ (plugins.nix without recursive)
+declare -A new_hashes
+stale_detected=false
+while IFS= read -r -d '' entry; do
+  name=$(basename "$entry")
+
+  # Directory symlink: target is the nix store path itself
+  target=$(readlink "$entry")
+  [[ "$target" == /nix/store/* ]] || continue
+
+  # Hash the store path string (not file contents - that's what matters for staleness)
+  hash=$(printf '%s' "$target" | sha256_string | cut -d' ' -f1)
+  new_hashes["$name"]="$hash"
+
+  if [[ "${old_hashes[$name]:-}" != "$hash" ]]; then
+    stale_detected=true
+  fi
+done < <(find "$MARKETPLACES_DIR" -mindepth 1 -maxdepth 1 -type l -print0)
+
+# Session-aware guard: if caches are stale but Claude Code is running, defer the
+# purge to avoid breaking active sessions. Hook scripts inside cache directories are
+# resolved at session start — deleting them mid-session causes an unbreakable error
+# loop (every hook fails, including Stop). By also skipping the hash file update,
+# the next rebuild will re-detect staleness and purge when no sessions are active.
+if [[ "$stale_detected" == true ]] && pgrep -qx "claude"; then
+  log_info "Stale caches detected but Claude Code session is active — deferring purge"
+  exit 0
+fi
+
+# Purge stale caches (safe — no active sessions)
+for name in "${!new_hashes[@]}"; do
+  if [[ "${old_hashes[$name]:-}" != "${new_hashes[$name]}" ]]; then
+    if [[ -d "$CACHE_DIR/$name" ]]; then
+      rm -rf "${CACHE_DIR:?}/$name"
+      log_info "Purged stale cache: $name"
+    fi
+  fi
+done
+
+# Write updated hashes atomically to avoid leaving a partially written file
+mkdir -p "$CACHE_DIR"
+tmp_hash_file="$(mktemp "${HASH_FILE}.XXXXXX")"
+for name in "${!new_hashes[@]}"; do
+  echo "${name}=${new_hashes[$name]}" >> "$tmp_hash_file"
+done
+mv "$tmp_hash_file" "$HASH_FILE"


### PR DESCRIPTION
Extract the Claude-specific module stack into a standalone `nix-ai-claude` flake while keeping `nix-ai` as a consumer.

What changed:
- Added `nix-ai-claude/` with the Claude module, supporting libs, checks, scripts, and docs.
- Exported standalone and embedded Claude module entrypoints.
- Updated `nix-ai` to consume the extracted module instead of assembling Claude locally.
- Kept the existing Claude option surface and defaults intact.

Validation:
- `nix flake check ./nix-ai-claude --no-build`
- `nix flake show ./nix-ai-claude`
- `nix flake show .`

Notes:
- The new work lives on the dedicated branch `feat/nix-ai-claude` in a separate worktree.
- `nix-ai` top-level check still has an unrelated existing `fabric-marketplace-build` evaluation issue; Claude extraction itself validates cleanly.