### PR TITLE
feat(gemini): migrate to Policy Engine (TOML rules)

### DIFF
--- a/modules/common/formatters.nix
+++ b/modules/common/formatters.nix
@@ -116,47 +116,85 @@ in
   # ============================================================================
   # GEMINI CLI FORMATTER
   # ============================================================================
-  # Format: ShellTool(cmd) for shell commands
-  # No wildcard suffix - exact command match or prefix match
+  # Format: TOML rules for Policy Engine
   #
-  # CRITICAL - tools.allowed vs tools.core in settings.json:
-  # =========================================================
   # Per the official Gemini CLI schema:
-  # - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
-  # - tools.core = "Allowlist to RESTRICT built-in tools to a specific set" (LIMITS usage!)
-  #
-  # This formatter provides formatAllowedTools for the "allowed" key.
-  # NEVER use formatAllowedTools output for "core" - that would break permissions!
-  # Schema: https://github.com/google-gemini/gemini-cli/blob/main/schemas/settings.schema.json
+  # Policies use rule arrays with toolName, commandPrefix, and decision.
+  gemini = rec {
+    # Tool name mapping from legacy builtin names to new Policy Engine names
+    toolNameMap = {
+      "ReadFileTool" = "read_file";
+      "GlobTool" = "glob";
+      "GrepTool" = "grep_search";
+      "WebFetchTool" = "web_fetch";
+    };
 
-  gemini = {
-    # Format a single shell command for Gemini
+    # Format into TOML-compatible attribute sets for the Policy Engine
+    formatAllowRules =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.allow;
+        builtinTools = permissions.toolSpecific.gemini.builtin or [ ];
+
+        shellRules = map (cmd: {
+          toolName = "run_shell_command";
+          commandPrefix = cmd;
+          decision = "allow";
+          priority = 100;
+        }) allCommands;
+
+        builtinRules = map (tool: {
+          toolName = toolNameMap.${tool} or tool;
+          decision = "allow";
+          priority = 100;
+        }) builtinTools;
+      in
+      builtinRules ++ shellRules;
+
+    # Format all denied commands for the Policy Engine
+    formatDenyRules =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.deny;
+      in
+      map (cmd: {
+        toolName = "run_shell_command";
+        commandPrefix = cmd;
+        decision = "deny";
+        priority = 200;
+        denyMessage = "Command permanently blocked by system security policy.";
+      }) allCommands;
+
+    # Format all ask commands for the Policy Engine
+    formatAskRules =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.ask;
+      in
+      map (cmd: {
+        toolName = "run_shell_command";
+        commandPrefix = cmd;
+        decision = "ask_user";
+        priority = 50;
+      }) allCommands;
+
+    # Deprecated formatters (kept for backward compatibility during migration)
     formatShellCommand = cmd: "ShellTool(${cmd})";
-
-    # Format a list of shell commands
     formatShellCommands = cmds: map (cmd: "ShellTool(${cmd})") cmds;
-
-    # Format all auto-approved commands for tools.allowed (NOT tools.core!)
-    # Output goes to settings.json "tools.allowed" to bypass confirmation dialog
     formatAllowedTools =
       permissions:
       let
         allCommands = flattenCommands permissions.allow;
         shellTools = map (cmd: "ShellTool(${cmd})") allCommands;
-        # Built-in Gemini tools (ReadFileTool, etc.) from permissions.nix
         builtinTools = permissions.toolSpecific.gemini.builtin or [ ];
       in
       builtinTools ++ shellTools;
-
-    # Format all denied commands (excludeTools)
     formatExcludeTools =
       permissions:
       let
         allCommands = flattenCommands permissions.deny;
       in
       map (cmd: "ShellTool(${cmd})") allCommands;
-
-    # Get tool-specific permissions (non-shell)
     getToolPermissions = permissions: permissions.toolSpecific.gemini.builtin or [ ];
   };
 

--- a/modules/gemini.nix
+++ b/modules/gemini.nix
@@ -8,27 +8,25 @@
 # Instead, we use an activation script that deep-merges Nix config
 # with existing runtime state, preserving auth tokens across rebuilds.
 #
-# CRITICAL - tools.allowed vs tools.core:
+# POLICY ENGINE:
 # =========================================
-# DO NOT USE tools.core FOR AUTO-APPROVAL!
+# Gemini CLI has deprecated tools.allowed and tools.exclude in favor of the
+# Policy Engine. Policies are defined in TOML files and matched via rules.
+#
+# We generate a consolidated nix-managed.toml policy file from our unified
+# permission definitions and link it via policyPaths in settings.json.
 #
 # Per the official Gemini CLI schema:
-# - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
-# - tools.core = "Allowlist to RESTRICT built-in tools to a specific set" (LIMITS usage!)
-#
-# Using tools.core LIMITS what tools Gemini can use, it does NOT grant permissions.
-# Always use tools.allowed for auto-approved commands.
+# - tools.allowed = (DEPRECATED) replaced by Policy rules with decision="allow"
+# - tools.exclude = (DEPRECATED) replaced by Policy rules with decision="deny"
+# - tools.core = "Allowlist to RESTRICT built-in tools" (LIMITS usage!)
 #
 # Schema reference: https://github.com/google-gemini/gemini-cli/blob/main/schemas/settings.schema.json
 #
-# Configuration format:
-# - allowedTools: List of auto-approved tools (bypass confirmation dialog)
-# - excludeTools: List of permanently blocked commands
-#
 # Permission files:
-# - gemini-permissions-allow.nix - allowedTools (auto-approved commands)
-# - gemini-permissions-deny.nix - excludeTools (blocked commands)
-# - gemini-permissions-ask.nix - Reference only (Gemini doesn't support ask mode)
+# - gemini-permissions-allow.nix -> decision="allow" rules
+# - gemini-permissions-deny.nix -> decision="deny" rules
+# - gemini-permissions-ask.nix -> decision="ask_user" rules (now supported!)
 
 {
   config,
@@ -45,6 +43,14 @@ let
   geminiDeny = import ./permissions/gemini-permissions-deny.nix {
     inherit config lib ai-assistant-instructions;
   };
+  geminiAsk = import ./permissions/gemini-permissions-ask.nix {
+    inherit config lib ai-assistant-instructions;
+  };
+
+  # Generate consolidated TOML policy file for the Policy Engine
+  policyFile = (pkgs.formats.toml { }).generate "gemini-policy.toml" {
+    rule = geminiAllow.allowRules ++ geminiDeny.denyRules ++ geminiAsk.askRules;
+  };
 
   # Gemini settings object
   settings = {
@@ -54,6 +60,12 @@ let
     # See: https://github.com/google-gemini/gemini-cli/issues/12695
     "$schema" =
       "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json";
+
+    # Policy Engine Configuration
+    # We use a Nix-managed TOML file for all tool permissions
+    policyPaths = [
+      (builtins.toString policyFile)
+    ];
 
     # General settings
     general = {
@@ -106,17 +118,7 @@ let
 
     # Tools configuration (must be nested under "tools" key)
     # See: https://google-gemini.github.io/gemini-cli/docs/get-started/configuration.html
-    #
-    # CRITICAL: Use "allowed" NOT "core" for auto-approval!
-    # - "allowed" = bypass confirmation dialog (what we want)
-    # - "core" = RESTRICT available tools (NOT what we want!)
     tools = {
-      # Auto-approved tools (bypass confirmation dialog)
-      allowed = geminiAllow.allowedTools;
-
-      # Blocked tools (catastrophic operations)
-      exclude = geminiDeny.excludeTools;
-
       # Sandbox configuration (macOS Seatbelt)
       # Uses permissive-open profile: restricts writes outside project directory
       # CRITICAL: Gemini won't execute commands without sandbox enabled

--- a/modules/permissions/gemini-permissions-allow.nix
+++ b/modules/permissions/gemini-permissions-allow.nix
@@ -35,7 +35,10 @@ let
 
 in
 {
-  # Export allowedTools list (auto-approved commands that bypass confirmation)
+  # Export allowRules for the Policy Engine (TOML)
+  allowRules = formatters.gemini.formatAllowRules permissions;
+
+  # DEPRECATED: Export allowedTools list for tools.allowed (settings.json)
   # Maps to "tools.allowed" in settings.json - NOT "tools.core"!
   # Combines Gemini-specific tools with formatted shell commands
   allowedTools = formatters.gemini.formatAllowedTools permissions;

--- a/modules/permissions/gemini-permissions-ask.nix
+++ b/modules/permissions/gemini-permissions-ask.nix
@@ -1,105 +1,25 @@
-# Gemini CLI User-Prompted Commands (ASK List - REFERENCE ONLY)
+# Gemini CLI User-Prompted Commands (ASK List)
 #
-# IMPORTANT: Gemini CLI does NOT have an "ask" mode. Commands are either allowed
-# (tools.allowed) or blocked (tools.exclude). This file exists ONLY for reference
-# to keep sync with Claude and Copilot permission structures.
+# Gemini CLI now supports "ask_user" decision via the Policy Engine!
+# This file exports rules for commands that require explicit user confirmation.
 #
-# CRITICAL - tools.allowed vs tools.core:
-# Per the official Gemini CLI schema:
-# - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
-# - tools.core = "Allowlist to RESTRICT built-in tools" (LIMITS usage!)
-# NEVER use tools.core for auto-approval - it restricts, not grants!
-#
-# FILE STRUCTURE:
-# - gemini-permissions-allow.nix - allowedTools → tools.allowed (auto-approved)
-# - gemini-permissions-ask.nix (this file) - Commands that would require confirmation (reference only)
-# - gemini-permissions-deny.nix - excludeTools → tools.exclude (permanently blocked)
-#
-# NOTE: These permission lists are kept in sync across Claude, Gemini, and Copilot.
-# Currently each AI has separate files. Future improvement: DRY refactor to share
-# common command lists across all AI tools.
-#
-# The commands below are the same ones in Claude's ask list. They are commented
-# out because Gemini doesn't use this file - it's purely for documentation and
-# to maintain parity across AI tool configurations.
-#
-# WARNING: Since Gemini CLI doesn't support "ask" mode, users must exercise extra
-# caution when using Gemini with these commands. Consider using Claude Code for
-# tasks involving these operations if you want confirmation prompts.
-
-_:
+# Uses unified permission definitions from ai-cli/common/permissions.nix
+# with Gemini-specific formatting via formatters.nix.
 
 {
-  # This file is not imported anywhere - it exists for reference only.
-  # The commands below match Claude's askList for consistency.
+  config,
+  lib,
+  ai-assistant-instructions,
+  ...
+}:
 
-  # === COMMANDS THAT WOULD REQUIRE CONFIRMATION (if Gemini supported it) ===
-  #
-  # systemScriptCommands = [
-  #   "ShellTool(osascript)"
-  #   "ShellTool(osascript -e)"
-  # ];
-  #
-  # systemInfoDisclosureCommands = [
-  #   "ShellTool(system_profiler)"
-  #   "ShellTool(log show)"
-  # ];
-  #
-  # macosConfigCommands = [
-  #   "ShellTool(defaults read)"
-  # ];
-  #
-  # gitDestructiveOperations = [
-  #   "ShellTool(git reset)"
-  # ];
-  #
-  # securityOperations = [
-  #   "ShellTool(gpg)"
-  #   "ShellTool(chown)"
-  # ];
-  #
-  # dangerousFileOperations = [
-  #   "ShellTool(chmod)"
-  #   "ShellTool(rm)"
-  #   "ShellTool(rmdir)"
-  #   "ShellTool(cp)"
-  #   "ShellTool(mv)"
-  #   "ShellTool(sed -i)"
-  #   "ShellTool(sed --in-place)"
-  # ];
-  #
-  # dockerPrivilegedOperations = [
-  #   "ShellTool(docker exec)"
-  #   "ShellTool(docker run)"
-  # ];
-  #
-  # kubernetesDestructiveOperations = [
-  #   "ShellTool(kubectl apply)"
-  #   "ShellTool(kubectl create)"
-  #   "ShellTool(kubectl delete)"
-  #   "ShellTool(kubectl set)"
-  #   "ShellTool(kubectl patch)"
-  #   "ShellTool(helm install)"
-  #   "ShellTool(helm upgrade)"
-  #   "ShellTool(helm uninstall)"
-  # ];
-  #
-  # awsDestructiveOperations = [
-  #   "ShellTool(aws s3 cp)"
-  #   "ShellTool(aws s3 sync)"
-  #   "ShellTool(aws s3 rm)"
-  #   "ShellTool(aws ec2 run-instances)"
-  #   "ShellTool(aws ec2 terminate-instances)"
-  #   "ShellTool(aws lambda invoke)"
-  #   "ShellTool(aws cloudformation delete-stack)"
-  # ];
-  #
-  # packageExecutionCommands = [
-  #   "ShellTool(npx)"
-  # ];
-  #
-  # databaseModificationCommands = [
-  #   "ShellTool(sqlite3)"
-  #   "ShellTool(mongosh)"
-  # ];
+let
+  # Import unified permissions and formatters
+  aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
+  inherit (aiCommon) permissions formatters;
+
+in
+{
+  # Export askRules for the Policy Engine (TOML)
+  askRules = formatters.gemini.formatAskRules permissions;
 }

--- a/modules/permissions/gemini-permissions-deny.nix
+++ b/modules/permissions/gemini-permissions-deny.nix
@@ -28,6 +28,9 @@ let
 
 in
 {
-  # Export excludeTools (permanently blocked commands)
+  # Export denyRules for the Policy Engine (TOML)
+  denyRules = formatters.gemini.formatDenyRules permissions;
+
+  # DEPRECATED: Export excludeTools (permanently blocked commands)
   excludeTools = formatters.gemini.formatExcludeTools permissions;
 }


### PR DESCRIPTION
Migrate from deprecated tools.allowed and tools.exclude to the Gemini CLI Policy Engine.

Highlights:
- Updated formatters.nix to output TOML-compatible rules (isolated to Gemini).
- Updated permission exports to support Policy Engine decisions (allow, deny, ask_user).
- Updated modules/gemini.nix to generate gemini-policy.toml and use policyPaths in settings.json.
- Removed deprecated tools.allowed and tools.exclude.