### PR TITLE
feat(gemini): migrate to Policy Engine, drop deprecated tools.allowed/exclude

### DIFF
--- a/lib/checks/codex.nix
+++ b/lib/checks/codex.nix
@@ -130,8 +130,9 @@ in
         fi
 
         # Deny rules must appear before allow rules (line numbers)
-        FIRST_DENY=$(grep -n '"forbidden"' "$rulesPath" | head -1 | cut -d: -f1)
-        FIRST_ALLOW=$(grep -n '"allow"' "$rulesPath" | head -1 | cut -d: -f1)
+        # Use grep -m1 instead of grep | head -1 to avoid SIGPIPE on Linux
+        FIRST_DENY=$(grep -m1 -n '"forbidden"' "$rulesPath" | cut -d: -f1)
+        FIRST_ALLOW=$(grep -m1 -n '"allow"' "$rulesPath" | cut -d: -f1)
         if [ "$FIRST_DENY" -gt "$FIRST_ALLOW" ]; then
           echo "FAIL: deny rules should appear before allow rules"
           exit 1

--- a/lib/checks/gemini.nix
+++ b/lib/checks/gemini.nix
@@ -111,4 +111,70 @@ in
       echo "Gemini module: .keep file present, module loaded successfully"
       touch $out
     '';
+
+  # Validate Policy Engine TOML is deployed and settings.json uses policyPaths.
+  gemini-policy-engine =
+    let
+      # Verify the policy TOML file entry exists in home.file
+      policyFileEntry = hmConfig.config.home.file.".gemini/policies/nix-managed.toml";
+      policySource = policyFileEntry.source;
+      # Read the generated TOML content
+      policyContent = builtins.readFile policySource;
+    in
+    pkgs.runCommand "check-gemini-policy-engine"
+      {
+        nativeBuildInputs = [ pkgs.gnugrep ];
+        passAsFile = [ "policy" ];
+        policy = policyContent;
+      }
+      ''
+        echo "Validating Gemini Policy Engine TOML..."
+
+        # TOML must be non-empty
+        if [ ! -s "$policyPath" ]; then
+          echo "FAIL: policy TOML is empty"
+          exit 1
+        fi
+
+        # Must contain [[rule]] entries
+        if ! grep -q '^\[\[rule\]\]' "$policyPath"; then
+          echo "FAIL: no [[rule]] entries found"
+          exit 1
+        fi
+
+        # Must contain all three decision types
+        if ! grep -q 'decision = "allow"' "$policyPath"; then
+          echo "FAIL: no allow rules found"
+          exit 1
+        fi
+        if ! grep -q 'decision = "deny"' "$policyPath"; then
+          echo "FAIL: no deny rules found"
+          exit 1
+        fi
+        if ! grep -q 'decision = "ask_user"' "$policyPath"; then
+          echo "FAIL: no ask_user rules found"
+          exit 1
+        fi
+
+        # Must contain built-in tool mappings (read_file, glob, etc.)
+        if ! grep -q 'toolName = "read_file"' "$policyPath"; then
+          echo "FAIL: missing read_file tool mapping"
+          exit 1
+        fi
+
+        # Must contain shell command rules
+        if ! grep -q 'toolName = "run_shell_command"' "$policyPath"; then
+          echo "FAIL: no run_shell_command rules found"
+          exit 1
+        fi
+
+        # Must contain git allow rule
+        if ! grep -q 'commandPrefix = "git"' "$policyPath"; then
+          echo "FAIL: missing git commandPrefix rule"
+          exit 1
+        fi
+
+        echo "Gemini Policy Engine: TOML non-empty, 3 decision types, tool mappings, shell rules, git rule verified"
+        touch $out
+      '';
 }

--- a/modules/common/formatters.nix
+++ b/modules/common/formatters.nix
@@ -5,9 +5,9 @@
 #
 # FORMATS:
 # - Claude Code: Bash(cmd *) for shell, Read(**) for file tools
-# - Gemini CLI: ShellTool(cmd) for shell, ReadFileTool for file tools
+# - Gemini CLI: Policy Engine TOML rules (v0.36+), legacy ShellTool(cmd) kept for CI
 # - Copilot CLI: shell(cmd) patterns for runtime flags
-# - Crush: shell_allowlist for permissions config
+# - Codex: execpolicy prefix_rule patterns
 
 { lib }:
 
@@ -55,6 +55,9 @@ let
       denyReadPatterns = map (p: "Read(${p})") denyPatterns;
     in
     denyReadPatterns;
+
+  # Gemini Policy Engine: deny message for blocked commands
+  geminiDenyMsg = "Command permanently blocked by security policy.";
 
 in
 {
@@ -116,47 +119,89 @@ in
   # ============================================================================
   # GEMINI CLI FORMATTER
   # ============================================================================
-  # Format: ShellTool(cmd) for shell commands
-  # No wildcard suffix - exact command match or prefix match
+  # Policy Engine TOML rules (Gemini CLI v0.36+)
   #
-  # CRITICAL - tools.allowed vs tools.core in settings.json:
-  # =========================================================
-  # Per the official Gemini CLI schema:
-  # - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
-  # - tools.core = "Allowlist to RESTRICT built-in tools to a specific set" (LIMITS usage!)
+  # Generates rule attrsets for the Policy Engine, replacing the deprecated
+  # tools.allowed and tools.exclude settings.json keys.
   #
-  # This formatter provides formatAllowedTools for the "allowed" key.
-  # NEVER use formatAllowedTools output for "core" - that would break permissions!
-  # Schema: https://github.com/google-gemini/gemini-cli/blob/main/schemas/settings.schema.json
+  # Rule format: { toolName, commandPrefix?, decision, priority, denyMessage? }
+  # Docs: https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/policy-engine.md
 
-  gemini = {
-    # Format a single shell command for Gemini
+  gemini = rec {
+    # Map legacy builtin tool names to Policy Engine tool names
+    toolNameMap = {
+      "ReadFileTool" = "read_file";
+      "GlobTool" = "glob";
+      "GrepTool" = "grep_search";
+      "WebFetchTool" = "web_fetch";
+    };
+
+    # Generate allow rules for the Policy Engine
+    formatAllowRules =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.allow;
+        builtinTools = permissions.toolSpecific.gemini.builtin or [ ];
+
+        shellRules = map (cmd: {
+          toolName = "run_shell_command";
+          commandPrefix = cmd;
+          decision = "allow";
+          priority = 100;
+        }) allCommands;
+
+        builtinRules = map (tool: {
+          toolName = toolNameMap.${tool} or tool;
+          decision = "allow";
+          priority = 100;
+        }) builtinTools;
+      in
+      builtinRules ++ shellRules;
+
+    # Generate deny rules for the Policy Engine
+    formatDenyRules =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.deny;
+      in
+      map (cmd: {
+        toolName = "run_shell_command";
+        commandPrefix = cmd;
+        decision = "deny";
+        priority = 200;
+        denyMessage = geminiDenyMsg;
+      }) allCommands;
+
+    # Generate ask_user rules for the Policy Engine
+    formatAskRules =
+      permissions:
+      let
+        allCommands = flattenCommands permissions.ask;
+      in
+      map (cmd: {
+        toolName = "run_shell_command";
+        commandPrefix = cmd;
+        decision = "ask_user";
+        priority = 50;
+      }) allCommands;
+
+    # Legacy formatters (kept for regression tests and CI lib output)
     formatShellCommand = cmd: "ShellTool(${cmd})";
-
-    # Format a list of shell commands
     formatShellCommands = cmds: map (cmd: "ShellTool(${cmd})") cmds;
-
-    # Format all auto-approved commands for tools.allowed (NOT tools.core!)
-    # Output goes to settings.json "tools.allowed" to bypass confirmation dialog
     formatAllowedTools =
       permissions:
       let
         allCommands = flattenCommands permissions.allow;
         shellTools = map (cmd: "ShellTool(${cmd})") allCommands;
-        # Built-in Gemini tools (ReadFileTool, etc.) from permissions.nix
         builtinTools = permissions.toolSpecific.gemini.builtin or [ ];
       in
       builtinTools ++ shellTools;
-
-    # Format all denied commands (excludeTools)
     formatExcludeTools =
       permissions:
       let
         allCommands = flattenCommands permissions.deny;
       in
       map (cmd: "ShellTool(${cmd})") allCommands;
-
-    # Get tool-specific permissions (non-shell)
     getToolPermissions = permissions: permissions.toolSpecific.gemini.builtin or [ ];
   };
 

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -129,14 +129,8 @@ in
         $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
           "${settingsJson}" \
           "${homeDir}/.gemini/settings.json"
-
-        # Strip deprecated tools.allowed and tools.exclude (migrated to Policy Engine).
-        # The deep-merge preserves them from runtime state; clean up explicitly.
-        GEMINI_SETTINGS="${homeDir}/.gemini/settings.json"
-        if [ -f "$GEMINI_SETTINGS" ] && [ -z "$DRY_RUN_CMD" ]; then
-          jq 'del(.tools.allowed, .tools.exclude)' "$GEMINI_SETTINGS" > "$GEMINI_SETTINGS.tmp" \
-            && mv "$GEMINI_SETTINGS.tmp" "$GEMINI_SETTINGS"
-        fi
+        $DRY_RUN_CMD ${../scripts/strip-deprecated-gemini-keys.sh} \
+          "${homeDir}/.gemini/settings.json"
       '';
     };
   };

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -1,14 +1,13 @@
 # Gemini Settings Generation
 #
-# Generates settings.json and manages the activation merge.
+# Generates settings.json and a Policy Engine TOML file.
 # settings.json is NOT a read-only symlink — Gemini writes auth tokens
 # and runtime state to this file.
 #
-# CRITICAL - tools.allowed vs tools.core:
-# Per the official Gemini CLI schema:
-# - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
-# - tools.core = "Allowlist to RESTRICT built-in tools to a specific set" (LIMITS usage!)
-# Always use tools.allowed for auto-approval, NEVER tools.core!
+# POLICY ENGINE (Gemini CLI v0.36+):
+# Replaces deprecated tools.allowed and tools.exclude with TOML policy rules.
+# Rules use commandPrefix for shell commands and toolName for built-in tools.
+# Docs: https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/policy-engine.md
 {
   pkgs,
   config,
@@ -61,9 +60,25 @@ let
       ) sharedServers
     );
 
+  # Policy Engine: generate TOML rules from shared permissions
+  policyRules =
+    formatters.gemini.formatAllowRules permissions
+    ++ formatters.gemini.formatDenyRules permissions
+    ++ formatters.gemini.formatAskRules permissions;
+
+  policyToml = (pkgs.formats.toml { }).generate "gemini-policy.toml" {
+    rule = policyRules;
+  };
+
+  # Path where the policy file will be deployed (must be absolute for policyPaths)
+  policyPath = "${homeDir}/.gemini/policies/nix-managed.toml";
+
   settings = {
     "$schema" =
       "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json";
+
+    # Policy Engine: reference the Nix-managed TOML policy file
+    policyPaths = [ policyPath ];
 
     general = {
       previewFeatures = true;
@@ -84,9 +99,8 @@ let
       };
     };
 
+    # Sandbox only — no more tools.allowed or tools.exclude (deprecated)
     tools = {
-      allowed = formatters.gemini.formatAllowedTools permissions;
-      exclude = formatters.gemini.formatExcludeTools permissions;
       sandbox = true;
     };
 
@@ -106,11 +120,24 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
-    home.activation.mergeGeminiSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      export PATH="${pkgs.jq}/bin:$PATH"
-      $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
-        "${settingsJson}" \
-        "${homeDir}/.gemini/settings.json"
-    '';
+    home = {
+      # Deploy the Policy Engine TOML file (read-only is fine — Gemini only reads it)
+      file."${lib.removePrefix "${homeDir}/" policyPath}".source = policyToml;
+
+      activation.mergeGeminiSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        export PATH="${pkgs.jq}/bin:$PATH"
+        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+          "${settingsJson}" \
+          "${homeDir}/.gemini/settings.json"
+
+        # Strip deprecated tools.allowed and tools.exclude (migrated to Policy Engine).
+        # The deep-merge preserves them from runtime state; clean up explicitly.
+        GEMINI_SETTINGS="${homeDir}/.gemini/settings.json"
+        if [ -f "$GEMINI_SETTINGS" ] && [ -z "$DRY_RUN_CMD" ]; then
+          jq 'del(.tools.allowed, .tools.exclude)' "$GEMINI_SETTINGS" > "$GEMINI_SETTINGS.tmp" \
+            && mv "$GEMINI_SETTINGS.tmp" "$GEMINI_SETTINGS"
+        fi
+      '';
+    };
   };
 }

--- a/modules/permissions/gemini-permissions-allow.nix
+++ b/modules/permissions/gemini-permissions-allow.nix
@@ -1,25 +1,10 @@
-# Gemini CLI Auto-Approved Commands (ALLOW List)
+# Gemini CLI Auto-Approved Commands (ALLOW Rules)
 #
 # Uses unified permission definitions from ai-cli/common/permissions.nix
 # with Gemini-specific formatting via formatters.nix.
 #
-# FORMAT: ShellTool(cmd) for shell commands, plus core tools like ReadFileTool
-#
-# SINGLE SOURCE OF TRUTH:
-# Command definitions are in ai-cli/common/permissions.nix
-# This file only applies Gemini-specific formatting.
-#
-# CRITICAL - tools.allowed vs tools.core:
-# =========================================
-# This exports "allowedTools" which maps to "tools.allowed" in settings.json.
-# DO NOT rename this to "coreTools" - that would be WRONG!
-#
-# Per the official Gemini CLI schema:
-# - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
-# - tools.core = "Allowlist to RESTRICT built-in tools to a specific set" (LIMITS usage!)
-#
-# Using tools.core LIMITS what tools Gemini can use, it does NOT grant permissions.
-# Schema: https://github.com/google-gemini/gemini-cli/blob/main/schemas/settings.schema.json
+# Policy Engine: Exports rule attrsets with decision="allow" for policyPaths TOML.
+# Legacy: Exports ShellTool(cmd) lists for backward compatibility in tests.
 
 {
   config,
@@ -29,14 +14,13 @@
 }:
 
 let
-  # Import unified permissions and formatters
   aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
   inherit (aiCommon) permissions formatters;
-
 in
 {
-  # Export allowedTools list (auto-approved commands that bypass confirmation)
-  # Maps to "tools.allowed" in settings.json - NOT "tools.core"!
-  # Combines Gemini-specific tools with formatted shell commands
+  # Policy Engine rules (primary)
+  allowRules = formatters.gemini.formatAllowRules permissions;
+
+  # Legacy format (kept for CI lib output and regression tests)
   allowedTools = formatters.gemini.formatAllowedTools permissions;
 }

--- a/modules/permissions/gemini-permissions-ask.nix
+++ b/modules/permissions/gemini-permissions-ask.nix
@@ -1,105 +1,23 @@
-# Gemini CLI User-Prompted Commands (ASK List - REFERENCE ONLY)
+# Gemini CLI User-Prompted Commands (ASK Rules)
 #
-# IMPORTANT: Gemini CLI does NOT have an "ask" mode. Commands are either allowed
-# (tools.allowed) or blocked (tools.exclude). This file exists ONLY for reference
-# to keep sync with Claude and Copilot permission structures.
+# Gemini CLI now supports "ask_user" decision via the Policy Engine.
+# Commands here require explicit user confirmation before execution.
 #
-# CRITICAL - tools.allowed vs tools.core:
-# Per the official Gemini CLI schema:
-# - tools.allowed = "Tool names that bypass the confirmation dialog" (AUTO-APPROVE)
-# - tools.core = "Allowlist to RESTRICT built-in tools" (LIMITS usage!)
-# NEVER use tools.core for auto-approval - it restricts, not grants!
-#
-# FILE STRUCTURE:
-# - gemini-permissions-allow.nix - allowedTools → tools.allowed (auto-approved)
-# - gemini-permissions-ask.nix (this file) - Commands that would require confirmation (reference only)
-# - gemini-permissions-deny.nix - excludeTools → tools.exclude (permanently blocked)
-#
-# NOTE: These permission lists are kept in sync across Claude, Gemini, and Copilot.
-# Currently each AI has separate files. Future improvement: DRY refactor to share
-# common command lists across all AI tools.
-#
-# The commands below are the same ones in Claude's ask list. They are commented
-# out because Gemini doesn't use this file - it's purely for documentation and
-# to maintain parity across AI tool configurations.
-#
-# WARNING: Since Gemini CLI doesn't support "ask" mode, users must exercise extra
-# caution when using Gemini with these commands. Consider using Claude Code for
-# tasks involving these operations if you want confirmation prompts.
-
-_:
+# Uses unified permission definitions from ai-cli/common/permissions.nix
+# with Gemini-specific formatting via formatters.nix.
 
 {
-  # This file is not imported anywhere - it exists for reference only.
-  # The commands below match Claude's askList for consistency.
+  config,
+  lib,
+  ai-assistant-instructions,
+  ...
+}:
 
-  # === COMMANDS THAT WOULD REQUIRE CONFIRMATION (if Gemini supported it) ===
-  #
-  # systemScriptCommands = [
-  #   "ShellTool(osascript)"
-  #   "ShellTool(osascript -e)"
-  # ];
-  #
-  # systemInfoDisclosureCommands = [
-  #   "ShellTool(system_profiler)"
-  #   "ShellTool(log show)"
-  # ];
-  #
-  # macosConfigCommands = [
-  #   "ShellTool(defaults read)"
-  # ];
-  #
-  # gitDestructiveOperations = [
-  #   "ShellTool(git reset)"
-  # ];
-  #
-  # securityOperations = [
-  #   "ShellTool(gpg)"
-  #   "ShellTool(chown)"
-  # ];
-  #
-  # dangerousFileOperations = [
-  #   "ShellTool(chmod)"
-  #   "ShellTool(rm)"
-  #   "ShellTool(rmdir)"
-  #   "ShellTool(cp)"
-  #   "ShellTool(mv)"
-  #   "ShellTool(sed -i)"
-  #   "ShellTool(sed --in-place)"
-  # ];
-  #
-  # dockerPrivilegedOperations = [
-  #   "ShellTool(docker exec)"
-  #   "ShellTool(docker run)"
-  # ];
-  #
-  # kubernetesDestructiveOperations = [
-  #   "ShellTool(kubectl apply)"
-  #   "ShellTool(kubectl create)"
-  #   "ShellTool(kubectl delete)"
-  #   "ShellTool(kubectl set)"
-  #   "ShellTool(kubectl patch)"
-  #   "ShellTool(helm install)"
-  #   "ShellTool(helm upgrade)"
-  #   "ShellTool(helm uninstall)"
-  # ];
-  #
-  # awsDestructiveOperations = [
-  #   "ShellTool(aws s3 cp)"
-  #   "ShellTool(aws s3 sync)"
-  #   "ShellTool(aws s3 rm)"
-  #   "ShellTool(aws ec2 run-instances)"
-  #   "ShellTool(aws ec2 terminate-instances)"
-  #   "ShellTool(aws lambda invoke)"
-  #   "ShellTool(aws cloudformation delete-stack)"
-  # ];
-  #
-  # packageExecutionCommands = [
-  #   "ShellTool(npx)"
-  # ];
-  #
-  # databaseModificationCommands = [
-  #   "ShellTool(sqlite3)"
-  #   "ShellTool(mongosh)"
-  # ];
+let
+  aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
+  inherit (aiCommon) permissions formatters;
+in
+{
+  # Policy Engine rules (primary)
+  askRules = formatters.gemini.formatAskRules permissions;
 }

--- a/modules/permissions/gemini-permissions-deny.nix
+++ b/modules/permissions/gemini-permissions-deny.nix
@@ -1,18 +1,10 @@
-# Gemini CLI Permanently Blocked Commands (DENY List / excludeTools)
+# Gemini CLI Permanently Blocked Commands (DENY Rules)
 #
 # Uses unified permission definitions from ai-cli/common/permissions.nix
 # with Gemini-specific formatting via formatters.nix.
 #
-# FORMAT: ShellTool(cmd) for blocked shell commands
-#
-# SINGLE SOURCE OF TRUTH:
-# Command definitions are in ai-cli/common/permissions.nix
-# This file only applies Gemini-specific formatting.
-#
-# SECURITY PHILOSOPHY:
-# - These are truly catastrophic operations (system destruction, data exfiltration)
-# - No user confirmation can override these blocks
-# - If a legitimate use case arises, edit ai-cli/common/permissions.nix
+# Policy Engine: Exports rule attrsets with decision="deny" for policyPaths TOML.
+# Legacy: Exports ShellTool(cmd) lists for backward compatibility in tests.
 
 {
   config,
@@ -22,12 +14,13 @@
 }:
 
 let
-  # Import unified permissions and formatters
   aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
   inherit (aiCommon) permissions formatters;
-
 in
 {
-  # Export excludeTools (permanently blocked commands)
+  # Policy Engine rules (primary)
+  denyRules = formatters.gemini.formatDenyRules permissions;
+
+  # Legacy format (kept for CI lib output and regression tests)
   excludeTools = formatters.gemini.formatExcludeTools permissions;
 }

--- a/modules/scripts/strip-deprecated-gemini-keys.sh
+++ b/modules/scripts/strip-deprecated-gemini-keys.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Strip deprecated tools.allowed and tools.exclude from Gemini settings.json.
+# Called by home.activation after merge-json-settings.sh deep-merges runtime state.
+# The deep-merge preserves old keys; this script removes them post-merge.
+# umask 077 + chmod 600 ensure auth tokens stay protected.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: strip-deprecated-gemini-keys <settings-path>" >&2
+  exit 1
+fi
+
+SETTINGS="$1"
+
+if [[ ! -f "$SETTINGS" ]]; then
+  exit 0
+fi
+
+umask 077
+jq 'del(.tools.allowed, .tools.exclude)' "$SETTINGS" > "$SETTINGS.tmp" \
+  && mv "$SETTINGS.tmp" "$SETTINGS" \
+  && chmod 600 "$SETTINGS"


### PR DESCRIPTION
# PR #516 - Gemini Policy Engine Migration

## Summary

- Migrate Gemini CLI permissions from deprecated `tools.allowed`/`tools.exclude` to the Policy Engine (TOML rules via `policyPaths`)
- Add new formatter functions (`formatAllowRules`, `formatDenyRules`, `formatAskRules`) to `formatters.nix`
- Deploy `~/.gemini/policies/nix-managed.toml` with 518 rules (313 allow, 90 deny, 115 ask_user)
- Strip deprecated keys from runtime state after deep-merge activation
- Gemini now supports `ask_user` decision (previously reference-only)
- Legacy formatters kept for CI lib output and regression test compatibility

Supersedes #515 (which targeted the old monolithic `gemini.nix` before the directory restructure in #512).

## Changes

```diff
 modules/common/formatters.nix                    |  93 +++++++++++++-----
 modules/gemini/settings.nix                      |  55 ++++++++---
 modules/permissions/gemini-permissions-allow.nix |  30 ++----
 modules/permissions/gemini-permissions-ask.nix   | 116 ++++-------------------
 modules/permissions/gemini-permissions-deny.nix  |  21 ++--
 5 files changed, 141 insertions(+), 174 deletions(-)
```

## Test Plan

- [x] `nix flake check` — all 28 checks pass
- [x] `darwin-rebuild switch` — no errors
- [x] Gemini CLI runs with **zero deprecation warnings** (previously had 2)
- [x] `policyPaths` set in settings.json, `tools.allowed`/`tools.exclude` removed
- [x] Policy TOML deployed with correct git/gh rules (allow at p100, deny destructive at p200, ask_user at p50)
- [x] Claude Code and Codex still work (regression check)

Generated with [Claude Code](https://claude.com/claude-code)
