### PR TITLE
fix: relax codex default approvals

### DIFF
--- a/lib/checks/codex.nix
+++ b/lib/checks/codex.nix
@@ -37,7 +37,7 @@ in
         {
           name = "codex.approvalPolicy";
           actual = cfg.approvalPolicy;
-          expected = "untrusted";
+          expected = "on-request";
         }
         {
           name = "codex.features";

--- a/modules/codex/options.nix
+++ b/modules/codex/options.nix
@@ -61,7 +61,7 @@ in
         "on-request"
         "never"
       ];
-      default = "untrusted";
+      default = "on-request";
       description = "Default approval policy for Codex sessions";
     };
 


### PR DESCRIPTION
# PR #526: Relax Codex Default Approvals

## Summary

Relax Codex default approval policy from `untrusted` to `on-request`. This allows safe
commands to execute without prompting while preserving prompts for risky operations.

## Changes

- **modules/codex/options.nix**: Change default `approvalPolicy` from `"untrusted"` to `"on-request"`
- **lib/checks/codex.nix**: Update regression test to match new default

## Test Plan

1. Static validation:

   ```bash
   nix flake check
   ```

2. Runtime validation:

   ```bash
   sudo darwin-rebuild switch --flake "$HOME/git/nix-darwin/main" \
     --override-input nix-ai "/Users/jevans/git/nix-ai/fix/codex-approval-defaults"
   ```

3. Behavioral verification:
   - `ls -la` → allow (safe command)
   - `git rebase` → prompt (risky operation)
   - `git commit --no-verify` → forbid (explicitly dangerous)
   - Check `~/.codex/config.toml` contains `approval_policy = "on-request"`
