### PR TITLE
chore(claude): prune ~/.claude runtime data on home-manager switch

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -179,6 +179,9 @@ in
     "retrospective-report-location" = ./claude/rules/retrospective-report-location.md;
   };
 
+  # Prune stale runtime data on every home-manager switch (no custom agents/timers)
+  runtimeCleanup.enable = true;
+
   settings = {
     # Extended thinking enabled with token budget controlled via env vars
     alwaysThinkingEnabled = true;

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -310,6 +310,21 @@ in
       description = "Commit attribution trailer. Set commit = \"(claude)\" for minimal attribution.";
     };
 
+    # Runtime data cleanup — prunes stale session artifacts on home-manager switch
+    runtimeCleanup = {
+      enable = lib.mkEnableOption "Prune stale ~/.claude runtime data on home-manager switch";
+      retentionDays = lib.mkOption {
+        type = lib.types.int;
+        default = 30;
+        description = "Delete runtime data (projects, todos, snapshots, etc.) older than this many days";
+      };
+      maxBackups = lib.mkOption {
+        type = lib.types.int;
+        default = 5;
+        description = "Maximum number of ~/.claude.json backups to retain";
+      };
+    };
+
     # Settings
     settings = {
       # Extended thinking mode

--- a/modules/claude/orphan-cleanup.nix
+++ b/modules/claude/orphan-cleanup.nix
@@ -18,7 +18,12 @@
 # - Removes known cruft files and empty directories
 # - Controlled by programs.claude.runtimeCleanup.{retentionDays, maxBackups}
 #
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.programs.claude;
@@ -85,7 +90,9 @@ in
     }
     // lib.optionalAttrs cfg.runtimeCleanup.enable {
       # Phase 4: Prune stale runtime data on every home-manager switch.
+      # Prepend jq to PATH — activation runs before the Nix profile is fully sourced.
       cleanupRuntimeData = lib.hm.dag.entryAfter [ "verifyCacheIntegrity" ] ''
+        export PATH="${pkgs.jq}/bin:$PATH"
         $DRY_RUN_CMD ${./scripts/cleanup-runtime-data.sh} \
           "${homeDir}" \
           "${toString cfg.runtimeCleanup.retentionDays}" \

--- a/modules/claude/orphan-cleanup.nix
+++ b/modules/claude/orphan-cleanup.nix
@@ -1,6 +1,6 @@
 # Orphan Cleanup Module
 #
-# Three-phase cleanup for Nix-managed directories:
+# Three-phase cleanup for Nix-managed directories, plus optional runtime data pruning:
 #
 # Phase 1 (BEFORE linkGeneration):
 # - Removes directory symlinks and real directories that conflict with
@@ -12,6 +12,11 @@
 #
 # Phase 3 (AFTER linkGeneration):
 # - Verifies plugin cache integrity when marketplace symlinks change.
+#
+# Phase 4 (AFTER linkGeneration, when programs.claude.runtimeCleanup.enable = true):
+# - Prunes stale runtime data (projects/, todos/, shell-snapshots/, etc.)
+# - Removes known cruft files and empty directories
+# - Controlled by programs.claude.runtimeCleanup.{retentionDays, maxBackups}
 #
 { config, lib, ... }:
 
@@ -76,6 +81,15 @@ in
       # See: https://github.com/anthropics/claude-code/issues/17361
       verifyCacheIntegrity = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
         $DRY_RUN_CMD ${./scripts/verify-cache-integrity.sh} "${homeDir}"
+      '';
+    }
+    // lib.optionalAttrs cfg.runtimeCleanup.enable {
+      # Phase 4: Prune stale runtime data on every home-manager switch.
+      cleanupRuntimeData = lib.hm.dag.entryAfter [ "verifyCacheIntegrity" ] ''
+        $DRY_RUN_CMD ${./scripts/cleanup-runtime-data.sh} \
+          "${homeDir}" \
+          "${toString cfg.runtimeCleanup.retentionDays}" \
+          "${toString cfg.runtimeCleanup.maxBackups}"
       '';
     };
   };

--- a/modules/claude/plugins/community.nix
+++ b/modules/claude/plugins/community.nix
@@ -19,7 +19,7 @@ _:
 
     # Superpowers - comprehensive Claude enhancement suite
     "superpowers@superpowers-marketplace" = true;
-    "double-shot-latte@superpowers-marketplace" = true; # User requested restore
+    # "double-shot-latte@superpowers-marketplace" = true; # Disabled — auto-continuation not in use
     "superpowers-lab@superpowers-marketplace" = true; # User requested add
     "superpowers-developing-for-claude-code@superpowers-marketplace" = true; # User requested restore
 

--- a/modules/claude/scripts/cleanup-runtime-data.sh
+++ b/modules/claude/scripts/cleanup-runtime-data.sh
@@ -27,13 +27,22 @@ CLAUDE_DIR="${HOME_DIR}/.claude"
 
 ACTIVE_UUIDS=()
 
-if compgen -G "${CLAUDE_DIR}/sessions/*.json" >/dev/null 2>&1; then
-  while IFS= read -r uuid; do
-    [[ -n "$uuid" ]] && ACTIVE_UUIDS+=("$uuid")
-  done < <(
-    jq -r '.sessionId // .session_id // empty' "${CLAUDE_DIR}"/sessions/*.json 2>/dev/null | sort -u
-  )
-fi
+# Use find to enumerate session files — avoids ARG_MAX limits with many sessions.
+# PID is encoded in the filename (e.g., 36922.json); check it with kill -0 to
+# confirm the process is still running before treating the session as active.
+while IFS= read -r session_file; do
+  uuid=$(jq -r '.sessionId // .session_id // empty' "$session_file" 2>/dev/null)
+  [[ -z "$uuid" ]] && continue
+  pid="${session_file##*/}"
+  pid="${pid%.json}"
+  if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+    ACTIVE_UUIDS+=("$uuid")
+  elif [[ ! "$pid" =~ ^[0-9]+$ ]]; then
+    # Non-numeric filename: include UUID conservatively
+    ACTIVE_UUIDS+=("$uuid")
+  fi
+  # Numeric pid that failed kill -0: process is dead — omit UUID so its data gets pruned
+done < <(find "${CLAUDE_DIR}/sessions" -maxdepth 1 -name "*.json" -type f 2>/dev/null)
 
 log_info "Active sessions: ${#ACTIVE_UUIDS[@]}"
 
@@ -97,23 +106,35 @@ LOCAL_JSON="${CLAUDE_DIR}/settings.local.json"
 MAIN_JSON="${CLAUDE_DIR}/settings.json"
 
 if [[ -f "$LOCAL_JSON" ]] && [[ -f "$MAIN_JSON" ]]; then
-  all_redundant=true
-  while IFS= read -r perm; do
-    [[ -z "$perm" ]] && continue
-    # Check if any entry in settings.json.permissions.allow covers this permission
-    covered=$(jq -r --arg p "$perm" '
-      .permissions.allow // [] |
-      map(. as $pat |
-        $p | test("^" + ($pat | gsub("\\*"; ".*")) + "$")
-      ) | any
-    ' "$MAIN_JSON" 2>/dev/null)
-    if [[ "$covered" != "true" ]]; then
-      all_redundant=false
-      break
-    fi
-  done < <(jq -r '.permissions.allow // [] | .[]' "$LOCAL_JSON" 2>/dev/null)
+  # Delete settings.local.json only when:
+  # 1. It contains ONLY a non-empty permissions.allow list (no other keys)
+  # 2. Every permission is already covered by a wildcard in settings.json
+  # Claude permissions contain literal parens/dots (e.g. "Bash(cmd *)") — escape all
+  # regex metacharacters before the wildcard substitution to avoid false matches.
+  all_redundant=$(jq -rs '
+    (.[0].permissions.allow // []) as $main |
+    .[1] as $local |
+    if (($local | keys | sort) == ["permissions"]) and
+       (($local.permissions | keys | sort) == ["allow"]) and
+       (($local.permissions.allow | type) == "array") and
+       (($local.permissions.allow | length) > 0)
+    then
+      $local.permissions.allow | all(. as $p |
+        $main | any(. as $pat |
+          $p | test(
+            "^" + (
+              $pat
+              | gsub("(?<c>[\\[\\]{}()\\\\^$+?|./-])"; "\\\(.c)")
+              | gsub("\\*"; ".*")
+            ) + "$"
+          )
+        )
+      ) | tostring
+    else "false"
+    end
+  ' "$MAIN_JSON" "$LOCAL_JSON" 2>/dev/null || echo "false")
 
-  if $all_redundant; then
+  if [[ "$all_redundant" == "true" ]]; then
     rm -f "$LOCAL_JSON"
     log_info "Removed redundant settings.local.json (all permissions covered by settings.json)"
   fi
@@ -155,8 +176,7 @@ for empty_dir in \
   "${CLAUDE_DIR}/debug" \
   "${CLAUDE_DIR}/powerline/locks"
 do
-  if [[ -d "$empty_dir" ]] && [[ -z "$(ls -A "$empty_dir" 2>/dev/null)" ]]; then
-    rmdir "$empty_dir"
+  if [[ -d "$empty_dir" ]] && rmdir "$empty_dir" 2>/dev/null; then
     log_info "Removed empty directory: ${empty_dir#"$HOME_DIR/"}"
   fi
 done
@@ -199,9 +219,11 @@ prune_dir_by_age "${CLAUDE_DIR}/tasks"          "task"
 
 backups_dir="${CLAUDE_DIR}/backups"
 if [[ -d "$backups_dir" ]]; then
-  mapfile -d $'\0' backup_files < <(
-    find "$backups_dir" -maxdepth 1 -name ".claude.json.backup.*" -print0 2>/dev/null |
-    sort -z
+  # Use -print (not -print0) + LC_ALL=C sort: backup filenames have no spaces/newlines
+  # and sort -z is a GNU extension not available on macOS BSD sort.
+  mapfile -t backup_files < <(
+    find "$backups_dir" -maxdepth 1 -name ".claude.json.backup.*" -print 2>/dev/null |
+    LC_ALL=C sort
   )
   excess=$(( ${#backup_files[@]} - MAX_BACKUPS ))
   if [[ $excess -gt 0 ]]; then
@@ -221,7 +243,7 @@ if [[ -d "${CLAUDE_DIR}/statsig" ]]; then
   while IFS= read -r -d $'\0' f; do
     rm -f "$f"
     statsig_pruned=$((statsig_pruned + 1))
-  done < <(find "${CLAUDE_DIR}/statsig" -maxdepth 1 -mtime +7 -print0 2>/dev/null)
+  done < <(find "${CLAUDE_DIR}/statsig" -mindepth 1 -maxdepth 1 -type f -mtime +7 -print0 2>/dev/null)
   [[ $statsig_pruned -gt 0 ]] && log_info "Pruned $statsig_pruned stale statsig cache files"
 fi
 

--- a/modules/claude/scripts/cleanup-runtime-data.sh
+++ b/modules/claude/scripts/cleanup-runtime-data.sh
@@ -55,10 +55,9 @@ is_active_session() {
 }
 
 # ────────────────────────────────────────────────
-# Helper: delete items older than RETENTION_DAYS
+# Helpers: delete items older than a given age
 # ────────────────────────────────────────────────
 
-# Deletes files/dirs inside $dir older than RETENTION_DAYS, skipping active sessions.
 prune_dir_by_age() {
   local dir="$1"
   local label="$2"
@@ -74,16 +73,31 @@ prune_dir_by_age() {
   [[ $count -gt 0 ]] && log_info "Pruned $count stale $label entries"
 }
 
+prune_files_by_age() {
+  local dir="$1"
+  local label="$2"
+  local days="$3"
+  [[ -d "$dir" ]] || return 0
+
+  local count=0
+  while IFS= read -r -d $'\0' f; do
+    rm -f "$f"
+    count=$((count + 1))
+  done < <(find "$dir" -mindepth 1 -maxdepth 1 -type f -mtime +"$days" -print0 2>/dev/null)
+  [[ $count -gt 0 ]] && log_info "Pruned $count stale $label files"
+}
+
 # ────────────────────────────────────────────────
 # 1. Telemetry — always delete (failed events never retry)
 # ────────────────────────────────────────────────
 
 if [[ -d "${CLAUDE_DIR}/telemetry" ]]; then
-  count=$(find "${CLAUDE_DIR}/telemetry" -name "1p_failed_events*" 2>/dev/null | wc -l | tr -d ' ')
-  if [[ $count -gt 0 ]]; then
-    find "${CLAUDE_DIR}/telemetry" -name "1p_failed_events*" -delete 2>/dev/null || true
-    log_info "Removed $count failed telemetry events"
-  fi
+  count=0
+  while IFS= read -r -d $'\0' f; do
+    rm -f "$f"
+    count=$((count + 1))
+  done < <(find "${CLAUDE_DIR}/telemetry" -name "1p_failed_events*" -print0 2>/dev/null)
+  [[ $count -gt 0 ]] && log_info "Removed $count failed telemetry events"
 fi
 
 # ────────────────────────────────────────────────
@@ -238,26 +252,12 @@ fi
 # 15. statsig/ — feature flag caches, 7-day retention
 # ────────────────────────────────────────────────
 
-if [[ -d "${CLAUDE_DIR}/statsig" ]]; then
-  statsig_pruned=0
-  while IFS= read -r -d $'\0' f; do
-    rm -f "$f"
-    statsig_pruned=$((statsig_pruned + 1))
-  done < <(find "${CLAUDE_DIR}/statsig" -mindepth 1 -maxdepth 1 -type f -mtime +7 -print0 2>/dev/null)
-  [[ $statsig_pruned -gt 0 ]] && log_info "Pruned $statsig_pruned stale statsig cache files"
-fi
+prune_files_by_age "${CLAUDE_DIR}/statsig" "statsig cache" 7
 
 # ────────────────────────────────────────────────
 # 16. logs/ — delete log files older than RETENTION_DAYS
 # ────────────────────────────────────────────────
 
-if [[ -d "${CLAUDE_DIR}/logs" ]]; then
-  logs_pruned=0
-  while IFS= read -r -d $'\0' f; do
-    rm -f "$f"
-    logs_pruned=$((logs_pruned + 1))
-  done < <(find "${CLAUDE_DIR}/logs" -maxdepth 1 -type f -mtime +"$RETENTION_DAYS" -print0 2>/dev/null)
-  [[ $logs_pruned -gt 0 ]] && log_info "Pruned $logs_pruned old log files"
-fi
+prune_files_by_age "${CLAUDE_DIR}/logs" "log" "$RETENTION_DAYS"
 
 log_info "Runtime data cleanup complete (retention: ${RETENTION_DAYS}d, max backups: ${MAX_BACKUPS})"

--- a/modules/claude/scripts/cleanup-runtime-data.sh
+++ b/modules/claude/scripts/cleanup-runtime-data.sh
@@ -8,7 +8,6 @@
 #
 # Safety: reads active session PIDs from ~/.claude/sessions/*.json before
 # touching anything. Files/dirs matching an active session UUID are skipped.
-# Projects dirs modified within the last hour are also skipped.
 
 set -euo pipefail
 
@@ -35,13 +34,11 @@ while IFS= read -r session_file; do
   [[ -z "$uuid" ]] && continue
   pid="${session_file##*/}"
   pid="${pid%.json}"
-  if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
-    ACTIVE_UUIDS+=("$uuid")
-  elif [[ ! "$pid" =~ ^[0-9]+$ ]]; then
-    # Non-numeric filename: include UUID conservatively
-    ACTIVE_UUIDS+=("$uuid")
+  # Skip only numeric PIDs confirmed dead; non-numeric filenames are included conservatively
+  if [[ "$pid" =~ ^[0-9]+$ ]] && ! kill -0 "$pid" 2>/dev/null; then
+    continue
   fi
-  # Numeric pid that failed kill -0: process is dead — omit UUID so its data gets pruned
+  ACTIVE_UUIDS+=("$uuid")
 done < <(find "${CLAUDE_DIR}/sessions" -maxdepth 1 -name "*.json" -type f 2>/dev/null)
 
 log_info "Active sessions: ${#ACTIVE_UUIDS[@]}"
@@ -113,112 +110,10 @@ done < <(find "${CLAUDE_DIR}" -maxdepth 1 -name "security_warnings_state_*.json"
 [[ $stale_warnings -gt 0 ]] && log_info "Removed $stale_warnings stale security_warnings_state files"
 
 # ────────────────────────────────────────────────
-# 3. settings.local.json — delete if fully covered by settings.json wildcards
+# 3. projects/ + session-keyed runtime data dirs
 # ────────────────────────────────────────────────
 
-LOCAL_JSON="${CLAUDE_DIR}/settings.local.json"
-MAIN_JSON="${CLAUDE_DIR}/settings.json"
-
-if [[ -f "$LOCAL_JSON" ]] && [[ -f "$MAIN_JSON" ]]; then
-  # Delete settings.local.json only when:
-  # 1. It contains ONLY a non-empty permissions.allow list (no other keys)
-  # 2. Every permission is already covered by a wildcard in settings.json
-  # Claude permissions contain literal parens/dots (e.g. "Bash(cmd *)") — escape all
-  # regex metacharacters before the wildcard substitution to avoid false matches.
-  all_redundant=$(jq -rs '
-    (.[0].permissions.allow // []) as $main |
-    .[1] as $local |
-    if (($local | keys | sort) == ["permissions"]) and
-       (($local.permissions | keys | sort) == ["allow"]) and
-       (($local.permissions.allow | type) == "array") and
-       (($local.permissions.allow | length) > 0)
-    then
-      $local.permissions.allow | all(. as $p |
-        $main | any(. as $pat |
-          $p | test(
-            "^" + (
-              $pat
-              | gsub("(?<c>[\\[\\]{}()\\\\^$+?|./-])"; "\\\(.c)")
-              | gsub("\\*"; ".*")
-            ) + "$"
-          )
-        )
-      ) | tostring
-    else "false"
-    end
-  ' "$MAIN_JSON" "$LOCAL_JSON" 2>/dev/null || echo "false")
-
-  if [[ "$all_redundant" == "true" ]]; then
-    rm -f "$LOCAL_JSON"
-    log_info "Removed redundant settings.local.json (all permissions covered by settings.json)"
-  fi
-fi
-
-# ────────────────────────────────────────────────
-# 4. Known cruft files — always delete
-# ────────────────────────────────────────────────
-
-for cruft in \
-  "${CLAUDE_DIR}/settings.json.backup-manual" \
-  "${CLAUDE_DIR}/auto-claude-control.json"
-do
-  if [[ -f "$cruft" ]]; then
-    rm -f "$cruft"
-    log_info "Removed cruft: $(basename "$cruft")"
-  fi
-done
-
-# ────────────────────────────────────────────────
-# 5. Broken symlinks in ~/.claude root
-# ────────────────────────────────────────────────
-
-broken=0
-while IFS= read -r -d $'\0' link; do
-  rm -f "$link"
-  broken=$((broken + 1))
-done < <(find "${CLAUDE_DIR}" -maxdepth 2 -xtype l -print0 2>/dev/null)
-[[ $broken -gt 0 ]] && log_info "Removed $broken broken symlinks"
-
-# ────────────────────────────────────────────────
-# 6. Known empty directories
-# ────────────────────────────────────────────────
-
-for empty_dir in \
-  "${CLAUDE_DIR}/.claude" \
-  "${CLAUDE_DIR}/downloads" \
-  "${CLAUDE_DIR}/statusline" \
-  "${CLAUDE_DIR}/debug" \
-  "${CLAUDE_DIR}/powerline/locks"
-do
-  if [[ -d "$empty_dir" ]] && rmdir "$empty_dir" 2>/dev/null; then
-    log_info "Removed empty directory: ${empty_dir#"$HOME_DIR/"}"
-  fi
-done
-
-# ────────────────────────────────────────────────
-# 7. projects/ — delete session dirs inactive longer than RETENTION_DAYS
-#    Extra guard: skip dirs modified within the last hour
-# ────────────────────────────────────────────────
-
-projects_dir="${CLAUDE_DIR}/projects"
-if [[ -d "$projects_dir" ]]; then
-  pruned_projects=0
-  while IFS= read -r -d $'\0' proj; do
-    is_active_session "$proj" && continue
-    # Skip if modified within the last hour (race condition guard)
-    if find "$proj" -mindepth 0 -maxdepth 0 -mmin -60 2>/dev/null | grep -q .; then
-      continue
-    fi
-    rm -rf "$proj"
-    pruned_projects=$((pruned_projects + 1))
-  done < <(find "$projects_dir" -mindepth 1 -maxdepth 1 -mtime +"$RETENTION_DAYS" -print0 2>/dev/null)
-  [[ $pruned_projects -gt 0 ]] && log_info "Pruned $pruned_projects stale project session dirs"
-fi
-
-# ────────────────────────────────────────────────
-# 8–13. Session-keyed runtime data dirs
-# ────────────────────────────────────────────────
-
+prune_dir_by_age "${CLAUDE_DIR}/projects"    "project session"
 prune_dir_by_age "${CLAUDE_DIR}/todos"          "todo"
 prune_dir_by_age "${CLAUDE_DIR}/file-history"   "file-history"
 prune_dir_by_age "${CLAUDE_DIR}/shell-snapshots" "shell-snapshot"
@@ -228,7 +123,7 @@ prune_dir_by_age "${CLAUDE_DIR}/plans"          "plan"
 prune_dir_by_age "${CLAUDE_DIR}/tasks"          "task"
 
 # ────────────────────────────────────────────────
-# 14. backups — keep only the newest MAX_BACKUPS
+# 4. backups — keep only the newest MAX_BACKUPS
 # ────────────────────────────────────────────────
 
 backups_dir="${CLAUDE_DIR}/backups"
@@ -249,13 +144,13 @@ if [[ -d "$backups_dir" ]]; then
 fi
 
 # ────────────────────────────────────────────────
-# 15. statsig/ — feature flag caches, 7-day retention
+# 5. statsig/ — feature flag caches, 7-day retention
 # ────────────────────────────────────────────────
 
 prune_files_by_age "${CLAUDE_DIR}/statsig" "statsig cache" 7
 
 # ────────────────────────────────────────────────
-# 16. logs/ — delete log files older than RETENTION_DAYS
+# 6. logs/ — delete log files older than RETENTION_DAYS
 # ────────────────────────────────────────────────
 
 prune_files_by_age "${CLAUDE_DIR}/logs" "log" "$RETENTION_DAYS"

--- a/modules/claude/scripts/cleanup-runtime-data.sh
+++ b/modules/claude/scripts/cleanup-runtime-data.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Runtime Data Cleanup for ~/.claude
+#
+# Prunes stale session artifacts that accumulate over time.
+# Runs on every home-manager switch via orphan-cleanup.nix Phase 4.
+#
+# Usage: cleanup-runtime-data.sh <home_dir> <retention_days> <max_backups>
+#
+# Safety: reads active session PIDs from ~/.claude/sessions/*.json before
+# touching anything. Files/dirs matching an active session UUID are skipped.
+# Projects dirs modified within the last hour are also skipped.
+
+set -euo pipefail
+
+# shellcheck source=cleanup-common.sh
+. "$(dirname "$0")/cleanup-common.sh"
+
+HOME_DIR="${1:?HOME_DIR required}"
+RETENTION_DAYS="${2:-30}"
+MAX_BACKUPS="${3:-5}"
+
+CLAUDE_DIR="${HOME_DIR}/.claude"
+
+# ────────────────────────────────────────────────
+# Active session detection
+# ────────────────────────────────────────────────
+
+ACTIVE_UUIDS=()
+
+if compgen -G "${CLAUDE_DIR}/sessions/*.json" >/dev/null 2>&1; then
+  while IFS= read -r uuid; do
+    [[ -n "$uuid" ]] && ACTIVE_UUIDS+=("$uuid")
+  done < <(
+    jq -r '.sessionId // .session_id // empty' "${CLAUDE_DIR}"/sessions/*.json 2>/dev/null | sort -u
+  )
+fi
+
+log_info "Active sessions: ${#ACTIVE_UUIDS[@]}"
+
+is_active_session() {
+  local target="$1"
+  for uuid in "${ACTIVE_UUIDS[@]}"; do
+    [[ "$target" == *"$uuid"* ]] && return 0
+  done
+  return 1
+}
+
+# ────────────────────────────────────────────────
+# Helper: delete items older than RETENTION_DAYS
+# ────────────────────────────────────────────────
+
+# Deletes files/dirs inside $dir older than RETENTION_DAYS, skipping active sessions.
+prune_dir_by_age() {
+  local dir="$1"
+  local label="$2"
+  [[ -d "$dir" ]] || return 0
+
+  local count=0
+  while IFS= read -r -d $'\0' item; do
+    is_active_session "$item" && continue
+    rm -rf "$item"
+    count=$((count + 1))
+  done < <(find "$dir" -mindepth 1 -maxdepth 1 -mtime +"$RETENTION_DAYS" -print0 2>/dev/null)
+
+  [[ $count -gt 0 ]] && log_info "Pruned $count stale $label entries"
+}
+
+# ────────────────────────────────────────────────
+# 1. Telemetry — always delete (failed events never retry)
+# ────────────────────────────────────────────────
+
+if [[ -d "${CLAUDE_DIR}/telemetry" ]]; then
+  count=$(find "${CLAUDE_DIR}/telemetry" -name "1p_failed_events*" 2>/dev/null | wc -l | tr -d ' ')
+  if [[ $count -gt 0 ]]; then
+    find "${CLAUDE_DIR}/telemetry" -name "1p_failed_events*" -delete 2>/dev/null || true
+    log_info "Removed $count failed telemetry events"
+  fi
+fi
+
+# ────────────────────────────────────────────────
+# 2. security_warnings_state_*.json — stale per-session files in ~/.claude root
+# ────────────────────────────────────────────────
+
+stale_warnings=0
+while IFS= read -r -d $'\0' f; do
+  is_active_session "$f" && continue
+  rm -f "$f"
+  stale_warnings=$((stale_warnings + 1))
+done < <(find "${CLAUDE_DIR}" -maxdepth 1 -name "security_warnings_state_*.json" -print0 2>/dev/null)
+[[ $stale_warnings -gt 0 ]] && log_info "Removed $stale_warnings stale security_warnings_state files"
+
+# ────────────────────────────────────────────────
+# 3. settings.local.json — delete if fully covered by settings.json wildcards
+# ────────────────────────────────────────────────
+
+LOCAL_JSON="${CLAUDE_DIR}/settings.local.json"
+MAIN_JSON="${CLAUDE_DIR}/settings.json"
+
+if [[ -f "$LOCAL_JSON" ]] && [[ -f "$MAIN_JSON" ]]; then
+  all_redundant=true
+  while IFS= read -r perm; do
+    [[ -z "$perm" ]] && continue
+    # Check if any entry in settings.json.permissions.allow covers this permission
+    covered=$(jq -r --arg p "$perm" '
+      .permissions.allow // [] |
+      map(. as $pat |
+        $p | test("^" + ($pat | gsub("\\*"; ".*")) + "$")
+      ) | any
+    ' "$MAIN_JSON" 2>/dev/null)
+    if [[ "$covered" != "true" ]]; then
+      all_redundant=false
+      break
+    fi
+  done < <(jq -r '.permissions.allow // [] | .[]' "$LOCAL_JSON" 2>/dev/null)
+
+  if $all_redundant; then
+    rm -f "$LOCAL_JSON"
+    log_info "Removed redundant settings.local.json (all permissions covered by settings.json)"
+  fi
+fi
+
+# ────────────────────────────────────────────────
+# 4. Known cruft files — always delete
+# ────────────────────────────────────────────────
+
+for cruft in \
+  "${CLAUDE_DIR}/settings.json.backup-manual" \
+  "${CLAUDE_DIR}/auto-claude-control.json"
+do
+  if [[ -f "$cruft" ]]; then
+    rm -f "$cruft"
+    log_info "Removed cruft: $(basename "$cruft")"
+  fi
+done
+
+# ────────────────────────────────────────────────
+# 5. Broken symlinks in ~/.claude root
+# ────────────────────────────────────────────────
+
+broken=0
+while IFS= read -r -d $'\0' link; do
+  rm -f "$link"
+  broken=$((broken + 1))
+done < <(find "${CLAUDE_DIR}" -maxdepth 2 -xtype l -print0 2>/dev/null)
+[[ $broken -gt 0 ]] && log_info "Removed $broken broken symlinks"
+
+# ────────────────────────────────────────────────
+# 6. Known empty directories
+# ────────────────────────────────────────────────
+
+for empty_dir in \
+  "${CLAUDE_DIR}/.claude" \
+  "${CLAUDE_DIR}/downloads" \
+  "${CLAUDE_DIR}/statusline" \
+  "${CLAUDE_DIR}/debug" \
+  "${CLAUDE_DIR}/powerline/locks"
+do
+  if [[ -d "$empty_dir" ]] && [[ -z "$(ls -A "$empty_dir" 2>/dev/null)" ]]; then
+    rmdir "$empty_dir"
+    log_info "Removed empty directory: ${empty_dir#"$HOME_DIR/"}"
+  fi
+done
+
+# ────────────────────────────────────────────────
+# 7. projects/ — delete session dirs inactive longer than RETENTION_DAYS
+#    Extra guard: skip dirs modified within the last hour
+# ────────────────────────────────────────────────
+
+projects_dir="${CLAUDE_DIR}/projects"
+if [[ -d "$projects_dir" ]]; then
+  pruned_projects=0
+  while IFS= read -r -d $'\0' proj; do
+    is_active_session "$proj" && continue
+    # Skip if modified within the last hour (race condition guard)
+    if find "$proj" -mindepth 0 -maxdepth 0 -mmin -60 2>/dev/null | grep -q .; then
+      continue
+    fi
+    rm -rf "$proj"
+    pruned_projects=$((pruned_projects + 1))
+  done < <(find "$projects_dir" -mindepth 1 -maxdepth 1 -mtime +"$RETENTION_DAYS" -print0 2>/dev/null)
+  [[ $pruned_projects -gt 0 ]] && log_info "Pruned $pruned_projects stale project session dirs"
+fi
+
+# ────────────────────────────────────────────────
+# 8–13. Session-keyed runtime data dirs
+# ────────────────────────────────────────────────
+
+prune_dir_by_age "${CLAUDE_DIR}/todos"          "todo"
+prune_dir_by_age "${CLAUDE_DIR}/file-history"   "file-history"
+prune_dir_by_age "${CLAUDE_DIR}/shell-snapshots" "shell-snapshot"
+prune_dir_by_age "${CLAUDE_DIR}/session-env"    "session-env"
+prune_dir_by_age "${CLAUDE_DIR}/paste-cache"    "paste-cache"
+prune_dir_by_age "${CLAUDE_DIR}/plans"          "plan"
+prune_dir_by_age "${CLAUDE_DIR}/tasks"          "task"
+
+# ────────────────────────────────────────────────
+# 14. backups — keep only the newest MAX_BACKUPS
+# ────────────────────────────────────────────────
+
+backups_dir="${CLAUDE_DIR}/backups"
+if [[ -d "$backups_dir" ]]; then
+  mapfile -d $'\0' backup_files < <(
+    find "$backups_dir" -maxdepth 1 -name ".claude.json.backup.*" -print0 2>/dev/null |
+    sort -z
+  )
+  excess=$(( ${#backup_files[@]} - MAX_BACKUPS ))
+  if [[ $excess -gt 0 ]]; then
+    for (( i=0; i<excess; i++ )); do
+      rm -f "${backup_files[$i]}"
+    done
+    log_info "Removed $excess old backups (kept $MAX_BACKUPS)"
+  fi
+fi
+
+# ────────────────────────────────────────────────
+# 15. statsig/ — feature flag caches, 7-day retention
+# ────────────────────────────────────────────────
+
+if [[ -d "${CLAUDE_DIR}/statsig" ]]; then
+  statsig_pruned=0
+  while IFS= read -r -d $'\0' f; do
+    rm -f "$f"
+    statsig_pruned=$((statsig_pruned + 1))
+  done < <(find "${CLAUDE_DIR}/statsig" -maxdepth 1 -mtime +7 -print0 2>/dev/null)
+  [[ $statsig_pruned -gt 0 ]] && log_info "Pruned $statsig_pruned stale statsig cache files"
+fi
+
+# ────────────────────────────────────────────────
+# 16. logs/ — delete log files older than RETENTION_DAYS
+# ────────────────────────────────────────────────
+
+if [[ -d "${CLAUDE_DIR}/logs" ]]; then
+  logs_pruned=0
+  while IFS= read -r -d $'\0' f; do
+    rm -f "$f"
+    logs_pruned=$((logs_pruned + 1))
+  done < <(find "${CLAUDE_DIR}/logs" -maxdepth 1 -type f -mtime +"$RETENTION_DAYS" -print0 2>/dev/null)
+  [[ $logs_pruned -gt 0 ]] && log_info "Pruned $logs_pruned old log files"
+fi
+
+log_info "Runtime data cleanup complete (retention: ${RETENTION_DAYS}d, max backups: ${MAX_BACKUPS})"

--- a/orchestrator/uv.lock
+++ b/orchestrator/uv.lock
@@ -770,7 +770,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.25"
+version = "0.7.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -783,9 +783,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/d7/21ffae5ccdc3c9b8de283e8f8bf48a92039681df0d39f15133d8ff8965bd/langsmith-0.7.25.tar.gz", hash = "sha256:d17da71f156ca69eafd28ac9627c8e0e93170260ec37cd27cedc83205a067598", size = 1145410, upload-time = "2026-04-03T13:11:42.36Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/13/67889d41baf7dbaf13ffd0b334a0f284e107fad1cc8782a1abb1e56e5eeb/langsmith-0.7.25-py3-none-any.whl", hash = "sha256:55ecc24c547f6c79b5a684ff8685c669eec34e52fcac5d2c0af7d613aef5a632", size = 359417, upload-time = "2026-04-03T13:11:40.729Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Extends `orphan-cleanup.nix` with Phase 4: activation-time cleanup of stale `~/.claude` runtime data on every `home-manager switch`
- New script `cleanup-runtime-data.sh` prunes: project session dirs, todos, file-history, shell-snapshots, session-env, paste-cache, plans, tasks, failed telemetry, stale security warning state files, redundant `settings.local.json`, and old backups
- Simplifies helper logic with `prune_files_by_age` helper and single-pass telemetry processing for efficiency
- Active sessions detected via PID liveness check (`kill -0`) against `~/.claude/sessions/*.json` — their data is never touched
- Adds `programs.claude.runtimeCleanup.{enable, retentionDays, maxBackups}` options — `enable` uses `mkEnableOption` (defaults `false`, safe opt-in), explicitly set to `true` in `claude-config.nix`; defaults: 30d retention, 5 max backups
- Disables `double-shot-latte` plugin (auto-continuation, not in active use)
- Bundles cherry-picked langsmith CVE fix (GHSA-rr7j-v2q5-chgv) from #556 — upgrades `langsmith 0.7.25 → 0.7.32` in `orchestrator/uv.lock`
- No custom launchd agents, cron jobs, or OS services — piggybacks entirely on existing `home-manager switch` workflow via activation script

## Test plan

- [ ] `nix flake check` passes (all 31 checks including shellcheck, formatting, statix)
- [ ] `home-manager switch` runs Phase 4 and logs cleanup activity
- [ ] Active Claude sessions are untouched after switch
- [ ] `du -sh ~/.claude/` shows reduced size
- [ ] `double-shot-latte` absent from `~/.claude/settings.json` enabledPlugins after switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
