### PR TITLE
fix(pal-mcp): prefix mlx-local models for Bifrost routing

### DIFF
--- a/modules/claude/pal-models.nix
+++ b/modules/claude/pal-models.nix
@@ -39,7 +39,7 @@ let
   # Static config lives in the script file; only values requiring Nix evaluation go here.
   palMcpEnv = ''
     export CUSTOM_MODELS_CONFIG_PATH="${outputFile}"
-    export CUSTOM_MODEL_NAME="${mlxCfg.defaultModel}"
+    export CUSTOM_MODEL_NAME="mlx-local/${mlxCfg.defaultModel}"
     export OPENROUTER_MODELS_CONFIG_PATH="${outputDir}/openrouter_models.json"
     export PAL_LOG_DIR="${palLogDir}"
     export PAL_MCP_SERVER="${palPkg}/bin/pal-mcp-server"

--- a/modules/claude/rules/pal-mcp-policy.md
+++ b/modules/claude/rules/pal-mcp-policy.md
@@ -31,6 +31,11 @@ the failure mode this rule exists to prevent.
 - **DEFAULT_MODEL=auto**: PAL picks a model alias per-task; for single-model
   work this flows through `CUSTOM_API_URL` → Bifrost → the right provider.
   `clink`/`consensus` use their own multi-provider fan-out, not Bifrost.
+- **MLX model prefix**: Bifrost requires `provider/model` format. Local MLX
+  models are addressed as `mlx-local/mlx-community/<model-id>` (e.g.
+  `mlx-local/mlx-community/Qwen3.5-35B-A3B-4bit`). The `mlx-local/` prefix
+  is baked into `custom_models.json` and `CUSTOM_MODEL_NAME` by the Nix module
+  — do not use bare `mlx-community/` names when calling Bifrost directly.
 - **Secrets**: Local PAL subprocess secrets (API keys, config) are injected by
   the `doppler-mcp` wrapper at launch time. This is separate from the Doppler
   **K8s Operator** that syncs Bifrost's in-cluster provider keys — different

--- a/modules/mcp/scripts/pal-models-mlx.jq
+++ b/modules/mcp/scripts/pal-models-mlx.jq
@@ -7,6 +7,9 @@
 # Input format (OpenAI-compatible):
 #   { "data": [{ "id": "mlx-community/<model-id>", ... }] }
 #
+# Output model_name uses Bifrost provider prefix: "mlx-local/mlx-community/<model-id>"
+# Bifrost requires "provider/model" format; mlx-local routes to the local MLX backend.
+#
 # Filtering: model MUST have a real LMSYS arena Elo rating. Models without
 # a benchmark score are omitted entirely. PAL only sees scored models.
 
@@ -25,7 +28,7 @@ def has_function_calling: test("Qwen3|Llama-4|Scout|Mistral|Nemotron");
     | model_intelligence_score($id) as $score
     | select($score != null)               # require real benchmark score
     | {
-        model_name: $id,
+        model_name: "mlx-local/\($id)",
         aliases: [$short, $clean],
         intelligence_score: $score,
         json_mode: false,


### PR DESCRIPTION
## Summary

Bifrost AI gateway requires all requests to include a `provider/model` format. MLX local models stored as bare `mlx-community/<id>` strings are rejected. This PR ensures all MLX model names are prefixed with `mlx-local/` to satisfy Bifrost's provider routing requirements.

## Changes

- `modules/mcp/scripts/pal-models-mlx.jq` — Emit model_name in custom_models.json with `mlx-local/mlx-community/<id>` prefix
- `modules/claude/pal-models.nix` — Prefix CUSTOM_MODEL_NAME env var with `mlx-local/` for Bifrost-compatible default
- `modules/claude/rules/pal-mcp-policy.md` — Document the mlx-local/ prefix requirement and Bifrost routing format

## Test Plan

- [ ] `nix flake check` passes
- [ ] `darwin-rebuild switch` with this branch completes without errors
- [ ] `sync-mlx-models` outputs custom_models.json with `mlx-local/mlx-community/` prefixes
- [ ] `mcp__pal__chat(model="mlx-local/mlx-community/Qwen3.5-35B-A3B-4bit", prompt="test")` succeeds
- [ ] `mcp__pal__listmodels()` lists models with `mlx-local/` prefix

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)