### PR TITLE
fix(claude): narrow additionalDirectories, DRY the list, add retrospecting/reports

### DIFF
--- a/.file-size.yml
+++ b/.file-size.yml
@@ -1,6 +1,7 @@
 # Per-repo file-size config for JacobPEvans/.github/_file-size.yml
 # options.nix: vllm-mlx parameter reference (active + commented-out options)
 # ai-tools: multi-tool AI package definitions
+# claude-config: comprehensive Claude Code module configuration
 extended:
   limit: 20480
-  files: [options, ai-tools]
+  files: [options, ai-tools, claude-config]

--- a/flake.nix
+++ b/flake.nix
@@ -257,6 +257,7 @@
                     inherit (nixpkgs) lib;
                     inherit marketplaceInputs claude-cookbooks;
                   }).pluginConfig;
+                additionalDirectories = [ "~/.claude/" ]; # CI fixture — real list in modules/claude-config.nix
               }
             );
           codexRules =

--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -227,6 +227,7 @@ in
           marketplaces = { };
           enabledPlugins = { };
         };
+        additionalDirectories = [ "~/.claude/" ]; # CI fixture — real list in modules/claude-config.nix
       };
     in
     pkgs.runCommand "check-settings-json"

--- a/lib/claude-settings.nix
+++ b/lib/claude-settings.nix
@@ -19,6 +19,7 @@
   schemaUrl,
   permissions, # { allow, deny, ask }
   plugins, # { marketplaces, enabledPlugins }
+  additionalDirectories ? [ ], # deployment list from modules/claude-config.nix
 }:
 
 let
@@ -43,12 +44,8 @@ in
   permissions = {
     inherit (permissions) allow deny ask;
 
-    # Directory-level read access
-    additionalDirectories = [
-      "~/" # Full home directory access
-      "~/.claude/" # Claude configuration
-      "~/.config/" # XDG config directory
-    ];
+    # Directory-level access — canonical list in modules/claude-config.nix
+    inherit additionalDirectories;
   };
 
   # Status line configuration

--- a/lib/claude-settings.nix
+++ b/lib/claude-settings.nix
@@ -19,7 +19,7 @@
   schemaUrl,
   permissions, # { allow, deny, ask }
   plugins, # { marketplaces, enabledPlugins }
-  additionalDirectories ? [ ], # deployment list from modules/claude-config.nix
+  additionalDirectories ? [ ], # caller-provided; CI passes a fixture, deployment uses modules/claude/settings.nix
 }:
 
 let

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -258,11 +258,18 @@ in
       ask = formatters.claude.formatAsk permissions;
     };
 
-    # Additional directories accessible to Claude Code without prompts
+    # Additional directories accessible to Claude Code without prompts.
+    # Single source of truth — lib/claude-settings.nix accepts this as a parameter.
     additionalDirectories = [
-      "~/"
       "~/.claude/"
-      "~/.config/"
+      "~/.claude/skills/retrospecting/reports/"
+      "~/.config/direnv/"
+      "~/.config/fabric/"
+      "~/.config/gh/"
+      "~/.config/git/"
+      "~/.config/mlx/"
+      "~/.config/nix/"
+      "~/.config/pal-mcp/"
     ];
 
     # Sandbox configuration (Dec 2025 feature)

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -259,7 +259,8 @@ in
     };
 
     # Additional directories accessible to Claude Code without prompts.
-    # Single source of truth — lib/claude-settings.nix accepts this as a parameter.
+    # Consumed by modules/claude/settings.nix via cfg.settings.additionalDirectories.
+    # lib/claude-settings.nix (CI-only) accepts a separate caller-provided parameter.
     additionalDirectories = [
       "~/.claude/"
       "~/.claude/skills/retrospecting/reports/"


### PR DESCRIPTION
## Summary

- Remove overly broad `~/` from `additionalDirectories` — Claude Code already has project working directory access; `~/` granted full home write without justification
- Replace blanket `~/.config/` with 7 explicit subdirs: `direnv`, `fabric`, `gh`, `git`, `mlx`, `nix`, `pal-mcp`
- Add `~/.claude/skills/retrospecting/reports/` for the retrospecting skill's centralized report output
- Fix DRY violation: `lib/claude-settings.nix` now accepts `additionalDirectories` as a parameter (default `[]`) — canonical list lives only in `modules/claude-config.nix`; CI callers pass a minimal fixture
- Add `claude-config` to `.file-size.yml` extended allowlist (comprehensive config file analogous to `options.nix`)

## Changes

| File | Change |
|------|--------|
| `modules/claude-config.nix` | Single source of truth for directory list; 3 broad paths → 9 specific paths |
| `lib/claude-settings.nix` | Parameterized `additionalDirectories` — no longer hardcoded |
| `flake.nix` | Passes CI fixture `["~/.claude/"]` to settings generator |
| `lib/checks/claude.nix` | Passes CI fixture to settings JSON validation check |
| `.file-size.yml` | Extends 20KB limit to `claude-config` files |

## Test Plan

- [x] `nix flake check` passes (settings-json, formatting, statix, deadnix, shellcheck)
- [x] CI green: File Size, Nix Validate, OSV Scan, CodeQL, Merge Gate
- [ ] After `darwin-rebuild switch`: `jq '.permissions.additionalDirectories' ~/.claude/settings.json` shows the 9 specific paths
- [ ] Fresh session: no permission prompts when writing to `~/.claude/skills/retrospecting/reports/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)