### PR TITLE
fix(claude): add /tmp/ to additionalDirectories

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -271,6 +271,7 @@ in
       "~/.config/mlx/"
       "~/.config/nix/"
       "~/.config/pal-mcp/"
+      "/tmp/"
     ];
 
     # Sandbox configuration (Dec 2025 feature)


### PR DESCRIPTION
## Summary
- Adds `/tmp/` to the `additionalDirectories` list in `modules/claude-config.nix`
- Allows Claude Code to read/write temp files without permission prompts

## Changes
- `modules/claude-config.nix`: append `"/tmp/"` to `additionalDirectories`

## Test Plan
- [x] `nix flake check` passes
- [ ] After `darwin-rebuild switch`, verify `/tmp/` access works without prompts in a fresh Claude Code session