### PR TITLE
fix(permissions): simplify deny rules for auto mode

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -16,7 +16,21 @@
 let
   # Import unified permissions from common module
   # This reads from ai-assistant-instructions agentsmd/permissions/
-  aiCommon = import ./common { inherit lib config ai-assistant-instructions; };
+  # Auto mode's AI classifier handles safety for excluded categories;
+  # shell.json (inline code execution) and network.json (curl mutations) are
+  # excluded because auto mode detects malicious usage contextually.
+  # npm run/test are false positives in the package-install deny list.
+  aiCommon = import ./common {
+    inherit lib config ai-assistant-instructions;
+    excludeDenyFiles = [
+      "shell.json"
+      "network.json"
+    ];
+    excludeDenyCommands = [
+      "npm run"
+      "npm test"
+    ];
+  };
   inherit (aiCommon) permissions;
   inherit (aiCommon) formatters;
 

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -23,12 +23,22 @@
   lib,
   config,
   ai-assistant-instructions,
+  excludeDenyFiles ? [ ],
+  excludeDenyCommands ? [ ],
   ...
 }:
 
 {
   # Unified permission definitions
-  permissions = import ./permissions.nix { inherit lib config ai-assistant-instructions; };
+  permissions = import ./permissions.nix {
+    inherit
+      lib
+      config
+      ai-assistant-instructions
+      excludeDenyFiles
+      excludeDenyCommands
+      ;
+  };
 
   # Tool-specific formatters
   formatters = import ./formatters.nix { inherit lib; };

--- a/modules/common/permissions.nix
+++ b/modules/common/permissions.nix
@@ -81,7 +81,7 @@ in
 
   # MCP tool permissions (non-shell, bare identifiers like mcp__plugin_*)
   mcpAllow = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) allowJsons);
-  mcpDeny = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) denyJsons);
+  mcpDeny = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) filteredDenyJsons);
   mcpAsk = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) askJsons);
 
   # WebFetch domains

--- a/modules/common/permissions.nix
+++ b/modules/common/permissions.nix
@@ -19,6 +19,8 @@
   lib,
   config,
   ai-assistant-instructions,
+  excludeDenyFiles ? [ ],
+  excludeDenyCommands ? [ ],
   ...
 }:
 
@@ -60,13 +62,19 @@ let
   denyJsons = readJsonsFromDir denyDir;
   askJsons = readJsonsFromDir askDir;
 
+  # Apply deny exclusions: drop entire files, then filter specific commands.
+  # Excluded categories are handled by auto mode's AI classifier instead.
+  filteredDenyJsons = lib.filterAttrs (name: _: !(builtins.elem name excludeDenyFiles)) denyJsons;
+
 in
 {
   # Auto-approved commands from ai-assistant-instructions
   allow = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) allowJsons);
 
-  # Denied commands from ai-assistant-instructions
-  deny = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) denyJsons);
+  # Denied commands with exclusions applied
+  deny = lib.filter (cmd: !(builtins.elem cmd excludeDenyCommands)) (
+    lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) filteredDenyJsons)
+  );
 
   # Commands that require explicit user confirmation
   ask = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) askJsons);


### PR DESCRIPTION
## Summary

Simplify the permission deny list by removing 40 entries that Claude Code's auto mode AI classifier now handles contextually. Adds `excludeDenyFiles` and `excludeDenyCommands` parameters to the permission engine for selective upstream deny exclusion without modifying ai-assistant-instructions source JSONs.

## Changes

### Removed deny categories (auto mode handles these)

| Source | Entries | Reason |
|--------|---------|--------|
| `shell.json` | 25 | Inline code execution (`python -c`, `bash -c`, etc.) — auto mode classifies malicious usage contextually |
| `network.json` | 13 | curl mutations, `nc`/`socat` — auto mode blocks data exfiltration |
| `npm run`/`npm test` | 2 | False positives in package-install deny (script runners, not installers) |

### Kept deny categories (policy enforcement)

| Source | Entries | Reason |
|--------|---------|--------|
| `dangerous.json` | 15 cmds + 13 Read patterns | Irreversible system destruction + secrets protection |
| `git.json` | 13 | Hook bypass policy enforcement |
| `package-install.json` (minus npm run/test) | 22 | Nix-first policy enforcement |

### Implementation

- Added `excludeDenyFiles` and `excludeDenyCommands` optional parameters to `permissions.nix` (default: empty lists for backward compatibility)
- Threaded parameters through `default.nix` to callers
- Applied file-level filtering before command extraction (avoids processing excluded files)
- Applied command-level filtering after flattening
- Ensured `mcpDeny` also uses filtered deny JSONs for consistency

## Test plan

- [x] `nix flake check` passes (formatting, statix, deadnix, shellcheck, all regression tests)
- [x] All CI checks pass (Nix Validate, CodeQL, OSV Scan, File Size, Merge Gate)
- [ ] `darwin-rebuild switch` with `--override-input nix-ai` to verify runtime settings
- [ ] Verify `python3 -c` not in deny list
- [ ] Verify `rm -rf` still in deny list
- [ ] Test MS docx skill works in a live Claude Code session

Generated with [Claude Code](https://claude.com/claude-code)