### PR TITLE
fix(claude): run conflicting-dir cleanup before checkLinkTargets

### DIFF
--- a/modules/claude/orphan-cleanup.nix
+++ b/modules/claude/orphan-cleanup.nix
@@ -2,10 +2,12 @@
 #
 # Three-phase cleanup for Nix-managed directories, plus optional runtime data pruning:
 #
-# Phase 1 (BEFORE linkGeneration):
+# Phase 1 (BEFORE checkLinkTargets):
 # - Removes directory symlinks and real directories that conflict with
 #   directory symlinks in the new generation.
 # - Also removes stale root-level symlinks whose nix store targets no longer exist.
+# - Must run before checkLinkTargets because cmp(1) fails on directories, causing
+#   checkLinkTargets to abort before any backup/link logic can run.
 #
 # Phase 2 (AFTER linkGeneration):
 # - Removes broken symlinks (targets that no longer exist) inside component dirs.
@@ -47,10 +49,12 @@ in
 {
   config = lib.mkIf cfg.enable {
     home.activation = {
-      # Phase 1: Remove conflicting entries BEFORE linkGeneration.
+      # Phase 1: Remove conflicting entries BEFORE checkLinkTargets.
       # Handles directory symlinks AND real directories (migration from recursive=true)
-      # so home-manager can create fresh directory symlinks.
-      cleanupConflictingDirectorySymlinks = lib.hm.dag.entryBefore [ "linkGeneration" ] ''
+      # so home-manager can create fresh directory symlinks without collision errors.
+      # Must run before checkLinkTargets (not just linkGeneration) because cmp(1) fails
+      # on directories, causing checkLinkTargets to abort before link generation begins.
+      cleanupConflictingDirectorySymlinks = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
         . ${./scripts/cleanup-common.sh}
         . ${./scripts/cleanup-conflicting-symlinks.sh} \
           ${lib.escapeShellArgs (componentDirs ++ marketplaceDirs)}


### PR DESCRIPTION
## Summary

- Fixes Phase 1 of `orphan-cleanup.nix` to run `entryBefore ["checkLinkTargets"]` instead of `entryBefore ["linkGeneration"]`
- Previously, `checkLinkTargets` ran before the Phase 1 cleanup, causing it to find a real directory at a marketplace symlink path and abort with "would be clobbered"
- `cmp(1)` cannot compare directories, so the `backupFileExtension` fallback logic never fires — only moving the DAG order earlier fixes this reliably

## Changes

- `modules/home-manager/orphan-cleanup.nix`: Updated `entryBefore` from `["linkGeneration"]` to `["checkLinkTargets"]` to resolve conflicts before home-manager's conflict detection runs

## Test plan

- [ ] Verify `darwin-rebuild switch` succeeds when a real directory exists at a marketplace path (e.g., `mkdir ~/.claude/plugins/marketplaces/claude-plugins-official`)
- [ ] Confirm the directory is removed and replaced with a proper Nix store symlink
- [ ] Confirm Phase 2/3 cleanup still runs correctly after `linkGeneration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
