### PR TITLE
docs(claude): add plugin ecosystem READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Design decisions: [`docs/adr/`](docs/adr/README.md)
 ## Key Files
 
 - `modules/default.nix` — Module entry point (imports all AI modules)
-- `modules/claude/` — Claude Code settings, plugins, statusline, auto-claude
+- `modules/claude/` — Claude Code module (plugins, hooks, agents, commands, rules); see [`modules/claude/README.md`](modules/claude/README.md)
 - `modules/mcp/` — MCP server definitions
 - `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools, perf tuning)
 - `modules/common/` — Shared permission engine and formatters

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ One command rebuilds everything, identically, every time.
 
 | Tool | What you get |
 | ---- | ------------ |
-| **Claude Code** | Plugins, marketplace, statusline, settings, autonomous agents, hooks |
+| **Claude Code** | [Plugin ecosystem](modules/claude/README.md), hooks, agents, commands, rules, statusline |
 | **Gemini CLI** | Settings, custom commands, permission rules |
 | **GitHub Copilot** | Configuration, permissions |
 | **OpenAI Codex** | Settings |
 | **MCP Servers** | 15+ servers — GitHub, Terraform, Context7, PAL, filesystem, memory, and more |
-| **Plugin Marketplace** | 14 curated plugin repositories |
+| **Plugin Marketplace** | [Curated marketplaces](modules/claude/plugins/README.md) with Nix-pinned flake inputs |
 | **AI Dev Tools** | cclint, doppler-mcp, claude-flow, sync-mlx-models |
 | **MLX** | Local Apple Silicon inference via vllm-mlx with macOS launchd integration |
 
@@ -114,7 +114,7 @@ nix fmt
 
 ```text
 modules/
-├── claude/          # Claude Code (settings, plugins, statusline, auto-claude)
+├── claude/          # Claude Code module — see [modules/claude/README.md](modules/claude/README.md)
 ├── maestro/         # Maestro agent orchestration
 ├── mcp/             # 15+ MCP server definitions
 ├── common/          # Shared permission engine

--- a/flake.lock
+++ b/flake.lock
@@ -265,11 +265,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1776061000,
-        "narHash": "sha256-U1xvduQgVnMiKvNPBQDqlAeOWrzKDV36yMtT4YhKtRc=",
+        "lastModified": 1776458585,
+        "narHash": "sha256-xV8rZITP9zgm5HsgB9Njs84llnJ+7BdY4CzSOChPh+E=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "7f70be52468b5daf594482bcce26f2738c744231",
+        "rev": "2d72bf42bcef213a1504d19d95eb488f31e50f3f",
         "type": "github"
       },
       "original": {

--- a/modules/claude/.readme-validator.yaml
+++ b/modules/claude/.readme-validator.yaml
@@ -1,0 +1,9 @@
+# Claude module README — subdirectory documentation, not a top-level project README.
+required_sections:
+  - Component Map
+optional_sections:
+  - Hooks
+  - Agents
+  - Commands
+  - Rules
+  - Plugins

--- a/modules/claude/README.md
+++ b/modules/claude/README.md
@@ -108,4 +108,4 @@ and enabled plugins organized by category.
 - [MCP Servers](../mcp/README.md) — 15+ MCP server definitions
 - [Fabric Module](../fabric/README.md) — Fabric CLI and pattern integration
 - [Auto-Claude Testing](TESTING.md) — Autonomous agent testing procedures
-- [Plugin Cache Architecture](rules/plugin-cache-architecture.md) — Marketplace symlink and cache rules
+- [Plugin Cache Architecture](../../.claude/rules/plugin-cache-architecture.md) — Marketplace symlink and cache rules

--- a/modules/claude/README.md
+++ b/modules/claude/README.md
@@ -1,0 +1,111 @@
+# Claude Code Module
+
+Home-manager module for Claude Code configuration. Manages plugins, hooks, agents, commands,
+rules, settings, and statusline via `programs.claude.*` options.
+
+Configured in [`modules/claude-config.nix`](../claude-config.nix). Deployed to `~/.claude/` by home-manager.
+
+## Component Map
+
+| Component | Location | Description |
+| --------- | -------- | ----------- |
+| Plugins | [`plugins/`](plugins/) | Marketplaces and enabled plugins — [full catalog](plugins/README.md) |
+| Hooks | [`hooks/`](hooks/) | Event-driven shell scripts triggered by Claude Code |
+| Agents | flake input: `claude-cookbooks` | Subagent persona definitions deployed to `~/.claude/agents/` |
+| Commands | flake input: `claude-cookbooks` | Slash commands deployed to `~/.claude/commands/` |
+| Rules | flake input: `ai-assistant-instructions` + [`rules/`](rules/) | Global instructions loaded every session |
+| Settings | [`settings.nix`](settings.nix), [`options.nix`](options.nix) | Generates `~/.claude/settings.json` |
+| Statusline | [`statusline/`](statusline/) | Powerline integration for terminal status display |
+
+## Hooks
+
+Defined in [`claude-config.nix`](../claude-config.nix), scripts in [`hooks/`](hooks/).
+
+| Event | Script | Trigger | What It Does |
+| ----- | ------ | ------- | ------------ |
+| `preToolUse` | [`ask-user-notify.sh`](hooks/ask-user-notify.sh) | `AskUserQuestion` tool call | Sends Slack notification for async/mobile workflow |
+| `postToolUse` | [`last-output.sh`](hooks/last-output.sh) | Every tool execution | Writes compact summary to `~/.cache/claude-last-output.txt` |
+
+The Slack hook requires `SLACK_CHANNEL` env var or a matching keychain entry
+(`SLACK_CHANNEL_<REPO>`). Exits silently if not configured.
+
+Available hook events: `preToolUse`, `postToolUse`, `userPromptSubmit`, `stop`,
+`subagentStop`, `sessionStart`, `sessionEnd`.
+
+## Agents
+
+Deployed to `~/.claude/agents/` from flake inputs via [`components.nix`](components.nix).
+
+| Agent | Source | Description |
+| ----- | ------ | ----------- |
+| `code-reviewer` | `claude-cookbooks` | Code review for Cookbook repo notebooks |
+
+Plugin-provided agents (from marketplace plugins) are separate — see the
+[plugin catalog](plugins/README.md) for plugins that include agents.
+
+## Commands
+
+Deployed to `~/.claude/commands/` from flake inputs via [`components.nix`](components.nix).
+
+| Command | Source | Description |
+| ------- | ------ | ----------- |
+| `/add-registry` | `claude-cookbooks` | Add a notebook to registry.yaml |
+| `/link-review` | `claude-cookbooks` | Review links in changed files |
+| `/model-check` | `claude-cookbooks` | Validate Claude model usage against current public models |
+| `/notebook-review` | `claude-cookbooks` | Comprehensive Jupyter notebook review |
+| `/review-issue` | `claude-cookbooks` | Review and respond to a GitHub issue |
+| `/review-pr` | `claude-cookbooks` | Review an open pull request |
+| `/review-pr-ci` | `claude-cookbooks` | Review a pull request (CI/automated use) |
+
+Plugin-provided commands (from marketplace plugins) are separate — see the
+[plugin catalog](plugins/README.md) for plugins that include slash commands.
+
+## Rules
+
+Global rules load every session. Deployed to `~/.claude/rules/` via [`components.nix`](components.nix).
+
+### From `ai-assistant-instructions/agentsmd/rules/`
+
+| Rule | Scope |
+| ---- | ----- |
+| `ci-cd-policy` | CI/CD automation guidance |
+| `config-secrets` | Secret scrubbing details for config files |
+| `nix-package-placement` | Nix package placement decision matrix (path-scoped: `*.nix`) |
+| `nix-tool-policy` | Nix dev shell tool usage rules (path-scoped: `*.nix`) |
+| `secrets-policy` | Never commit secrets (universal) |
+| `skill-execution-integrity` | Every skill invocation is fresh, not a continuation |
+| `soul` | AI personality and voice guidelines |
+| `tool-use` | Native tools over Bash, subagent dispatching, script policy |
+| `infra/pre-integration-checklist` | Infrastructure pre-integration validation |
+
+### Local rules — [`rules/`](rules/)
+
+| Rule | When Applied |
+| ---- | ------------ |
+| `pal-mcp-policy` | Always; PAL MCP availability protocol, clink/consensus escalation |
+| `retrospective-report-location` | Routes retrospective reports to `~/.claude/skills/retrospecting/reports/` |
+
+## Plugins
+
+See the [Plugin Catalog](plugins/README.md) for the full list of marketplaces
+and enabled plugins organized by category.
+
+## Key Nix Files
+
+| File | Role |
+| ---- | ---- |
+| [`claude-config.nix`](../claude-config.nix) | Top-level values: model, effort, hooks, agents, commands, rules |
+| [`plugins/default.nix`](plugins/default.nix) | Merges all plugin category files |
+| [`plugins/marketplaces.nix`](plugins/marketplaces.nix) | Marketplace definitions |
+| [`settings.nix`](settings.nix) | Generates `settings.json`, wires hooks to `~/.claude/hooks/` |
+| [`components.nix`](components.nix) | Deploys agents, commands, skills, rules as symlinks |
+| [`options.nix`](options.nix) | All `programs.claude.*` option declarations |
+| [`marketplace-overrides.nix`](marketplace-overrides.nix) | Synthetic marketplace derivations |
+| [`orphan-cleanup.nix`](orphan-cleanup.nix) | Runtime cache cleanup on `darwin-rebuild switch` |
+
+## Related Docs
+
+- [MCP Servers](../mcp/README.md) — 15+ MCP server definitions
+- [Fabric Module](../fabric/README.md) — Fabric CLI and pattern integration
+- [Auto-Claude Testing](TESTING.md) — Autonomous agent testing procedures
+- [Plugin Cache Architecture](rules/plugin-cache-architecture.md) — Marketplace symlink and cache rules

--- a/modules/claude/plugins/.readme-validator.yaml
+++ b/modules/claude/plugins/.readme-validator.yaml
@@ -1,0 +1,6 @@
+# Plugin catalog README — subdirectory documentation, not a top-level project README.
+required_sections:
+  - Marketplaces
+optional_sections:
+  - Synthetic Marketplaces
+  - Adding a Plugin

--- a/modules/claude/plugins/README.md
+++ b/modules/claude/plugins/README.md
@@ -6,8 +6,9 @@ Parent doc: [`modules/claude/README.md`](../README.md)
 
 ## How Plugins Work
 
-Plugins are referenced as `"plugin-name@marketplace-name"` pairs. Each marketplace is a GitHub repo
-containing a `.claude-plugin/marketplace.json` manifest. Nix pins every marketplace as a flake input
+Plugins are referenced as `"plugin-name@marketplace-name"` pairs. Most marketplaces are GitHub repos
+containing a `.claude-plugin/marketplace.json` manifest; synthetic marketplaces (see below) are adapted
+via Nix derivations without requiring the native structure. Nix pins every marketplace as a flake input
 for reproducible deployments. Setting a plugin to `true` enables it; `false` keeps it visible but disabled.
 
 ## Marketplaces
@@ -37,6 +38,11 @@ Registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix).
 | `fabric-patterns` | `danielmiessler/fabric` | Synthetic |
 
 ## Enabled Plugins by Category
+
+> **Note on status values**: Each table reflects the value set in the named `.nix` file, not the
+> final merged result. When a plugin appears in multiple sections, the last-merged file wins
+> (see `plugins/default.nix`). For example, `ralph-loop` is `false` in `official.nix` but
+> `true` in `experimental.nix` — the effective result is **enabled**.
 
 ### Official Anthropic — [`official.nix`](official.nix)
 
@@ -99,12 +105,12 @@ Registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix).
 | `proxmox-infrastructure@lunar-claude` | enabled | Proxmox VM/LXC management |
 | `ansible-workflows@lunar-claude` | enabled | Ansible playbook workflows |
 | `infrastructure-as-code-generator@claude-code-plugins-plus` | enabled | IaC generation |
-| `terraform-module-builder@claude-code-plugins-plus` | enabled | Terraform module authoring |
+| `terraform-module-builder@claude-code-plugins-plus` | enabled | OpenTofu module authoring |
 | `cicd-automation@claude-code-workflows` | enabled | GitHub Actions CI/CD |
 
 ### Development — [`development.nix`](development.nix)
 
-**Auto-discovered personal plugins (18):** All plugin directories in `JacobPEvans/claude-code-plugins`
+**Auto-discovered personal plugins:** All plugin directories in `JacobPEvans/claude-code-plugins`
 are discovered at flake update time and enabled automatically as `*@jacobpevans-cc-plugins`:
 
 `ai-delegation`, `code-standards`, `codeql-resolver`, `config-management`, `content-guards`,
@@ -162,7 +168,7 @@ are discovered at flake update time and enabled automatically as `*@jacobpevans-
 
 | Plugin | Status | Description |
 | ------ | ------ | ----------- |
-| `fabric-patterns@fabric-patterns` | enabled | 32 curated patterns from danielmiessler/fabric |
+| `fabric-patterns@fabric-patterns` | enabled | Curated patterns from danielmiessler/fabric |
 
 Curated pattern list is in [`fabric-curated-patterns.json`](../fabric-curated-patterns.json).
 See [`modules/fabric/README.md`](../../fabric/README.md) for full Fabric documentation.

--- a/modules/claude/plugins/README.md
+++ b/modules/claude/plugins/README.md
@@ -1,0 +1,187 @@
+# Claude Code Plugin Catalog
+
+Complete reference for all plugin marketplaces and enabled plugins managed by this module.
+
+Parent doc: [`modules/claude/README.md`](../README.md)
+
+## How Plugins Work
+
+Plugins are referenced as `"plugin-name@marketplace-name"` pairs. Each marketplace is a GitHub repo
+containing a `.claude-plugin/marketplace.json` manifest. Nix pins every marketplace as a flake input
+for reproducible deployments. Setting a plugin to `true` enables it; `false` keeps it visible but disabled.
+
+## Marketplaces
+
+Registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix).
+
+| Key | GitHub | Category |
+| --- | ------ | -------- |
+| `jacobpevans-cc-plugins` | `JacobPEvans/claude-code-plugins` | Personal |
+| `claude-plugins-official` | `anthropics/claude-plugins-official` | Official Anthropic |
+| `anthropic-agent-skills` | `anthropics/skills` | Official Anthropic |
+| `cc-marketplace` | `ananddtyagi/cc-marketplace` | Community |
+| `bills-claude-skills` | `BillChirico/bills-claude-skills` | Community |
+| `superpowers-marketplace` | `obra/superpowers-marketplace` | Community |
+| `obsidian-skills` | `kepano/obsidian-skills` | Community |
+| `axton-obsidian-visual-skills` | `axtonliu/axton-obsidian-visual-skills` | Community |
+| `visual-explainer-marketplace` | `nicobailon/visual-explainer` | Community |
+| `bitwarden-marketplace` | `bitwarden/ai-plugins` | Community |
+| `lunar-claude` | `basher83/lunar-claude` | Infrastructure |
+| `claude-code-plugins-plus` | `jeremylongshore/claude-code-plugins-plus` | Infrastructure |
+| `claude-code-workflows` | `wshobson/agents` | Infrastructure / Dev |
+| `claude-skills` | `secondsky/claude-skills` | Dev Tools |
+| `cc-dev-tools` | `Lucklyric/cc-dev-tools` | AI Integrations |
+| `wakatime` | `wakatime/claude-code-wakatime` | Time Tracking |
+| `openai-codex` | `openai/codex-plugin-cc` | AI Integrations |
+| `browser-use-skills` | `browser-use/browser-use` | Synthetic |
+| `fabric-patterns` | `danielmiessler/fabric` | Synthetic |
+
+## Enabled Plugins by Category
+
+### Official Anthropic — [`official.nix`](official.nix)
+
+| Plugin | Status | Description |
+| ------ | ------ | ----------- |
+| `document-skills@anthropic-agent-skills` | enabled | xlsx, docx, pptx, pdf document creation |
+| `commit-commands@claude-plugins-official` | enabled | Git commit workflows |
+| `code-review@claude-plugins-official` | enabled | Code review |
+| `pr-review-toolkit@claude-plugins-official` | enabled | PR review suite |
+| `feature-dev@claude-plugins-official` | enabled | Feature development guidance |
+| `security-guidance@claude-plugins-official` | enabled | Security guidance for infra work |
+| `plugin-dev@claude-plugins-official` | enabled | Plugin development tools |
+| `hookify@claude-plugins-official` | enabled | Hook creation from conversation analysis |
+| `claude-code-setup@claude-plugins-official` | enabled | Claude Code setup and configuration |
+| `claude-md-management@claude-plugins-official` | enabled | CLAUDE.md management |
+| `pyright-lsp@claude-plugins-official` | enabled | Python type checking LSP |
+| `typescript-lsp@claude-plugins-official` | disabled | Minimal TS usage |
+| `ralph-loop@claude-plugins-official` | disabled | Superseded by native agent teams |
+
+### External Third-Party — [`external.nix`](external.nix)
+
+| Plugin | Status | Auth Required | Description |
+| ------ | ------ | ------------- | ----------- |
+| `github@claude-plugins-official` | enabled | `GITHUB_PERSONAL_ACCESS_TOKEN` | Repository, issues, PRs |
+| `context7@claude-plugins-official` | enabled | Optional API key | Library documentation lookup |
+| `playwright@claude-plugins-official` | enabled | Playwright installed | Browser automation and testing |
+| `slack@claude-plugins-official` | enabled | Slack OAuth | Team communication |
+| `asana@claude-plugins-official` | disabled | Asana API token | Task management |
+| `linear@claude-plugins-official` | disabled | Linear API key | Issue tracking |
+| `gitlab@claude-plugins-official` | disabled | GitLab API token | GitLab integration |
+| `greptile@claude-plugins-official` | disabled | — | Removed: not worth cost |
+| `firebase@claude-plugins-official` | disabled | Firebase credentials | Firebase platform |
+| `supabase@claude-plugins-official` | disabled | Supabase API key | Supabase platform |
+| `stripe@claude-plugins-official` | disabled | Stripe API key | Payment processing |
+| `laravel-boost@claude-plugins-official` | disabled | Laravel project | Laravel framework |
+| `serena@claude-plugins-official` | disabled | Serena API key | AI memory management |
+
+### Community — [`community.nix`](community.nix)
+
+| Plugin | Status | Description |
+| ------ | ------ | ----------- |
+| `analyze-issue@cc-marketplace` | enabled | GitHub issue analysis |
+| `create-worktrees@cc-marketplace` | enabled | Git worktree creation |
+| `python-expert@cc-marketplace` | enabled | Python expertise |
+| `devops-automator@cc-marketplace` | enabled | CI/CD, cloud infra, deployment |
+| `superpowers@superpowers-marketplace` | enabled | Comprehensive Claude enhancement suite |
+| `superpowers-lab@superpowers-marketplace` | enabled | Experimental superpowers |
+| `superpowers-developing-for-claude-code@superpowers-marketplace` | enabled | Plugin development superpowers |
+| `obsidian@obsidian-skills` | enabled | 5 skills: markdown, bases, canvas, CLI, utilities |
+| `obsidian-visual-skills@axton-obsidian-visual-skills` | enabled | 3 skills: Excalidraw, Mermaid, Canvas Creator |
+| `visual-explainer@visual-explainer-marketplace` | enabled | 1 skill + 8 commands: HTML diagrams, diff reviews, slides |
+| `claude-retrospective@bitwarden-marketplace` | enabled | 3 skills: retrospecting, session data, git analysis |
+| `claude-config-validator@bitwarden-marketplace` | enabled | 1 skill: reviewing-claude-config |
+| `browser-use@browser-use-skills` | enabled | Browser automation (requires `browser-use` via uv) |
+
+### Infrastructure — [`infrastructure.nix`](infrastructure.nix)
+
+| Plugin | Status | Description |
+| ------ | ------ | ----------- |
+| `proxmox-infrastructure@lunar-claude` | enabled | Proxmox VM/LXC management |
+| `ansible-workflows@lunar-claude` | enabled | Ansible playbook workflows |
+| `infrastructure-as-code-generator@claude-code-plugins-plus` | enabled | IaC generation |
+| `terraform-module-builder@claude-code-plugins-plus` | enabled | Terraform module authoring |
+| `cicd-automation@claude-code-workflows` | enabled | GitHub Actions CI/CD |
+
+### Development — [`development.nix`](development.nix)
+
+**Auto-discovered personal plugins (18):** All plugin directories in `JacobPEvans/claude-code-plugins`
+are discovered at flake update time and enabled automatically as `*@jacobpevans-cc-plugins`:
+
+`ai-delegation`, `code-standards`, `codeql-resolver`, `config-management`, `content-guards`,
+`git-guards`, `git-standards`, `git-workflows`, `github-workflows`, `infra-orchestration`,
+`infra-standards`, `pal-health`, `pr-lifecycle`, `process-cleanup`, `project-standards`,
+`script-guards`, `session-analytics`, `skill-guards`
+
+**Explicit plugins:**
+
+| Plugin | Status | Description |
+| ------ | ------ | ----------- |
+| `backend-development@claude-code-workflows` | enabled | Python/Shell backend; multiple skills |
+| `unit-testing@claude-code-workflows` | enabled | Unit test workflows |
+| `tdd-workflows@claude-code-workflows` | enabled | TDD red/green/refactor cycle |
+| `code-refactoring@claude-code-workflows` | enabled | Refactoring assistance |
+| `codebase-cleanup@claude-code-workflows` | enabled | Dead code, cleanup |
+| `agent-orchestration@claude-code-workflows` | enabled | Multi-agent coordination |
+| `observability-monitoring@claude-code-workflows` | enabled | Distributed tracing, SLO |
+| `python-development@claude-code-workflows` | enabled | Django/FastAPI with 5 specialized skills |
+| `full-stack-orchestration@claude-code-workflows` | enabled | 7+ agent multi-agent workflows |
+| `developer-essentials@claude-code-workflows` | enabled | Common dev tools and utilities |
+| `performance-testing-review@claude-code-workflows` | enabled | Performance analysis, test coverage |
+| `api-design-principles@claude-skills` | enabled | REST/GraphQL API design |
+| `rest-api-design@claude-skills` | enabled | REST design patterns |
+| `graphql-implementation@claude-skills` | enabled | GraphQL implementation |
+| `websocket-implementation@claude-skills` | enabled | WebSocket patterns |
+| `playwright@claude-skills` | enabled | Browser testing skills |
+| `vitest-testing@claude-skills` | enabled | Vitest unit testing |
+| `jest-generator@claude-skills` | enabled | Jest test generation |
+| `vulnerability-scanning@claude-skills` | enabled | Security scanning |
+| `csrf-protection@claude-skills` | enabled | CSRF protection patterns |
+| `xss-prevention@claude-skills` | enabled | XSS prevention patterns |
+| `recommendation-engine@claude-skills` | enabled | Recommendation systems |
+| `sql-query-optimization@claude-skills` | enabled | SQL optimization |
+| `better-auth@claude-skills` | enabled | Auth implementation |
+| `oauth-implementation@claude-skills` | enabled | OAuth flows |
+
+### Monitoring — [`monitoring.nix`](monitoring.nix)
+
+| Plugin | Status | Description |
+| ------ | ------ | ----------- |
+| `claude-code-wakatime@wakatime` | enabled | Time tracking via WakaTime |
+
+### Experimental — [`experimental.nix`](experimental.nix)
+
+| Plugin | Status | Description |
+| ------ | ------ | ----------- |
+| `ralph-loop@claude-plugins-official` | enabled | Autonomous iteration loops (`/ralph-loop`, `/cancel-ralph`) |
+| `codex@cc-dev-tools` | enabled | OpenAI GPT for high-reasoning coding (community) |
+| `codex@openai-codex` | enabled | Official OpenAI Codex (`/codex:review`, `/codex:rescue`) |
+| `gemini@cc-dev-tools` | enabled | Google Gemini with web search + session resumption |
+| `telegram-notifier@cc-dev-tools` | disabled | Requires `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` |
+
+### Fabric Patterns — [`fabric.nix`](fabric.nix)
+
+| Plugin | Status | Description |
+| ------ | ------ | ----------- |
+| `fabric-patterns@fabric-patterns` | enabled | 32 curated patterns from danielmiessler/fabric |
+
+Curated pattern list is in [`fabric-curated-patterns.json`](../fabric-curated-patterns.json).
+See [`modules/fabric/README.md`](../../fabric/README.md) for full Fabric documentation.
+
+## Synthetic Marketplaces
+
+Three marketplaces lack native `.claude-plugin/` structure in their upstream repos. Nix wraps
+them via derivations in [`marketplace-overrides.nix`](../marketplace-overrides.nix):
+
+| Marketplace | Upstream Repo | Wrapping Strategy |
+| ----------- | ------------- | ----------------- |
+| `browser-use-skills` | `browser-use/browser-use` | Wraps upstream skills directory |
+| `fabric-patterns` | `danielmiessler/fabric` | Wraps curated subset of 252+ patterns as individual skills |
+| `jacobpevans-cc-plugins` | `JacobPEvans/claude-code-plugins` | Auto-generates `marketplace.json` from discovered `plugin.json` files |
+
+## Adding a Plugin
+
+1. Check if the marketplace exists in [`marketplaces.nix`](marketplaces.nix). If not, add it
+   with the key matching the `name` field from the repo's `.claude-plugin/marketplace.json`.
+2. Add `"plugin-name@marketplace-key" = true;` to the appropriate category `.nix` file.
+3. Run `nix flake check` to validate.
+4. Deploy with `darwin-rebuild switch` and verify in a live Claude Code session.


### PR DESCRIPTION
## Summary

- Add `modules/claude/README.md` — component map, hooks, agents, commands, rules, key Nix files
- Add `modules/claude/plugins/README.md` — full plugin catalog organized by category (official, external, community, infrastructure, development, monitoring, experimental, fabric)
- Add `.readme-validator.yaml` configs for both subdirectories
- Update `CLAUDE.md` Key Files entry with cross-link
- Update `README.md` tool table with cross-links

## Notes

- Dropped hardcoded marketplace/plugin counts (maintenance burden — go stale immediately)
- Removed `<!-- cspell:disable -->` directives (cspell removed in #573)
- Fixed hallucinated "Opus 4.7 agent teams" → "native agent teams"
- All 13 cross-referenced files verified to exist in the codebase

## Test plan

- [ ] CI passes
- [ ] Links in READMEs resolve correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)