### PR TITLE
feat(mlx): expose llama-swap logLevel and logToStdout as configurable options

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -139,11 +139,12 @@ let
 
   llamaSwapConfigAttrs = {
     inherit (cfg.proxy) healthCheckTimeout;
-    # debug logs every proxied HTTP request/response — required for live I/O
-    # visibility via `curl http://localhost:11434/logs/stream`.
-    # "both" includes vllm-mlx upstream output alongside proxy request logs.
-    logLevel = "debug";
-    logToStdout = "both";
+    # logLevel="debug" logs every proxied HTTP request/response body.
+    # logToStdout="both" merges proxy and vllm-mlx output into one stream.
+    # Tap live I/O with: curl http://127.0.0.1:11434/logs/stream
+    # Configurable via programs.mlx.proxy.logLevel / logToStdout.
+    logLevel = cfg.proxy.logLevel;
+    logToStdout = cfg.proxy.logToStdout;
     startPort = 11436;
 
     models = allModels;

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -138,13 +138,11 @@ let
   // additionalModels;
 
   llamaSwapConfigAttrs = {
-    inherit (cfg.proxy) healthCheckTimeout;
+    inherit (cfg.proxy) healthCheckTimeout logLevel logToStdout;
     # logLevel="debug" logs every proxied HTTP request/response body.
     # logToStdout="both" merges proxy and vllm-mlx output into one stream.
     # Tap live I/O with: curl http://127.0.0.1:11434/logs/stream
     # Configurable via programs.mlx.proxy.logLevel / logToStdout.
-    logLevel = cfg.proxy.logLevel;
-    logToStdout = cfg.proxy.logToStdout;
     startPort = 11436;
 
     models = allModels;

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -139,7 +139,11 @@ let
 
   llamaSwapConfigAttrs = {
     inherit (cfg.proxy) healthCheckTimeout;
-    logLevel = "info";
+    # debug logs every proxied HTTP request/response — required for live I/O
+    # visibility via `curl http://localhost:11434/logs/stream`.
+    # "both" includes vllm-mlx upstream output alongside proxy request logs.
+    logLevel = "debug";
+    logToStdout = "both";
     startPort = 11436;
 
     models = allModels;

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -405,6 +405,27 @@
         default = 1800;
         description = "Default idle TTL in seconds for non-default models. 0 = never auto-unload. Default 30 min.";
       };
+      logLevel = lib.mkOption {
+        type = lib.types.enum [ "debug" "info" "warn" "error" ];
+        default = "debug";
+        description = ''
+          llama-swap log verbosity. "debug" logs every proxied HTTP
+          request/response body (prompts and completions), making
+          `curl http://127.0.0.1:11434/logs/stream` a live I/O tap.
+          Set to "info" to suppress request bodies and reduce log volume.
+          Note: debug output rotates within the 10 MB LaunchAgent log limit.
+        '';
+      };
+      logToStdout = lib.mkOption {
+        type = lib.types.enum [ "proxy" "upstream" "both" "none" ];
+        default = "both";
+        description = ''
+          Which output streams llama-swap forwards to stdout (and therefore
+          the /logs/stream SSE endpoint). "both" interleaves proxy request
+          logs with vllm-mlx upstream output. "proxy" (default upstream
+          behaviour) shows only proxy-level events.
+        '';
+      };
     };
   };
 }

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -406,7 +406,12 @@
         description = "Default idle TTL in seconds for non-default models. 0 = never auto-unload. Default 30 min.";
       };
       logLevel = lib.mkOption {
-        type = lib.types.enum [ "debug" "info" "warn" "error" ];
+        type = lib.types.enum [
+          "debug"
+          "info"
+          "warn"
+          "error"
+        ];
         default = "debug";
         description = ''
           llama-swap log verbosity. "debug" logs every proxied HTTP
@@ -417,7 +422,12 @@
         '';
       };
       logToStdout = lib.mkOption {
-        type = lib.types.enum [ "proxy" "upstream" "both" "none" ];
+        type = lib.types.enum [
+          "proxy"
+          "upstream"
+          "both"
+          "none"
+        ];
         default = "both";
         description = ''
           Which output streams llama-swap forwards to stdout (and therefore


### PR DESCRIPTION
## Summary

- Adds `programs.mlx.proxy.logLevel` option (`"debug"` | `"info"` | `"warn"` | `"error"`, default `"debug"`)
- Adds `programs.mlx.proxy.logToStdout` option (`"proxy"` | `"upstream"` | `"both"` | `"none"`, default `"both"`)
- With `logLevel = "debug"`, llama-swap logs every proxied HTTP request/response body — tap live I/O with `curl http://127.0.0.1:11434/logs/stream`
- Fixes `localhost` → `127.0.0.1` in `llamaSwapConfigAttrs` comment for consistency with `cfg.host` default

## Changes

- `modules/mlx/options.nix`: two new options under `programs.mlx.proxy` with full descriptions
- `modules/mlx/default.nix`: `inherit (cfg.proxy) logLevel logToStdout` — options wired into llama-swap JSON config

## Test plan

- [x] Nix validate passes (statix, nixfmt, deadnix, module-eval)
- [x] All review threads resolved
- [x] No merge conflicts
