### PR TITLE
feat(gemini): add worktree, sandbox path, and auto-edit defaults

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -170,6 +170,7 @@ in
         skills.fromFlakeInputs = sharedSkills;
         worktrees = true;
         sandboxAllowedPaths = [ "${config.home.homeDirectory}/git" ];
+        defaultApprovalMode = "auto_edit";
       };
 
       # MLX inference server (vllm-mlx on port 11434)

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -168,6 +168,8 @@ in
       gemini = {
         enable = true;
         skills.fromFlakeInputs = sharedSkills;
+        worktrees = true;
+        sandboxAllowedPaths = [ "${config.home.homeDirectory}/git" ];
       };
 
       # MLX inference server (vllm-mlx on port 11434)

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -118,7 +118,7 @@ in
     sandboxAllowedPaths = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      description = "Additional paths the sandbox is allowed to write to (merged with defaults). Required for git operations on bare repos when sandbox is enabled.";
+      description = "Paths the sandbox is allowed to write to. Required for git operations on bare repos when sandbox is enabled.";
     };
 
     # Worktrees feature

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -114,6 +114,20 @@ in
       description = "Additional trusted folders (merged with defaults)";
     };
 
+    # Sandbox allowed paths
+    sandboxAllowedPaths = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional paths the sandbox is allowed to write to (merged with defaults). Required for git operations on bare repos when sandbox is enabled.";
+    };
+
+    # Worktrees feature
+    worktrees = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable automated Git worktree management for parallel work (experimental).";
+    };
+
     # MCP servers to exclude from shared definitions
     excludedMcpServers = lib.mkOption {
       type = lib.types.listOf lib.types.str;

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -128,6 +128,21 @@ in
       description = "Enable automated Git worktree management for parallel work (experimental).";
     };
 
+    # Default approval mode
+    defaultApprovalMode = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum [
+        "default"
+        "auto_edit"
+        "plan"
+      ]);
+      default = null;
+      description = ''
+        Default approval mode for tool execution.
+        "auto_edit" auto-approves file edits without prompting.
+        Null omits the key from settings.json (Gemini uses its built-in default).
+      '';
+    };
+
     # MCP servers to exclude from shared definitions
     excludedMcpServers = lib.mkOption {
       type = lib.types.listOf lib.types.str;

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -130,11 +130,13 @@ in
 
     # Default approval mode
     defaultApprovalMode = lib.mkOption {
-      type = lib.types.nullOr (lib.types.enum [
-        "default"
-        "auto_edit"
-        "plan"
-      ]);
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "default"
+          "auto_edit"
+          "plan"
+        ]
+      );
       default = null;
       description = ''
         Default approval mode for tool execution.

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -83,6 +83,8 @@ let
     general = {
       previewFeatures = true;
       disableAutoUpdate = true;
+    } // lib.optionalAttrs (cfg.defaultApprovalMode != null) {
+      defaultApprovalMode = cfg.defaultApprovalMode;
     };
 
     context = {
@@ -99,13 +101,14 @@ let
       };
     };
 
-    # Sandbox + worktree support
     tools = {
       sandbox = true;
-      inherit (cfg) worktrees;
-    }
-    // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
-      inherit (cfg) sandboxAllowedPaths;
+    } // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
+      sandboxAllowedPaths = cfg.sandboxAllowedPaths;
+    };
+
+    experimental = lib.optionalAttrs cfg.worktrees {
+      worktrees = true;
     };
 
     inherit mcpServers;

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -99,9 +99,13 @@ let
       };
     };
 
-    # Sandbox only — no more tools.allowed or tools.exclude (deprecated)
+    # Sandbox + worktree support
     tools = {
       sandbox = true;
+      inherit (cfg) worktrees;
+    }
+    // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
+      inherit (cfg) sandboxAllowedPaths;
     };
 
     inherit mcpServers;

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -83,8 +83,9 @@ let
     general = {
       previewFeatures = true;
       disableAutoUpdate = true;
-    } // lib.optionalAttrs (cfg.defaultApprovalMode != null) {
-      defaultApprovalMode = cfg.defaultApprovalMode;
+    }
+    // lib.optionalAttrs (cfg.defaultApprovalMode != null) {
+      inherit (cfg) defaultApprovalMode;
     };
 
     context = {
@@ -103,8 +104,9 @@ let
 
     tools = {
       sandbox = true;
-    } // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
-      sandboxAllowedPaths = cfg.sandboxAllowedPaths;
+    }
+    // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
+      inherit (cfg) sandboxAllowedPaths;
     };
 
     experimental = lib.optionalAttrs cfg.worktrees {

--- a/modules/mcp/scripts/check-pal-mcp.sh
+++ b/modules/mcp/scripts/check-pal-mcp.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # check-pal-mcp — interactive PAL MCP health diagnostic.
 #
 # Run after darwin-rebuild switch or when PAL is absent from Claude Code sessions.

--- a/modules/mcp/scripts/doppler-mcp.sh
+++ b/modules/mcp/scripts/doppler-mcp.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # doppler-mcp — wraps any command with Doppler secret injection.
 #
 # Fetches secrets from ai-ci-automation/prd at subprocess launch time.

--- a/modules/mcp/scripts/pal-mcp.sh
+++ b/modules/mcp/scripts/pal-mcp.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # PAL MCP launcher — static config.
 #
 # Dynamic values exported by pal-models.nix wrapper (Nix-interpolated paths):

--- a/modules/mcp/scripts/splunk-mcp-connect.sh
+++ b/modules/mcp/scripts/splunk-mcp-connect.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # splunk-mcp-connect — connects to the Splunk MCP Server via mcp-remote stdio proxy.
 #
 # Reads credentials from env (injected by doppler-mcp wrapper at MCP launch time).

--- a/modules/mcp/scripts/sync-lmarena-ratings.sh
+++ b/modules/mcp/scripts/sync-lmarena-ratings.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # sync-lmarena-ratings.sh
 #
 # Fetches LMSYS Chatbot Arena leaderboard via HuggingFace datasets-server

--- a/modules/mcp/scripts/sync-pal-models.sh
+++ b/modules/mcp/scripts/sync-pal-models.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # sync-pal-models.sh
 #
 # Shared logic for PAL custom_models.json generation.


### PR DESCRIPTION
# Gemini Worktree, Sandbox, and Auto-Edit Configuration

## Summary

Adds three new Gemini CLI options to enable git worktree operations in sandboxed
environments:

- **`experimental.worktrees`** — Enables Gemini's automated git worktree management
- **`tools.sandboxAllowedPaths`** — List of paths the sandbox can write to
  (defaults to `~/git`); unblocks bare repo lock file writes
- **`general.defaultApprovalMode`** — Auto-approves file edits (`"auto_edit"`)
  without prompting; combined with policy engine rules allowing git/gh/nix
  commands, Gemini can operate hands-off

All three options are enabled/configured by default in personal settings.

## Root Cause

Gemini's sandbox confines writes to the active worktree path (e.g.,
`~/git/nix-darwin/main`). Git operations on a bare repo require writing lock
files to the bare repo root (`~/git/nix-darwin/`), which is the parent of the
worktree — outside the sandbox boundary. Without this fix, every branch create,
fetch, and commit fails with `Operation not permitted`.

## Changes

- `modules/gemini/options.nix` — Defines three new module options with type
  checking
- `modules/gemini/settings.nix` — Wires options into Gemini settings.json keys:
  - `worktrees` → `experimental.worktrees`
  - `sandboxAllowedPaths` → `tools.sandboxAllowedPaths`
  - `defaultApprovalMode` → `general.defaultApprovalMode`
- `modules/default.nix` — Personal defaults: `worktrees = true`,
  `sandboxAllowedPaths = ["~/git"]`, `defaultApprovalMode = "auto_edit"`
- MCP scripts — Added `# shellcheck shell=bash` directive to 6 scripts missing
  shell metadata (SC2148)
- Code style — Fixed formatting per alejandra conventions

## Test Plan

- [x] `nix flake check` passes (statix, deadnix, shellcheck, formatting)
- [ ] `darwin-rebuild switch --override-input nix-ai
  ~/git/nix-ai/feat/gemini-sandbox-worktrees`
- [ ] Fresh Gemini session in bare repo worktree; confirm `git branch`,
  `git worktree add`, and file edits succeed without approval prompts
