### PR TITLE
fix(mlx): bump defaultModel to Qwen3.6-35B-A3B-mxfp4

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -48,7 +48,7 @@ in
         {
           name = "mlx.defaultModel";
           actual = mlxCfg.defaultModel;
-          expected = "mlx-community/Qwen3.5-35B-A3B-4bit";
+          expected = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
         }
         {
           name = "mlx.port";

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -12,7 +12,7 @@
 
     defaultModel = lib.mkOption {
       type = lib.types.str;
-      default = "mlx-community/Qwen3.5-35B-A3B-4bit";
+      default = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
       description = ''
         Default mlx-community/ HuggingFace model to serve via vllm-mlx.
         Benchmark-driven rationale and historical default-swap context live


### PR DESCRIPTION
## Summary
- Updates `programs.mlx.defaultModel` default from `Qwen3.5-35B-A3B-4bit` to `Qwen3.6-35B-A3B-mxfp4`
- Updates corresponding hardcoded expected value in `lib/checks/mlx.nix` regression test

## Changes
- `modules/mlx/options.nix`: new default model string
- `lib/checks/mlx.nix`: regression test expected value updated to match

## Test Plan
- [x] `nix flake check` passes (Nix Validate CI check green)
- [x] CodeQL clean
- [ ] `darwin-rebuild switch` applies cleanly
- [ ] MLX inference loads the new default model