### PR TITLE
fix(claude): automate marketplace cache refresh after Nix rebuilds

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -245,9 +245,6 @@ in
       # Effort level via env var (alternative to settings.json key)
       # CLAUDE_CODE_EFFORT_LEVEL = "medium";
 
-      # Force plugin auto-update on startup (skips staleness check)
-      FORCE_AUTOUPDATE_PLUGINS = "1";
-
       # Auto-compact threshold — using upstream default (~95% of context window)
       # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "95";
 
@@ -323,6 +320,12 @@ in
     # Writes compact summary of last tool execution to ~/.cache/claude-last-output.txt
     # Can be read by statusline, tmux, or other display tools
     postToolUse = ./claude/hooks/last-output.sh;
+
+    # Refresh marketplace indexes after Nix rebuilds update marketplace symlinks.
+    # Reads the .nix-refresh-needed marker written by verify-cache-integrity.sh
+    # when store paths change. Best-effort: failures are logged but do not block
+    # session start. Runs within Claude Code's lifecycle (safe — before any tool use).
+    sessionStart = ./claude/hooks/marketplace-refresh.sh;
 
   };
 }

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -321,10 +321,7 @@ in
     # Can be read by statusline, tmux, or other display tools
     postToolUse = ./claude/hooks/last-output.sh;
 
-    # Refresh marketplace indexes after Nix rebuilds update marketplace symlinks.
-    # Reads the .nix-refresh-needed marker written by verify-cache-integrity.sh
-    # when store paths change. Best-effort: failures are logged but do not block
-    # session start. Runs within Claude Code's lifecycle (safe — before any tool use).
+    # Refresh stale marketplace indexes after Nix rebuilds; see hooks/marketplace-refresh.sh.
     sessionStart = ./claude/hooks/marketplace-refresh.sh;
 
   };

--- a/modules/claude/hooks/marketplace-refresh.sh
+++ b/modules/claude/hooks/marketplace-refresh.sh
@@ -1,58 +1,36 @@
 #!/usr/bin/env bash
-# Claude Code Hook: Refresh marketplace indexes after Nix rebuilds
-#
-# Reads the .nix-refresh-needed marker written by verify-cache-integrity.sh
-# when Nix marketplace store paths change (i.e., after darwin-rebuild switch
-# updates flake inputs). Refreshes each changed marketplace's index so that
-# claude plugin list shows current versions from the updated Nix store content.
-#
-# Hook Type: sessionStart
-# Triggers: At the start of every new Claude Code session
-#
-# Safety: Only runs when the marker file exists (a rebuild changed marketplace
-# store paths). Does not delete cache directories. Does not invoke claude from
-# home.activation. Best-effort: failures are logged but do not block session start.
+# Refresh marketplace indexes after Nix rebuilds change store paths.
+# Consumes the .nix-refresh-needed marker written by verify-cache-integrity.sh.
+# Best-effort: failures rewrite the marker for next-session retry.
 
 set -euo pipefail
 
 MARKER="${HOME}/.claude/plugins/cache/.nix-refresh-needed"
-
-# Nothing to do — no rebuild changed marketplace paths since last refresh
 [[ -f "$MARKER" ]] || exit 0
 
 log_info() { echo "[marketplace-refresh] $1" >&2; }
 
-# Collect failed marketplaces in a temp file to avoid shell string splitting issues.
-# Use while-read to stay compatible with macOS system bash (3.2).
 failures_tmp="$(mktemp "${MARKER}.failures.XXXXXX")"
 trap 'rm -f "$failures_tmp"' EXIT
+echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$failures_tmp"
 
-failed_count=0
 while IFS='=' read -r key value; do
   [[ "$key" == "marketplace" ]] || continue
   mp="$value"
   log_info "Refreshing marketplace index: $mp"
   # No timeout — claude plugin marketplace update has its own network timeout.
-  # macOS does not ship the GNU coreutils timeout command.
   if claude plugin marketplace update "$mp" >/dev/null 2>&1; then
-    log_info "Refreshed: $mp"
+    :
   else
-    log_info "Failed to refresh: $mp (will retry next session)"
+    log_info "Failed: $mp (will retry next session)"
     echo "marketplace=$mp" >> "$failures_tmp"
-    failed_count=$((failed_count + 1))
   fi
 done < "$MARKER"
 
-if [[ "$failed_count" -eq 0 ]]; then
+if grep -q "^marketplace=" "$failures_tmp"; then
+  mv "$failures_tmp" "$MARKER"
+  log_info "Partial refresh — some marketplace(s) queued for next session"
+else
   rm -f "$MARKER"
   log_info "All marketplace indexes refreshed"
-else
-  # Rewrite marker with only failed entries so the next session retries them
-  tmp="$(mktemp "${MARKER}.XXXXXX")"
-  echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$tmp"
-  cat "$failures_tmp" >> "$tmp"
-  mv "$tmp" "$MARKER"
-  log_info "Partial refresh — ${failed_count} marketplace(s) queued for next session"
 fi
-
-exit 0

--- a/modules/claude/hooks/marketplace-refresh.sh
+++ b/modules/claude/hooks/marketplace-refresh.sh
@@ -22,34 +22,37 @@ MARKER="${HOME}/.claude/plugins/cache/.nix-refresh-needed"
 
 log_info() { echo "[marketplace-refresh] $1" >&2; }
 
-# Read marketplaces from marker and refresh each one.
+# Collect failed marketplaces in a temp file to avoid shell string splitting issues.
 # Use while-read to stay compatible with macOS system bash (3.2).
-failed_list=""
+failures_tmp="$(mktemp "${MARKER}.failures.XXXXXX")"
+trap 'rm -f "$failures_tmp"' EXIT
+
+failed_count=0
 while IFS='=' read -r key value; do
   [[ "$key" == "marketplace" ]] || continue
   mp="$value"
   log_info "Refreshing marketplace index: $mp"
-  if timeout 15 claude plugin marketplace update "$mp" >/dev/null 2>&1; then
+  # No timeout — claude plugin marketplace update has its own network timeout.
+  # macOS does not ship the GNU coreutils timeout command.
+  if claude plugin marketplace update "$mp" >/dev/null 2>&1; then
     log_info "Refreshed: $mp"
   else
     log_info "Failed to refresh: $mp (will retry next session)"
-    failed_list="${failed_list}${mp}:"
+    echo "marketplace=$mp" >> "$failures_tmp"
+    failed_count=$((failed_count + 1))
   fi
 done < "$MARKER"
 
-if [[ -z "$failed_list" ]]; then
+if [[ "$failed_count" -eq 0 ]]; then
   rm -f "$MARKER"
   log_info "All marketplace indexes refreshed"
 else
   # Rewrite marker with only failed entries so the next session retries them
   tmp="$(mktemp "${MARKER}.XXXXXX")"
   echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$tmp"
-  IFS=':' read -r -a failed_arr <<< "$failed_list"
-  for mp in "${failed_arr[@]}"; do
-    [[ -n "$mp" ]] && echo "marketplace=$mp" >> "$tmp"
-  done
+  cat "$failures_tmp" >> "$tmp"
   mv "$tmp" "$MARKER"
-  log_info "Partial refresh — ${#failed_arr[@]} marketplace(s) queued for next session"
+  log_info "Partial refresh — ${failed_count} marketplace(s) queued for next session"
 fi
 
 exit 0

--- a/modules/claude/hooks/marketplace-refresh.sh
+++ b/modules/claude/hooks/marketplace-refresh.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Claude Code Hook: Refresh marketplace indexes after Nix rebuilds
+#
+# Reads the .nix-refresh-needed marker written by verify-cache-integrity.sh
+# when Nix marketplace store paths change (i.e., after darwin-rebuild switch
+# updates flake inputs). Refreshes each changed marketplace's index so that
+# claude plugin list shows current versions from the updated Nix store content.
+#
+# Hook Type: sessionStart
+# Triggers: At the start of every new Claude Code session
+#
+# Safety: Only runs when the marker file exists (a rebuild changed marketplace
+# store paths). Does not delete cache directories. Does not invoke claude from
+# home.activation. Best-effort: failures are logged but do not block session start.
+
+set -euo pipefail
+
+MARKER="${HOME}/.claude/plugins/cache/.nix-refresh-needed"
+
+# Nothing to do — no rebuild changed marketplace paths since last refresh
+[[ -f "$MARKER" ]] || exit 0
+
+log_info() { echo "[marketplace-refresh] $1" >&2; }
+
+# Read marketplaces from marker and refresh each one.
+# Use while-read to stay compatible with macOS system bash (3.2).
+failed_list=""
+while IFS='=' read -r key value; do
+  [[ "$key" == "marketplace" ]] || continue
+  mp="$value"
+  log_info "Refreshing marketplace index: $mp"
+  if timeout 15 claude plugin marketplace update "$mp" >/dev/null 2>&1; then
+    log_info "Refreshed: $mp"
+  else
+    log_info "Failed to refresh: $mp (will retry next session)"
+    failed_list="${failed_list}${mp}:"
+  fi
+done < "$MARKER"
+
+if [[ -z "$failed_list" ]]; then
+  rm -f "$MARKER"
+  log_info "All marketplace indexes refreshed"
+else
+  # Rewrite marker with only failed entries so the next session retries them
+  tmp="$(mktemp "${MARKER}.XXXXXX")"
+  echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$tmp"
+  IFS=':' read -r -a failed_arr <<< "$failed_list"
+  for mp in "${failed_arr[@]}"; do
+    [[ -n "$mp" ]] && echo "marketplace=$mp" >> "$tmp"
+  done
+  mv "$tmp" "$MARKER"
+  log_info "Partial refresh — ${#failed_arr[@]} marketplace(s) queued for next session"
+fi
+
+exit 0

--- a/modules/claude/scripts/verify-cache-integrity.sh
+++ b/modules/claude/scripts/verify-cache-integrity.sh
@@ -66,11 +66,28 @@ while IFS= read -r -d '' entry; do
   fi
 done < <(find "$MARKETPLACES_DIR" -mindepth 1 -maxdepth 1 -type l -print0)
 
+# When staleness is detected, write a refresh marker so the sessionStart hook can
+# update marketplace indexes on the next session. Writing a marker file is always
+# safe — it does NOT invoke claude or mutate plugin cache directories.
+if [[ "$stale_detected" == true ]]; then
+  REFRESH_MARKER="$CACHE_DIR/.nix-refresh-needed"
+  tmp_marker="$(mktemp "${REFRESH_MARKER}.XXXXXX")"
+  echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$tmp_marker"
+  for name in "${!new_hashes[@]}"; do
+    if [[ "${old_hashes[$name]:-}" != "${new_hashes[$name]}" ]]; then
+      echo "marketplace=$name" >> "$tmp_marker"
+    fi
+  done
+  mv "$tmp_marker" "$REFRESH_MARKER"
+  log_info "Wrote marketplace refresh marker: $REFRESH_MARKER"
+fi
+
 # Session-aware guard: if caches are stale but Claude Code is running, defer the
 # purge to avoid breaking active sessions. Hook scripts inside cache directories are
 # resolved at session start — deleting them mid-session causes an unbreakable error
 # loop (every hook fails, including Stop). By also skipping the hash file update,
 # the next rebuild will re-detect staleness and purge when no sessions are active.
+# The refresh marker above will be consumed by the sessionStart hook instead.
 if [[ "$stale_detected" == true ]] && pgrep -qx "claude"; then
   log_info "Stale caches detected but Claude Code session is active — deferring purge"
   exit 0

--- a/modules/claude/scripts/verify-cache-integrity.sh
+++ b/modules/claude/scripts/verify-cache-integrity.sh
@@ -49,6 +49,7 @@ fi
 # Build new hashes and detect staleness
 # Marketplaces are directory symlinks to /nix/store/ (plugins.nix without recursive)
 declare -A new_hashes
+declare -a stale_names
 stale_detected=false
 while IFS= read -r -d '' entry; do
   name=$(basename "$entry")
@@ -63,20 +64,18 @@ while IFS= read -r -d '' entry; do
 
   if [[ "${old_hashes[$name]:-}" != "$hash" ]]; then
     stale_detected=true
+    stale_names+=("$name")
   fi
 done < <(find "$MARKETPLACES_DIR" -mindepth 1 -maxdepth 1 -type l -print0)
 
-# When staleness is detected, write a refresh marker so the sessionStart hook can
-# update marketplace indexes on the next session. Writing a marker file is always
-# safe — it does NOT invoke claude or mutate plugin cache directories.
+# Write a refresh marker so the sessionStart hook can update marketplace indexes.
+# Writing a marker file is safe — it does not invoke claude or mutate cache directories.
 if [[ "$stale_detected" == true ]]; then
   REFRESH_MARKER="$CACHE_DIR/.nix-refresh-needed"
   tmp_marker="$(mktemp "${REFRESH_MARKER}.XXXXXX")"
   echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$tmp_marker"
-  for name in "${!new_hashes[@]}"; do
-    if [[ "${old_hashes[$name]:-}" != "${new_hashes[$name]}" ]]; then
-      echo "marketplace=$name" >> "$tmp_marker"
-    fi
+  for name in "${stale_names[@]}"; do
+    echo "marketplace=$name" >> "$tmp_marker"
   done
   mv "$tmp_marker" "$REFRESH_MARKER"
   log_info "Wrote marketplace refresh marker: $REFRESH_MARKER"
@@ -87,7 +86,6 @@ fi
 # resolved at session start — deleting them mid-session causes an unbreakable error
 # loop (every hook fails, including Stop). By also skipping the hash file update,
 # the next rebuild will re-detect staleness and purge when no sessions are active.
-# The refresh marker above will be consumed by the sessionStart hook instead.
 if [[ "$stale_detected" == true ]] && pgrep -qx "claude"; then
   log_info "Stale caches detected but Claude Code session is active — deferring purge"
   exit 0

--- a/modules/claude/settings.nix
+++ b/modules/claude/settings.nix
@@ -130,11 +130,11 @@ let
     };
   };
 
-  # Synthetic marketplaces need entries in known_marketplaces.json (Claude Code's actual registry).
-  # Claude Code populates this file by fetching from GitHub sources in extraKnownMarketplaces,
-  # but synthetic marketplaces fail the fetch (upstream has no .claude-plugin structure).
-  # This overlay ensures the local installLocation is registered so Claude Code reads from disk.
-  syntheticMarketplaces = lib.filterAttrs (_: m: m.flakeInput != null) cfg.plugins.marketplaces;
+  # All Nix-managed marketplaces need entries in known_marketplaces.json (Claude Code's actual registry).
+  # Without this, Claude Code may resolve installLocation to a git-cloned path instead of the
+  # Nix-managed symlink at ~/.claude/plugins/marketplaces/<name>. Writing installLocation for every
+  # marketplace ensures the merge-json-settings overlay wins over any runtime-written paths.
+  nixManagedMarketplaces = lib.filterAttrs (_: m: m.flakeInput != null) cfg.plugins.marketplaces;
   knownMarketplacesOverlay = lib.mapAttrs (
     name: m:
     let
@@ -146,7 +146,7 @@ let
       installLocation = "${homeDir}/.claude/plugins/marketplaces/${marketplaceName}";
       lastUpdated = "1970-01-01T00:00:00.000Z";
     }
-  ) syntheticMarketplaces;
+  ) nixManagedMarketplaces;
 
   knownMarketplacesJson =
     pkgs.runCommand "known-marketplaces-overlay.json"


### PR DESCRIPTION
## Summary

Root cause: `FORCE_AUTOUPDATE_PLUGINS=1` was causing Claude Code to git-clone all marketplaces on startup, overwriting Nix-managed symlinks with mutable directories. Two marketplaces (jacobpevans-cc-plugins, claude-plugins-official) were real directories; the other 17 were proper symlinks—a stale cache issue that broke when flake inputs changed.

Solution: Remove the env var that causes overwriting, then add a marker-based refresh mechanism. After darwin-rebuild updates marketplace symlinks to new Nix store paths, verify-cache-integrity.sh detects the change and writes a `.nix-refresh-needed` marker. On the next session start, a new sessionStart hook (marketplace-refresh.sh) reads the marker and refreshes each changed marketplace's index via `claude plugin marketplace update`, then retries failures in subsequent sessions.

## How it works

1. **Nix rebuild updates symlinks**: `darwin-rebuild switch` replaces `~/.claude/plugins/marketplaces/*` symlinks with new store paths
2. **Staleness detection**: `verify-cache-integrity.sh` compares old and new store path hashes, writes a `.nix-refresh-needed` marker listing changed marketplaces (safe—just a file write, no cache mutation, works even if Claude is running)
3. **Index refresh on session start**: `marketplace-refresh.sh` sessionStart hook reads the marker, runs `claude plugin marketplace update <name>` for each changed marketplace
4. **Retry on failure**: If updates fail, failed marketplace names are kept in the marker file for next session retry
5. **Success cleanup**: Marker is deleted once all marketplaces refresh successfully

## Changes

- `modules/claude-config.nix`: removed `FORCE_AUTOUPDATE_PLUGINS = "1"`, added `sessionStart = ./claude/hooks/marketplace-refresh.sh`
- `modules/claude/hooks/marketplace-refresh.sh`: NEW — sessionStart hook that reads `.nix-refresh-needed` marker, refreshes each marketplace, accumulates failures in a temp file (avoids string-splitting edge cases), retries on next session
- `modules/claude/scripts/verify-cache-integrity.sh`: writes `.nix-refresh-needed` marker when store paths change, includes timestamp and marketplace names
- `modules/claude/settings.nix`: renamed `syntheticMarketplaces` → `nixManagedMarketplaces` (cosmetic clarification; all 19 already had `flakeInput != null`)

## Implementation details

**Why a marker file approach?**
- `home.activation` scripts cannot invoke `claude` CLI (constraint from plugin-cache-architecture.md)
- Staleness detection happens at rebuild time; refresh should happen at session start
- Marker decouples these two phases while respecting the constraint

**Why a temp file for failures?**
- Colon-delimited strings in shell have trailing-colon issues when splitting into arrays
- Temp file avoids the edge case: `failed_list="mp1:mp2:"` with split would create an empty element
- Evaluated `${#failed_arr[@]}` would count the empty element as a success

**Why no timeout command?**
- macOS ships bash 3.2 (GNU coreutils `timeout` is not available)
- `claude plugin marketplace update` has its own network timeout anyway

## Constraint compliance

Per `modules/claude/.claude/rules/plugin-cache-architecture.md`:
- Does NOT run `claude plugin marketplace update` from `home.activation`
- Does NOT delete cache directories mid-session (orphan cleanup is separate)
- Marker file write happens before the "Claude is running" guard in verify-cache-integrity.sh, so it always writes safely
- sessionStart hook is best-effort: failures are logged but don't block session start

## Test Plan

- [x] `nix flake check` passes (formatting, statix, deadnix, regression tests)
- [ ] After rebuild: verify all `~/.claude/plugins/marketplaces/*/` paths are symlinks (not directories)
- [ ] Update a flake input (e.g., nixpkgs, claude-plugins-official) → rebuild → start new session → verify `.nix-refresh-needed` marker exists after rebuild, is consumed during session start
- [ ] `claude plugin list` shows current versions from the updated Nix store
- [ ] Trigger a failure: temporarily make a marketplace unreachable → verify failed marketplace name is re-queued in marker file for next session

## One-time manual cleanup after merge and rebuild

After this PR merges and you run `darwin-rebuild switch`, the two directories that were created by FORCE_AUTOUPDATE_PLUGINS should be replaced by symlinks. If any remnants exist, clean up:

```bash
rm -rf ~/.claude/plugins/marketplaces/jacobpevans-cc-plugins
rm -rf ~/.claude/plugins/marketplaces/claude-plugins-official
rm -rf ~/.claude/plugins/marketplaces/claude-plugins-official.bak
```