### PR TITLE
feat(gemini): support custom sandbox profile path

### DIFF
--- a/lib/checks/gemini.nix
+++ b/lib/checks/gemini.nix
@@ -13,6 +13,7 @@ in
         "excludedMcpServers"
         "extensions"
         "hooks"
+        "sandbox"
         "trustedFolders"
       ];
       actualOptions = builtins.attrNames cfg;
@@ -67,6 +68,16 @@ in
           name = "gemini.commands.local";
           actual = cfg.commands.local;
           expected = { };
+        }
+        {
+          name = "gemini.sandbox.enable";
+          actual = cfg.sandbox.enable;
+          expected = true;
+        }
+        {
+          name = "gemini.sandbox.profile";
+          actual = cfg.sandbox.profile;
+          expected = null;
         }
       ];
       failures = builtins.filter (c: c.actual != c.expected) checks;

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -107,6 +107,13 @@ in
       description = "Paths the sandbox is allowed to write to. Required for git operations on bare repos when sandbox is enabled.";
     };
 
+    # Custom sandbox profile
+    sandboxProfile = lib.mkOption {
+      type = lib.types.nullOr (lib.types.either lib.types.str lib.types.path);
+      default = null;
+      description = "Path to a custom macOS sandbox profile (.sb) to use instead of the default sandbox.";
+    };
+
     # Worktrees feature
     worktrees = lib.mkOption {
       type = lib.types.bool;

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -107,11 +107,18 @@ in
       description = "Paths the sandbox is allowed to write to. Required for git operations on bare repos when sandbox is enabled.";
     };
 
-    # Custom sandbox profile
-    sandboxProfile = lib.mkOption {
-      type = lib.types.nullOr (lib.types.either lib.types.str lib.types.path);
-      default = null;
-      description = "Path to a custom macOS sandbox profile (.sb) to use instead of the default sandbox.";
+    # Sandbox configuration
+    sandbox = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable sandbox mode for filesystem/network isolation.";
+      };
+      profile = lib.mkOption {
+        type = lib.types.nullOr (lib.types.either lib.types.str lib.types.path);
+        default = null;
+        description = "Path to a custom macOS sandbox profile (.sb) to use instead of the default sandbox.";
+      };
     };
 
     # Worktrees feature

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -103,7 +103,7 @@ let
     };
 
     tools = {
-      sandbox = true;
+      sandbox = if cfg.sandboxProfile != null then cfg.sandboxProfile else true;
     }
     // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
       inherit (cfg) sandboxAllowedPaths;

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -103,7 +103,7 @@ let
     };
 
     tools = {
-      sandbox = if cfg.sandboxProfile != null then cfg.sandboxProfile else true;
+      sandbox = if cfg.sandbox.profile != null then cfg.sandbox.profile else cfg.sandbox.enable;
     }
     // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
       inherit (cfg) sandboxAllowedPaths;


### PR DESCRIPTION
Adds  to allow using a custom macOS sandbox profile string instead of unconditionally defaulting to the boolean .

This is necessary for cases where a user wants to configure a custom  file (e.g. ) to allow access to bare repo .git directories from worktrees.