### PR TITLE
feat(claude): bump effort to high, add claude-latest install, centralize AI aliases

### DIFF
--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -152,7 +152,7 @@ in
         {
           name = "effortLevel";
           actual = cfg.effortLevel;
-          expected = "medium";
+          expected = "high";
         }
         {
           name = "sandbox.enabled";

--- a/modules/ai-aliases.zsh
+++ b/modules/ai-aliases.zsh
@@ -1,0 +1,21 @@
+# AI CLI aliases — sourced by nix-home/nix-darwin zsh init
+# Managed by nix-ai's programs.zsh.initContent via modules/ai-shell.nix.
+# Single source of truth for Claude/Doppler AI-tool wrapper aliases.
+
+# Bleeding-edge native install managed by nix-ai's programs.claude-latest module.
+# `claude` (unaliased) resolves via PATH — whatever that points at is intentional.
+alias claude-latest="$HOME/.local/bin/claude"
+
+# --dangerously-skip-permissions variants (aliases chain at command start in zsh).
+alias claude-d="claude --dangerously-skip-permissions"
+alias claude-latest-d="claude-latest --dangerously-skip-permissions"
+
+# Doppler-wrapped Claude — injects ai-ci-automation/prd secrets (GEMINI_API_KEY,
+# OPENROUTER_API_KEY, etc.) for sessions that need MCP/API credentials.
+# Usage: d-claude               # interactive
+#        d-claude -p "prompt"   # non-interactive
+alias d-claude="doppler run -p ai-ci-automation -c prd -- claude"
+
+# aws-vault terraform profile layered on top of d-claude. For infra-repo sessions
+# that need BOTH AWS credentials AND AI MCP secrets loaded.
+alias tf-claude="aws-vault exec terraform -- doppler run -p ai-ci-automation -c prd -- claude"

--- a/modules/ai-shell.nix
+++ b/modules/ai-shell.nix
@@ -1,0 +1,15 @@
+# AI shell aliases wiring
+#
+# Appends AI-tool aliases to programs.zsh.initContent after nix-home's base
+# init block. lib.mkAfter ensures these entries load last so any collisions
+# with nix-home's aliases.nix win in our favor. The companion nix-home PR
+# removes d-claude/tf-claude from that file, but mkAfter keeps us safe
+# during the transitional window.
+
+{ lib, ... }:
+
+{
+  programs.zsh.initContent = lib.mkAfter ''
+    source ${./ai-aliases.zsh}
+  '';
+}

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -102,13 +102,14 @@ in
   # teammateMode — using upstream default: "auto" (options.nix)
   # "auto" splits panes in tmux, in-process otherwise.
 
-  # Model: opusplan — Opus 4.7 for planning, Sonnet 4.6 for execution (1M context).
+  # Model: opusplan — Opus for planning, Sonnet for execution (1M context).
   model = "opusplan";
 
-  # Effort: medium — matches upstream Max/Team default (v2.1.68+).
-  # Must be explicit to override runtime "high" value (merge script preserves runtime keys).
+  # Effort: high — maximize reasoning quality by default.
+  # Must be explicit (merge script preserves runtime keys, so without this users stay on
+  # whatever was last set at runtime or upstream default).
   # Override per-session via /model effort slider or "ultrathink" keyword.
-  effortLevel = "medium";
+  effortLevel = "high";
 
   # autoUpdatesChannel — using upstream default: "latest" (options.nix)
   # showTurnDuration — using upstream default: false (options.nix)
@@ -224,7 +225,7 @@ in
       # See: https://code.claude.com/docs/en/agent-teams
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
 
-      # Adaptive thinking for Opus 4.7/Sonnet 4.6 (explicitly enabled)
+      # Adaptive thinking for Opus/Sonnet (explicitly enabled)
       CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0";
 
       # DEFAULT VALUES (upstream) - reference only, do not uncomment unless tuning

--- a/modules/claude-latest.nix
+++ b/modules/claude-latest.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+#
+# claude-latest install module
+#
+# Manages the bleeding-edge Claude Code native install at ~/.local/bin/claude,
+# coexisting with Homebrew's /opt/homebrew/bin/claude (stable). Aliases that
+# disambiguate `claude` vs `claude-latest` live in modules/ai-aliases.zsh.
+#
+# Pattern: mirrors nix-darwin/modules/darwin/apps/cribl-edge.nix — committed
+# shell file wrapped via pkgs.writeShellApplication, invoked declaratively by
+# a LaunchAgent. No home.activation for software installs.
+#
+# After first install, Claude Code's own `claude update` command keeps the
+# binary current — this module only bootstraps a missing install and provides
+# an on-demand `claude-latest-install` command.
+#
+# Web docs: https://claude.ai/install.sh
+#
+let
+  cfg = config.programs.claude-latest;
+
+  installScript = pkgs.writeShellApplication {
+    name = "claude-latest-install";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.bash
+      pkgs.coreutils
+    ];
+    text = builtins.readFile ./claude/scripts/claude-latest-install.sh;
+  };
+in
+{
+  options.programs.claude-latest = {
+    enable = lib.mkEnableOption "bleeding-edge Claude Code install at ~/.local/bin/claude via the official installer";
+  };
+
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.isDarwin) {
+    # On PATH for manual re-install or forced re-run.
+    home.packages = [ installScript ];
+
+    # Fires once at login; no-op when already installed (script is idempotent).
+    # KeepAlive = false: we only care about bootstrap, not a long-running service.
+    launchd.agents.claude-latest-install = {
+      enable = true;
+      config = {
+        Label = "com.jacobpevans.claude-latest-install";
+        ProgramArguments = [ "${installScript}/bin/claude-latest-install" ];
+        RunAtLoad = true;
+        KeepAlive = false;
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/ClaudeLatest/install.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/ClaudeLatest/install.error.log";
+      };
+    };
+
+    # Ensure the logs directory exists so launchd doesn't bail on first run.
+    home.file."Library/Logs/ClaudeLatest/.keep".text = "";
+  };
+}

--- a/modules/claude-latest.nix
+++ b/modules/claude-latest.nix
@@ -28,7 +28,6 @@ let
     name = "claude-latest-install";
     runtimeInputs = [
       pkgs.curl
-      pkgs.bash
       pkgs.coreutils
     ];
     text = builtins.readFile ./claude/scripts/claude-latest-install.sh;

--- a/modules/claude/README.md
+++ b/modules/claude/README.md
@@ -5,6 +5,25 @@ rules, settings, and statusline via `programs.claude.*` options.
 
 Configured in [`modules/claude-config.nix`](../claude-config.nix). Deployed to `~/.claude/` by home-manager.
 
+## Parallel Installs
+
+Two Claude Code binaries live side-by-side on this system:
+
+| Binary | Path | Channel | Managed by |
+| ------ | ---- | ------- | ---------- |
+| `claude` | `/opt/homebrew/bin/claude` | Stable (Homebrew) | nix-darwin `homebrew.brews` |
+| `claude-latest` | `~/.local/bin/claude` | Bleeding edge (Anthropic installer) | [`modules/claude-latest.nix`](../claude-latest.nix) |
+
+`claude-latest` is bootstrapped once by a user-level LaunchAgent
+(`com.jacobpevans.claude-latest-install`) that runs
+[`scripts/claude-latest-install.sh`](scripts/claude-latest-install.sh) via
+`pkgs.writeShellApplication`. Self-updates happen via `claude update` after
+first install. Run `claude-latest-install` by hand to force a reinstall.
+
+Shell aliases (`claude-latest`, `claude-d`, `claude-latest-d`, `d-claude`,
+`tf-claude`) live in [`../ai-aliases.zsh`](../ai-aliases.zsh), wired into
+`programs.zsh.initContent` by [`../ai-shell.nix`](../ai-shell.nix).
+
 ## Component Map
 
 | Component | Location | Description |

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -295,7 +295,7 @@ in
       );
       default = null;
       description = ''
-        Adaptive reasoning effort for Opus 4.7 and Sonnet 4.6.
+        Adaptive reasoning effort for Opus and Sonnet.
         - null: Use upstream default (medium for Max/Team as of v2.1.68)
         - "high": Full reasoning
         - "medium": Balanced cost/quality

--- a/modules/claude/scripts/claude-latest-install.sh
+++ b/modules/claude/scripts/claude-latest-install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# claude-latest-install.sh - Install bleeding-edge Claude Code via the official installer
+#
+# Idempotent: if ~/.local/bin/claude already resolves to a native install
+# (symlink into ~/.local/share/claude/versions/), exit 0 without touching anything.
+# Otherwise, run the official Anthropic installer from claude.ai/install.sh.
+#
+# Claude Code self-updates thereafter via `claude update`. This script is only
+# responsible for bootstrapping a missing install (and forced re-install on demand).
+#
+# Invoked by:
+#   - LaunchAgent com.jacobpevans.claude-latest-install at login (RunAtLoad=true, no-op normally)
+#   - Manual `claude-latest-install` command (writeShellApplication on PATH)
+#
+# Exit codes:
+#   0 - Already installed (no-op) OR installer succeeded
+#   non-zero - Installer failed (propagated from upstream)
+
+set -euo pipefail
+
+BIN="$HOME/.local/bin/claude"
+STATE_DIR="$HOME/.local/share/claude"
+TS() { date '+%Y-%m-%d %H:%M:%S'; }
+
+# Fast path: already a symlink into the native install's versions directory.
+if [ -L "$BIN" ]; then
+  target="$(readlink "$BIN")"
+  case "$target" in
+    "$STATE_DIR"/versions/*)
+      echo "$(TS) [INFO] claude-latest already installed at $BIN -> $target; skipping."
+      exit 0
+      ;;
+  esac
+fi
+
+echo "$(TS) [INFO] Installing claude-latest via https://claude.ai/install.sh ..."
+curl -fsSL https://claude.ai/install.sh | bash
+echo "$(TS) [INFO] claude-latest install completed; $BIN -> $(readlink "$BIN" 2>/dev/null || echo '(not a symlink)')"

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -73,8 +73,10 @@ let
 in
 {
   imports = [
-    ./claude
+    ./ai-shell.nix
     ./agent-skills
+    ./claude
+    ./claude-latest.nix
     ./codex
     ./gemini
     ./fabric
@@ -152,6 +154,11 @@ in
       # Fabric — 252+ AI prompt patterns + CLI (defaults to MLX backend)
       # REST API server is opt-in via programs.fabric.enableServer
       fabric.enable = true;
+
+      # Bleeding-edge Claude Code at ~/.local/bin/claude via the official installer.
+      # Coexists with Homebrew's stable `claude`. See modules/ai-aliases.zsh for
+      # alias definitions (claude-latest, claude-d, claude-latest-d).
+      claude-latest.enable = true;
 
       # GitHub CLI extension for AI workflows
       gh.extensions = [ ghExtensions.gh-aw ];


### PR DESCRIPTION
## Summary

Three coordinated changes consolidating AI-tool surface area in nix-ai:

1. **Opus defaults** — bump \`effortLevel\` \`\"medium\"\` → \`\"high\"\` in \`claude-config.nix\` for full-reasoning-by-default sessions. Keep \`model = \"opusplan\"\` unchanged. Scrub version suffixes (\"4.6\", \"4.7\") from live config comments so they read cleanly without pinning versions. Bumps the defaults-regression expectation to match.

2. **claude-latest install module** — Nix-native bootstrap for the official Anthropic installer via \`programs.claude-latest\`. Mirrors the [Cribl-Edge pattern](../nix-darwin/blob/main/modules/darwin/apps/cribl-edge.nix) — committed shell script (\`modules/claude/scripts/claude-latest-install.sh\`) invoked via \`pkgs.writeShellApplication\`, triggered by a declarative LaunchAgent at login. Idempotent (no-op when \`~/.local/bin/claude\` already resolves to a native install). Self-updates thereafter via \`claude update\`. **No \`home.activation\` for software installs.** Exposes \`claude-latest-install\` on \`PATH\` for manual re-runs.

3. **AI zsh aliases module** — new \`modules/ai-aliases.zsh\` (wired via \`modules/ai-shell.nix\`) centralizes \`claude-latest\`, \`claude-d\`, \`claude-latest-d\`, \`d-claude\`, and \`tf-claude\`. Needs the companion nix-home PR that removes \`d-claude\`/\`tf-claude\` from its \`aliases.nix\`.

## Companion PR

- nix-home: https://github.com/JacobPEvans/nix-home/pull/new/feat/move-ai-aliases-to-nix-ai

## Test plan

- [x] \`nix fmt\` clean
- [x] \`nix flake check\` passes (including the bumped \`defaults-regression\` expectation)
- [x] \`nix build .#darwinConfigurations.jevans-mbp.config.system.build.toplevel\` with overrides succeeds; generated \`com.jacobpevans.claude-latest-install.plist\` points at the \`writeShellApplication\` derivation
- [x] Running \`/nix/store/.../bin/claude-latest-install\` directly against the current native install logs \"already installed; skipping.\" and exits 0 (idempotent path verified)
- [x] \`~/.claude/settings.json\` reflects \`effortLevel = \"high\"\` and \`model = \"opusplan\"\` after rebuild
- [x] Aliases load correctly in a fresh zsh: \`alias claude-latest claude-d claude-latest-d d-claude tf-claude\` all resolve as expected
- [ ] On-login LaunchAgent fires once after next \`darwin-rebuild\` completes (currently blocked by an unrelated Cribl CDN curl failure in system postActivation)