### PR TITLE
feat(gemini): default sandboxAllowedPaths to ~/git

### DIFF
--- a/lib/checks/gemini.nix
+++ b/lib/checks/gemini.nix
@@ -79,6 +79,11 @@ in
           actual = cfg.sandbox.profile;
           expected = null;
         }
+        {
+          name = "gemini.sandboxAllowedPaths";
+          actual = cfg.sandboxAllowedPaths;
+          expected = [ ];
+        }
       ];
       failures = builtins.filter (c: c.actual != c.expected) checks;
       failureMsg = builtins.concatStringsSep "\n" (

--- a/lib/checks/gemini.nix
+++ b/lib/checks/gemini.nix
@@ -106,6 +106,24 @@ in
     ''
   );
 
+  # Validate that the evaluated settings always include the `~/git` sandbox
+  # default (what actually lands in `tools.sandboxAllowedPaths` in settings.json).
+  # Reads the read-only `sandboxAllowedPathsMerged` option the settings module
+  # populates, so a broken merge fails the check at eval time.
+  gemini-sandbox-default-paths =
+    let
+      expected = "${hmConfig.config.home.homeDirectory}/git";
+      merged = hmConfig.config.programs.gemini.sandboxAllowedPathsMerged;
+      hasGitDir = builtins.elem expected merged;
+    in
+    assert
+      hasGitDir
+      || throw "Gemini sandboxAllowedPathsMerged missing ${expected}: ${builtins.toJSON merged}";
+    pkgs.runCommand "check-gemini-sandbox-default-paths" { } ''
+      echo "Gemini sandbox default: ${expected} is present in merged settings"
+      touch $out
+    '';
+
   # Validate the .gemini/.keep directory marker is created (proves module loaded).
   gemini-module-loaded =
     let

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -136,7 +136,6 @@ in
       gemini = {
         enable = true;
         worktrees = true;
-        sandboxAllowedPaths = [ "${config.home.homeDirectory}/git" ];
         defaultApprovalMode = "auto_edit";
       };
 

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -108,10 +108,20 @@ in
       description = ''
         Extra paths the sandbox is allowed to write to.
 
-        Merged with the default `~/git` so git operations (including worktree
-        creation on bare repos) work out of the box. Use this option only for
-        paths outside `~/git/`.
+        De-duplicated and merged with the built-in `~/git` default via
+        `lib.unique`, so git operations (including worktree creation on bare
+        repos) work out of the box. Duplicate entries are safe — the unique
+        merge collapses them.
       '';
+    };
+
+    # Merged sandbox paths, read-only — exposes the list that ends up in
+    # settings.json so regression checks and introspection can verify it.
+    sandboxAllowedPathsMerged = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Merged sandbox allowed paths (default + sandboxAllowedPaths); read-only.";
     };
 
     # Sandbox configuration

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -100,11 +100,18 @@ in
       description = "Additional trusted folders (merged with defaults)";
     };
 
-    # Sandbox allowed paths
+    # Sandbox allowed paths (merged with `~/git` default so worktree operations
+    # on bare repos succeed without per-host configuration).
     sandboxAllowedPaths = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      description = "Paths the sandbox is allowed to write to. Required for git operations on bare repos when sandbox is enabled.";
+      description = ''
+        Extra paths the sandbox is allowed to write to.
+
+        Merged with the default `~/git` so git operations (including worktree
+        creation on bare repos) work out of the box. Use this option only for
+        paths outside `~/git/`.
+      '';
     };
 
     # Sandbox configuration

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -30,6 +30,12 @@ let
     "${homeDir}/git"
   ];
 
+  # Default paths the sandbox may write to. Merged with cfg.sandboxAllowedPaths
+  # so every bare repo under ~/git/ can create worktrees without a denial.
+  defaultSandboxAllowedPaths = [ "${homeDir}/git" ];
+
+  mergedSandboxAllowedPaths = lib.unique (defaultSandboxAllowedPaths ++ cfg.sandboxAllowedPaths);
+
   # Normalize MCP server for Gemini format
   # stdio: { command, args?, env?, cwd?, timeout? }
   # HTTP/SSE: { httpUrl, headers? } (note: httpUrl not url)
@@ -105,8 +111,8 @@ let
     tools = {
       sandbox = if cfg.sandbox.profile != null then cfg.sandbox.profile else cfg.sandbox.enable;
     }
-    // lib.optionalAttrs (cfg.sandboxAllowedPaths != [ ]) {
-      inherit (cfg) sandboxAllowedPaths;
+    // lib.optionalAttrs (mergedSandboxAllowedPaths != [ ]) {
+      sandboxAllowedPaths = mergedSandboxAllowedPaths;
     };
 
     experimental = lib.optionalAttrs cfg.worktrees {

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -19,6 +19,7 @@
 let
   cfg = config.programs.gemini;
   homeDir = config.home.homeDirectory;
+  gitDir = "${homeDir}/git";
 
   aiCommon = import ../common {
     inherit lib config ai-assistant-instructions;
@@ -27,12 +28,12 @@ let
 
   defaultTrustedFolders = [
     "${homeDir}/.config/nix"
-    "${homeDir}/git"
+    gitDir
   ];
 
   # Default paths the sandbox may write to. Merged with cfg.sandboxAllowedPaths
   # so every bare repo under ~/git/ can create worktrees without a denial.
-  defaultSandboxAllowedPaths = [ "${homeDir}/git" ];
+  defaultSandboxAllowedPaths = [ gitDir ];
 
   mergedSandboxAllowedPaths = lib.unique (defaultSandboxAllowedPaths ++ cfg.sandboxAllowedPaths);
 
@@ -110,8 +111,6 @@ let
 
     tools = {
       sandbox = if cfg.sandbox.profile != null then cfg.sandbox.profile else cfg.sandbox.enable;
-    }
-    // lib.optionalAttrs (mergedSandboxAllowedPaths != [ ]) {
       sandboxAllowedPaths = mergedSandboxAllowedPaths;
     };
 
@@ -135,6 +134,8 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
+    programs.gemini.sandboxAllowedPathsMerged = mergedSandboxAllowedPaths;
+
     home = {
       # Deploy the Policy Engine TOML file (read-only is fine — Gemini only reads it)
       file."${lib.removePrefix "${homeDir}/" policyPath}".source = policyToml;


### PR DESCRIPTION
## Summary
- Move the `~/git` sandbox allowance from a per-consumer setting in `modules/default.nix` to a default baked into `modules/gemini/settings.nix`.
- User-supplied `sandboxAllowedPaths` are merged on top (de-duplicated via `lib.unique`).
- Adds a regression assertion that the user-facing default stays `[]` so the merge behaviour is only visible through the generated `settings.json`.
- Exposes `programs.gemini.sandboxAllowedPathsMerged` (read-only) so regression tests can verify the merged list without poking at activation scripts.

## Motivation
Bare-repo worktree operations require the sandbox to allow writes to `~/git`. Every consumer of this module was doing that opt-in manually. With the default in place, new hosts and fresh installs no longer hit a sandbox denial on the first worktree attempt.

## Changes
- `modules/gemini/settings.nix` — new `gitDir` let-binding used by both `defaultTrustedFolders` and `defaultSandboxAllowedPaths`; `tools.sandboxAllowedPaths` emits the merged list unconditionally (no `lib.optionalAttrs` guard — the list is non-empty by construction); wires the merged value into the read-only option.
- `modules/gemini/options.nix` — option description updated to mention `lib.unique` merge semantics; new read-only `sandboxAllowedPathsMerged` option exposing the merged list for introspection and tests.
- `modules/default.nix` — removed the now-redundant `sandboxAllowedPaths = [ "${config.home.homeDirectory}/git" ]` line.
- `lib/checks/gemini.nix` — added regression assertion that `cfg.sandboxAllowedPaths` default is `[]`, plus `gemini-sandbox-default-paths` which asserts `${homeDir}/git` is present in the merged list.

## Test plan
- [x] `nix fmt` clean
- [x] `nix flake check` all green (formatting, statix, deadnix, shellcheck, gemini-defaults-regression, gemini-sandbox-default-paths, gemini-settings-json)
- [ ] Post-merge: `darwin-rebuild switch` and confirm `jq '.tools.sandboxAllowedPaths' ~/.gemini/settings.json` shows `["/Users/jevans/git"]`
- [ ] Post-merge: `gemini -p "create worktree for fix/smoke-test"` in `~/git/nix-ai/main/` completes without sandbox denial

## Deployment note
`merge-json-settings.sh` uses `jq '.[0] * .[1]'` which overwrites list-valued keys wholesale, so the new `~/git` default will replace any existing narrow `sandboxAllowedPaths` value in `~/.gemini/settings.json` automatically on the next `darwin-rebuild switch`. No manual cleanup needed.

## Related
- #615 added `sandbox.enable` / `sandbox.profile` options (merged).
- #597 added skills deployment to `~/.gemini/skills/` + `~/.agents/skills/` (merged).
- This PR is Phase 1 of the cross-tool permissions/skills/MCP sync tracked in the internal `pick-up-where-we-twinkling-hoare` plan.