### PR TITLE
feat(plugins): add VisiCore cribl-pack-validator skill (Claude+Codex+Gemini)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -383,6 +383,7 @@
         "openai-codex": "openai-codex",
         "pal-mcp-server": "pal-mcp-server",
         "superpowers-marketplace": "superpowers-marketplace",
+        "vct-cribl-pack-validator-skills": "vct-cribl-pack-validator-skills",
         "visual-explainer-marketplace": "visual-explainer-marketplace",
         "wakatime": "wakatime"
       }
@@ -400,6 +401,22 @@
       "original": {
         "owner": "obra",
         "repo": "superpowers-marketplace",
+        "type": "github"
+      }
+    },
+    "vct-cribl-pack-validator-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774484708,
+        "narHash": "sha256-cQEbj7K2HcFlL7vUVFYKsjlgZbzQqbVcAtw2QX7H4WQ=",
+        "owner": "VisiCore",
+        "repo": "vct-cribl-pack-validator",
+        "rev": "eaf3b3f17f77faf6825c587dfdd552f8a9837926",
+        "type": "github"
+      },
+      "original": {
+        "owner": "VisiCore",
+        "repo": "vct-cribl-pack-validator",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,10 @@
       url = "github:browser-use/browser-use";
       flake = false;
     };
+    vct-cribl-pack-validator-skills = {
+      url = "github:VisiCore/vct-cribl-pack-validator";
+      flake = false;
+    };
 
     # PAL MCP server - pinned for supply-chain safety; auto-bumped by deps-update-flake.yml
     pal-mcp-server = {
@@ -143,6 +147,7 @@
       visual-explainer-marketplace,
       wakatime,
       browser-use-skills,
+      vct-cribl-pack-validator-skills,
       pal-mcp-server,
       fabric-src,
       ...
@@ -160,6 +165,7 @@
           bills-claude-skills
           bitwarden-marketplace
           browser-use-skills
+          vct-cribl-pack-validator-skills
           cc-dev-tools
           cc-marketplace
           claude-code-plugins-plus

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -33,8 +33,29 @@ let
     in
     lib.concatMap pluginSkills (builtins.attrNames topDirs);
 
+  # Discovers SKILL.md files from a bare .claude/skills/ directory.
+  # Pattern: <repo>/.claude/skills/<skill-name>/SKILL.md
+  discoverDotClaudeSkills =
+    input:
+    let
+      skillsPath = "${input}/.claude/skills";
+      hasSkills = builtins.pathExists skillsPath;
+      skillDirs =
+        if hasSkills then
+          lib.filterAttrs (_: type: type == "directory") (builtins.readDir skillsPath)
+        else
+          { };
+    in
+    lib.mapAttrsToList (name: _: {
+      inherit name;
+      source = "${skillsPath}/${name}/SKILL.md";
+    }) (lib.filterAttrs (name: _: builtins.pathExists "${skillsPath}/${name}/SKILL.md") skillDirs);
+
   # Skills from JacobPEvans/claude-code-plugins (tool-agnostic markdown)
-  sharedSkills = discoverSkills marketplaceInputs.jacobpevans-cc-plugins;
+  # Plus VisiCore cribl-pack-validator (bare .claude/skills/ layout)
+  sharedSkills =
+    discoverSkills marketplaceInputs.jacobpevans-cc-plugins
+    ++ discoverDotClaudeSkills marketplaceInputs.vct-cribl-pack-validator-skills;
 in
 {
   imports = [

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -75,6 +75,7 @@ let
   };
   inherit (marketplaceOverrides)
     browserUseMarketplace
+    criblPackValidatorMarketplace
     jacobpevansMarketplace
     fabricMarketplace
     ;
@@ -154,6 +155,10 @@ in
         # Override flakeInput for synthetic marketplace (source defined in marketplaces.nix)
         "browser-use-skills" = base."browser-use-skills" // {
           flakeInput = browserUseMarketplace;
+        };
+        # Override flakeInput for synthetic Cribl pack validator marketplace.
+        "vct-cribl-pack-validator-skills" = base."vct-cribl-pack-validator-skills" // {
+          flakeInput = criblPackValidatorMarketplace;
         };
         # Override flakeInput with auto-generated marketplace manifest
         "jacobpevans-cc-plugins" = base."jacobpevans-cc-plugins" // {

--- a/modules/claude/marketplace-overrides.nix
+++ b/modules/claude/marketplace-overrides.nix
@@ -154,6 +154,14 @@
   # Upstream uses .claude/skills/<name>/SKILL.md layout (no marketplace structure).
   criblPackValidatorMarketplace =
     let
+      src = marketplaceInputs.vct-cribl-pack-validator-skills;
+      skillsPath = "${src}/.claude/skills";
+      # Discover skills dynamically — mirrors discoverDotClaudeSkills in agent-skills/default.nix
+      skillDirs = lib.filterAttrs (_: t: t == "directory") (builtins.readDir skillsPath);
+      skillNames = builtins.attrNames (
+        lib.filterAttrs (name: _: builtins.pathExists "${skillsPath}/${name}/SKILL.md") skillDirs
+      );
+
       manifestJson = builtins.toFile "marketplace.json" (
         builtins.toJSON {
           name = "vct-cribl-pack-validator-skills";
@@ -186,15 +194,14 @@
           author = {
             name = "VisiCore";
           };
-          skills = [ "./skills/validate-pack" ];
+          skills = map (n: "./skills/${n}") skillNames;
         }
       );
     in
     pkgs.runCommand "vct-cribl-pack-validator-marketplace" { } ''
-      mkdir -p $out/.claude-plugin $out/cribl-pack-validator/.claude-plugin
-      cp ${manifestJson} $out/.claude-plugin/marketplace.json
-      cp ${pluginJson} $out/cribl-pack-validator/.claude-plugin/plugin.json
-      ln -s ${marketplaceInputs.vct-cribl-pack-validator-skills}/.claude/skills $out/cribl-pack-validator/skills
+      install -D -m 644 ${manifestJson} $out/.claude-plugin/marketplace.json
+      install -D -m 644 ${pluginJson} $out/cribl-pack-validator/.claude-plugin/plugin.json
+      ln -s ${src}/.claude/skills $out/cribl-pack-validator/skills
     '';
 
   # Auto-generated marketplace manifest for jacobpevans-cc-plugins

--- a/modules/claude/marketplace-overrides.nix
+++ b/modules/claude/marketplace-overrides.nix
@@ -150,6 +150,53 @@
       ${copySkillCommands}
     '';
 
+  # Synthetic marketplace for VisiCore/vct-cribl-pack-validator.
+  # Upstream uses .claude/skills/<name>/SKILL.md layout (no marketplace structure).
+  criblPackValidatorMarketplace =
+    let
+      manifestJson = builtins.toFile "marketplace.json" (
+        builtins.toJSON {
+          name = "vct-cribl-pack-validator-skills";
+          metadata = {
+            description = "Cribl pack validation skill from VisiCore";
+            version = "0.1.0";
+          };
+          owner = {
+            name = "VisiCore";
+            url = "https://github.com/VisiCore";
+          };
+          plugins = [
+            {
+              name = "cribl-pack-validator";
+              source = "./cribl-pack-validator";
+              description = "Validate Cribl .crbl packs against pack standards: naming, routing, sources/destinations, pipeline ordering, PII masking, and test coverage.";
+              version = "0.1.0";
+              author = {
+                name = "VisiCore";
+              };
+            }
+          ];
+        }
+      );
+      pluginJson = builtins.toFile "plugin.json" (
+        builtins.toJSON {
+          name = "cribl-pack-validator";
+          version = "0.1.0";
+          description = "Validate Cribl .crbl packs against pack standards.";
+          author = {
+            name = "VisiCore";
+          };
+          skills = [ "./skills/validate-pack" ];
+        }
+      );
+    in
+    pkgs.runCommand "vct-cribl-pack-validator-marketplace" { } ''
+      mkdir -p $out/.claude-plugin $out/cribl-pack-validator/.claude-plugin
+      cp ${manifestJson} $out/.claude-plugin/marketplace.json
+      cp ${pluginJson} $out/cribl-pack-validator/.claude-plugin/plugin.json
+      ln -s ${marketplaceInputs.vct-cribl-pack-validator-skills}/.claude/skills $out/cribl-pack-validator/skills
+    '';
+
   # Auto-generated marketplace manifest for jacobpevans-cc-plugins
   # Ensures every plugin directory is registered — eliminates manual marketplace.json maintenance.
   jacobpevansMarketplace =

--- a/modules/claude/plugins/infrastructure.nix
+++ b/modules/claude/plugins/infrastructure.nix
@@ -33,6 +33,9 @@ _:
     # CI/CD (GitHub Actions in repos)
     "cicd-automation@claude-code-workflows" = true;
 
+    # Cribl pack validation (log pipeline infrastructure)
+    "cribl-pack-validator@vct-cribl-pack-validator-skills" = true;
+
     # REMOVED - not actively used:
     # observability-monitoring - moved to development.nix (avoid duplication)
     # cloud-infrastructure - too generic

--- a/modules/claude/plugins/marketplaces.nix
+++ b/modules/claude/plugins/marketplaces.nix
@@ -229,6 +229,15 @@ let
       };
     };
 
+    # VisiCore Cribl pack validator — lints .crbl pack files against pack standards.
+    # Bare .claude/skills/ layout; wrapped into synthetic marketplace.
+    "vct-cribl-pack-validator-skills" = {
+      source = {
+        type = "github";
+        url = "VisiCore/vct-cribl-pack-validator";
+      };
+    };
+
     # Fabric patterns — Daniel Miessler's 252+ AI prompt patterns.
     # The upstream repo has no .claude-plugin/ structure, so we wrap a curated
     # subset into a synthetic marketplace (see fabricMarketplace in


### PR DESCRIPTION
## Summary

Integrates `VisiCore/vct-cribl-pack-validator` as a **synthetic marketplace** so the `validate-pack` Cribl pack linting skill is available in all three AI CLIs:

- **Claude Code**: synthetic `.claude-plugin/` wrapper via `criblPackValidatorMarketplace` derivation; plugin enabled in `infrastructure.nix`
- **Codex + Gemini**: `discoverDotClaudeSkills` helper discovers `.claude/skills/<name>/SKILL.md` layout and deploys to `~/.agents/skills/`

The upstream repo ships a bare `.claude/skills/` layout with no marketplace manifest, so it requires the same synthetic treatment as `browser-use-skills`.

## Changes

| File | Change |
|---|---|
| `flake.nix` / `flake.lock` | New input `vct-cribl-pack-validator-skills` pinned to `eaf3b3f` |
| `modules/claude/plugins/marketplaces.nix` | Registers `vct-cribl-pack-validator-skills` in Synthetic Marketplaces section |
| `modules/claude/marketplace-overrides.nix` | `criblPackValidatorMarketplace` derivation: `install -D`, dynamic skill list via `builtins.readDir` |
| `modules/claude-config.nix` | Wires `criblPackValidatorMarketplace` as flakeInput override |
| `modules/claude/plugins/infrastructure.nix` | Enables `cribl-pack-validator@vct-cribl-pack-validator-skills` |
| `modules/agent-skills/default.nix` | Adds `discoverDotClaudeSkills` for bare `.claude/skills/` repos; extends `sharedSkills` |

## Test Plan

- [x] `nix flake check` — all checks green
- [x] `nix fmt` — formatter clean
- [ ] `sudo darwin-rebuild switch --flake "$HOME/git/nix-darwin/main" --override-input nix-ai "$HOME/git/nix-ai/feature/cribl-pack-validator-skills"` then verify:
  - `~/.claude/plugins/marketplaces/vct-cribl-pack-validator-skills/cribl-pack-validator/skills/validate-pack/SKILL.md`
  - `~/.agents/skills/validate-pack/SKILL.md`
- [ ] In a fresh Claude Code session: `/validate-pack` skill is discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)