### PR TITLE
fix(claude): run knownMarketplacesMerge before install activations

### DIFF
--- a/modules/claude/settings.nix
+++ b/modules/claude/settings.nix
@@ -250,19 +250,15 @@ in
       # Claude Code populates this by fetching from GitHub, but synthetic marketplaces (repos without
       # .claude-plugin structure) fail the fetch. This merge ensures the local installLocation is
       # registered so Claude Code reads the synthetic marketplace from the Nix-managed symlink.
-      # Run before install* activations (installBrowserUse, installDocumentSkillNpmDeps,
-      # installOpenWebui) so a failing uv/npm install cannot abort the activation before
-      # the critical file merge runs (activation uses set -eu).
-      knownMarketplacesMerge =
-        lib.hm.dag.entryBetween
-          [ "installBrowserUse" "installDocumentSkillNpmDeps" "installOpenWebui" ]
-          [ "writeBoundary" ]
-          ''
-            export PATH="${pkgs.jq}/bin:$PATH"
-            $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
-              "${knownMarketplacesJson}" \
-              "${homeDir}/.claude/plugins/known_marketplaces.json"
-          '';
+      # install* activations (installBrowserUse, installOpenWebui) declare a dependency on this step
+      # so a failing uv/npm install cannot abort the activation before the critical file merge runs
+      # (activation uses set -eu).
+      knownMarketplacesMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        export PATH="${pkgs.jq}/bin:$PATH"
+        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+          "${knownMarketplacesJson}" \
+          "${homeDir}/.claude/plugins/known_marketplaces.json"
+      '';
     };
 
     # Validate configuration before generating settings.json

--- a/modules/claude/settings.nix
+++ b/modules/claude/settings.nix
@@ -250,12 +250,19 @@ in
       # Claude Code populates this by fetching from GitHub, but synthetic marketplaces (repos without
       # .claude-plugin structure) fail the fetch. This merge ensures the local installLocation is
       # registered so Claude Code reads the synthetic marketplace from the Nix-managed symlink.
-      knownMarketplacesMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        export PATH="${pkgs.jq}/bin:$PATH"
-        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
-          "${knownMarketplacesJson}" \
-          "${homeDir}/.claude/plugins/known_marketplaces.json"
-      '';
+      # Run before install* activations (installBrowserUse, installDocumentSkillNpmDeps,
+      # installOpenWebui) so a failing uv/npm install cannot abort the activation before
+      # the critical file merge runs (activation uses set -eu).
+      knownMarketplacesMerge =
+        lib.hm.dag.entryBetween
+          [ "installBrowserUse" "installDocumentSkillNpmDeps" "installOpenWebui" ]
+          [ "writeBoundary" ]
+          ''
+            export PATH="${pkgs.jq}/bin:$PATH"
+            $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+              "${knownMarketplacesJson}" \
+              "${homeDir}/.claude/plugins/known_marketplaces.json"
+          '';
     };
 
     # Validate configuration before generating settings.json

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -102,7 +102,7 @@ in
         '';
 
         # open-webui: installed via uv (nixpkgs broken on darwin — see modules/open-webui.nix)
-        installOpenWebui = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        installOpenWebui = lib.hm.dag.entryAfter [ "writeBoundary" "knownMarketplacesMerge" ] ''
           if ! ${lib.getExe pkgs.uv} tool list 2>/dev/null | grep -q "^open-webui"; then
             echo "-> Installing open-webui via uv (Python 3.14)..."
             $DRY_RUN_CMD ${lib.getExe pkgs.uv} tool install "open-webui==0.8.12" --python 3.14
@@ -110,7 +110,7 @@ in
         '';
 
         # browser-use: CLI for browser automation (not in nixpkgs)
-        installBrowserUse = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        installBrowserUse = lib.hm.dag.entryAfter [ "writeBoundary" "knownMarketplacesMerge" ] ''
           if ! ${lib.getExe pkgs.uv} tool list 2>/dev/null | grep -q "^browser-use"; then
             echo "-> Installing browser-use via uv..."
             $DRY_RUN_CMD ${lib.getExe pkgs.uv} tool install "browser-use==0.12.6"


### PR DESCRIPTION
## Summary

- `known_marketplaces.json` was missing the `vct-cribl-pack-validator-skills` entry after PR #630 added the plugin
- Root cause: `set -eu` in the home-manager activation script causes any failing `install*` activation (`installBrowserUse`, `installDocumentSkillNpmDeps`, `installOpenWebui`) to abort the script before `knownMarketplacesMerge` runs — since `k` sorts after `i` alphabetically in DAG evaluation
- Fix: change DAG entry to `lib.hm.dag.entryBetween` so the registry merge runs after `writeBoundary` but **before** the install activations that can fail

## Changes

- `modules/claude/settings.nix`: `knownMarketplacesMerge` activation changed from `entryAfter ["writeBoundary"]` to `entryBetween ["installBrowserUse" "installDocumentSkillNpmDeps" "installOpenWebui"] ["writeBoundary"]`

## Test plan

- [x] `nix flake check` passes (formatting, deadnix, statix, shellcheck, nix-validate)
- [x] Immediate operational fix applied: manual merge confirmed `vct-cribl-pack-validator-skills` now in `known_marketplaces.json`
- [ ] After deployment: confirm `[INFO] Merged known_marketplaces.json` appears before install activation log lines in `darwin-rebuild switch` output
- [ ] Fresh Claude Code session loads `cribl-pack-validator` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)