### PR TITLE
fix(plugins): remove ralph-loop plugin references

### DIFF
--- a/modules/claude/plugins/README.md
+++ b/modules/claude/plugins/README.md
@@ -41,8 +41,7 @@ Registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix).
 
 > **Note on status values**: Each table reflects the value set in the named `.nix` file, not the
 > final merged result. When a plugin appears in multiple sections, the last-merged file wins
-> (see `plugins/default.nix`). For example, `ralph-loop` is `false` in `official.nix` but
-> `true` in `experimental.nix` — the effective result is **enabled**.
+> (see `plugins/default.nix`).
 
 ### Official Anthropic — [`official.nix`](official.nix)
 
@@ -60,7 +59,6 @@ Registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix).
 | `claude-md-management@claude-plugins-official` | enabled | CLAUDE.md management |
 | `pyright-lsp@claude-plugins-official` | enabled | Python type checking LSP |
 | `typescript-lsp@claude-plugins-official` | disabled | Minimal TS usage |
-| `ralph-loop@claude-plugins-official` | disabled | Superseded by native agent teams |
 
 ### External Third-Party — [`external.nix`](external.nix)
 
@@ -158,7 +156,6 @@ are discovered at flake update time and enabled automatically as `*@jacobpevans-
 
 | Plugin | Status | Description |
 | ------ | ------ | ----------- |
-| `ralph-loop@claude-plugins-official` | enabled | Autonomous iteration loops (`/ralph-loop`, `/cancel-ralph`) |
 | `codex@cc-dev-tools` | enabled | OpenAI GPT for high-reasoning coding (community) |
 | `codex@openai-codex` | enabled | Official OpenAI Codex (`/codex:review`, `/codex:rescue`) |
 | `gemini@cc-dev-tools` | enabled | Google Gemini with web search + session resumption |

--- a/modules/claude/plugins/experimental.nix
+++ b/modules/claude/plugins/experimental.nix
@@ -17,13 +17,6 @@ _:
 {
   enabledPlugins = {
     # ========================================================================
-    # Autonomous Iteration
-    # ========================================================================
-    # ralph-loop: autonomous iteration loops with file/git history preservation
-    # Commands: /ralph-loop, /cancel-ralph
-    "ralph-loop@claude-plugins-official" = true;
-
-    # ========================================================================
     # Multi-Model AI Integrations (cc-dev-tools)
     # ========================================================================
     # WARNING: These plugins invoke external AI models (OpenAI, Google)

--- a/modules/claude/plugins/official.nix
+++ b/modules/claude/plugins/official.nix
@@ -51,10 +51,6 @@ _:
     "pyright-lsp@claude-plugins-official" = true;
     "typescript-lsp@claude-plugins-official" = false; # Minimal TS usage
 
-    # Workflow
-    # DISABLED - New Opus 4.7 and Agent Teams sort of handle this
-    "ralph-loop@claude-plugins-official" = false;
-
     # External plugins (GitHub, Slack, Context7, etc.) moved to external.nix
   };
 }


### PR DESCRIPTION
## Summary
- Remove `ralph-loop@claude-plugins-official` from `official.nix` (was already disabled)
- Remove `ralph-loop@claude-plugins-official` from `experimental.nix` (was enabled)
- Remove all `ralph-loop` mentions from `plugins/README.md` (table rows + note)

## Test plan
- [x] `nix flake check` — all 34 checks pass