### PR TITLE
feat(plugins): add huggingface/skills marketplace with hf-cli enabled

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,6 +262,22 @@
         "type": "github"
       }
     },
+    "huggingface-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776941956,
+        "narHash": "sha256-p8sMxWxn6r5wdGo+HAH0p76wO9SZO5pRXt6RkSSOV/8=",
+        "owner": "huggingface",
+        "repo": "skills",
+        "rev": "ddcf68038c45b78adda240b924a427f1e069f4b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "huggingface",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
@@ -376,6 +392,7 @@
         "claude-skills": "claude-skills",
         "fabric-src": "fabric-src",
         "home-manager": "home-manager",
+        "huggingface-skills": "huggingface-skills",
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "lunar-claude": "lunar-claude",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,12 @@
       flake = false;
     };
 
+    # Hugging Face Skills marketplace - hf-cli, datasets, papers, models, gradio, etc.
+    huggingface-skills = {
+      url = "github:huggingface/skills";
+      flake = false;
+    };
+
     # Skill-only repos (no marketplace structure — wrapped via synthetic derivation)
     browser-use-skills = {
       url = "github:browser-use/browser-use";
@@ -146,6 +152,7 @@
       superpowers-marketplace,
       visual-explainer-marketplace,
       wakatime,
+      huggingface-skills,
       browser-use-skills,
       vct-cribl-pack-validator-skills,
       pal-mcp-server,
@@ -165,6 +172,7 @@
           bills-claude-skills
           bitwarden-marketplace
           browser-use-skills
+          huggingface-skills
           vct-cribl-pack-validator-skills
           cc-dev-tools
           cc-marketplace

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -33,6 +33,25 @@ let
     in
     lib.concatMap pluginSkills (builtins.attrNames topDirs);
 
+  # Discovers SKILL.md files from a flat skills/ directory at the repo root.
+  # Pattern: <repo>/skills/<skill-name>/SKILL.md
+  # Used for marketplaces like huggingface/skills that store skills at the top level.
+  discoverFlatSkills =
+    input:
+    let
+      skillsPath = "${input}/skills";
+      hasSkills = builtins.pathExists skillsPath;
+      skillDirs =
+        if hasSkills then
+          lib.filterAttrs (_: type: type == "directory") (builtins.readDir skillsPath)
+        else
+          { };
+    in
+    lib.mapAttrsToList (name: _: {
+      inherit name;
+      source = "${skillsPath}/${name}/SKILL.md";
+    }) (lib.filterAttrs (name: _: builtins.pathExists "${skillsPath}/${name}/SKILL.md") skillDirs);
+
   # Discovers SKILL.md files from a bare .claude/skills/ directory.
   # Pattern: <repo>/.claude/skills/<skill-name>/SKILL.md
   discoverDotClaudeSkills =
@@ -53,9 +72,11 @@ let
 
   # Skills from JacobPEvans/claude-code-plugins (tool-agnostic markdown)
   # Plus VisiCore cribl-pack-validator (bare .claude/skills/ layout)
+  # Plus Hugging Face Hub skills (flat skills/<n>/SKILL.md layout)
   sharedSkills =
     discoverSkills marketplaceInputs.jacobpevans-cc-plugins
-    ++ discoverDotClaudeSkills marketplaceInputs.vct-cribl-pack-validator-skills;
+    ++ discoverDotClaudeSkills marketplaceInputs.vct-cribl-pack-validator-skills
+    ++ discoverFlatSkills marketplaceInputs.huggingface-skills;
 in
 {
   imports = [

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -40,17 +40,20 @@ let
     input:
     let
       skillsPath = "${input}/skills";
-      hasSkills = builtins.pathExists skillsPath;
-      skillDirs =
-        if hasSkills then
-          lib.filterAttrs (_: type: type == "directory") (builtins.readDir skillsPath)
-        else
-          { };
     in
-    lib.mapAttrsToList (name: _: {
-      inherit name;
-      source = "${skillsPath}/${name}/SKILL.md";
-    }) (lib.filterAttrs (name: _: builtins.pathExists "${skillsPath}/${name}/SKILL.md") skillDirs);
+    if builtins.pathExists skillsPath then
+      lib.mapAttrsToList
+        (name: _: {
+          inherit name;
+          source = "${skillsPath}/${name}/SKILL.md";
+        })
+        (
+          lib.filterAttrs (
+            name: type: type == "directory" && builtins.pathExists "${skillsPath}/${name}/SKILL.md"
+          ) (builtins.readDir skillsPath)
+        )
+    else
+      [ ];
 
   # Discovers SKILL.md files from a bare .claude/skills/ directory.
   # Pattern: <repo>/.claude/skills/<skill-name>/SKILL.md

--- a/modules/claude/plugins/README.md
+++ b/modules/claude/plugins/README.md
@@ -34,6 +34,7 @@ Registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix).
 | `cc-dev-tools` | `Lucklyric/cc-dev-tools` | AI Integrations |
 | `wakatime` | `wakatime/claude-code-wakatime` | Time Tracking |
 | `openai-codex` | `openai/codex-plugin-cc` | AI Integrations |
+| `huggingface-skills` | `huggingface/skills` | AI/ML |
 | `browser-use-skills` | `browser-use/browser-use` | Synthetic |
 | `fabric-patterns` | `danielmiessler/fabric` | Synthetic |
 
@@ -95,6 +96,7 @@ Registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix).
 | `claude-retrospective@bitwarden-marketplace` | enabled | 3 skills: retrospecting, session data, git analysis |
 | `claude-config-validator@bitwarden-marketplace` | enabled | 1 skill: reviewing-claude-config |
 | `browser-use@browser-use-skills` | enabled | Browser automation (requires `browser-use` via uv) |
+| `hf-cli@huggingface-skills` | enabled | HF CLI: download/upload models, datasets, manage Hub repos |
 
 ### Infrastructure — [`infrastructure.nix`](infrastructure.nix)
 

--- a/modules/claude/plugins/community.nix
+++ b/modules/claude/plugins/community.nix
@@ -6,6 +6,7 @@
 # - visual-explainer-marketplace: Rich HTML diagrams, diff reviews, slides (nicobailon)
 # - bitwarden-marketplace: Enterprise-grade session analysis and config validation
 # - browser-use-skills: Browser automation (synthetic marketplace — repo lacks native structure)
+# - huggingface-skills: HF CLI, datasets, papers, local models, gradio, and more
 
 _:
 
@@ -46,6 +47,9 @@ _:
 
     # Browser Automation - browser-use (CLI skills require `browser-use` installed via uv)
     "browser-use@browser-use-skills" = true;
+
+    # Hugging Face Skills - hf CLI for Hub operations (download/upload models, manage repos)
+    "hf-cli@huggingface-skills" = true;
 
     # REMOVED - redundant or unused:
     # double-check - unnecessary

--- a/modules/claude/plugins/marketplaces.nix
+++ b/modules/claude/plugins/marketplaces.nix
@@ -109,6 +109,12 @@ let
         url = "anthropics/skills";
       };
     };
+    "huggingface-skills" = {
+      source = {
+        type = "github";
+        url = "huggingface/skills";
+      };
+    };
 
     # --- Community ---
     "cc-marketplace" = {

--- a/modules/claude/plugins/marketplaces.nix
+++ b/modules/claude/plugins/marketplaces.nix
@@ -109,6 +109,8 @@ let
         url = "anthropics/skills";
       };
     };
+
+    # --- AI/ML ---
     "huggingface-skills" = {
       source = {
         type = "github";


### PR DESCRIPTION
## Summary

Wires `huggingface/skills` as a native Claude Code marketplace—no synthesis needed, the repo ships a proper `.claude-plugin/marketplace.json` with 13 plugins. Enables `hf-cli@huggingface-skills` for Hub operations (download/upload models, manage repos).

Adds `discoverFlatSkills` helper to agent-skills discovery, populating `~/.agents/skills/<n>/SKILL.md` for Gemini/Codex consumers from the flat `skills/<n>/SKILL.md` layout HuggingFace uses.

## Changes

- Add `huggingface-skills` as flake input (locks at commit `ddcf680`, 2026-04-23)
- Enable marketplace in `modules/claude/plugins/marketplaces.nix` with `hf-cli` entrypoint
- Implement `discoverFlatSkills` in `modules/agent-skills/default.nix` for flat skill discovery
- Move `huggingface-skills` into AI/ML marketplace section (separate from Official Anthropic)
- Auto-update: Renovate bumps `huggingface-skills` in `flake.lock` → next rebuild refreshes skill content

## Test Plan

- [x] `nix flake check` — all 35 checks pass (agent-skills-home-files, deadnix, statix, shellcheck, formatting)
- [ ] `sudo darwin-rebuild switch --flake "$HOME/git/nix-darwin/main" --override-input nix-ai "$HOME/git/nix-ai/<worktree>`
- [ ] Verify marketplace symlink: `readlink ~/.claude/plugins/marketplaces/huggingface-skills`
- [ ] Verify agent skill: `readlink ~/.agents/skills/hf-cli/SKILL.md`
- [ ] Fresh Claude Code session: `hf-cli` skill loads from marketplace
- [ ] Cleanup: remove stale files `~/.claude/skills/hf-cli/SKILL.md` and `~/.agents/skills/hf-cli/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)