### PR TITLE
feat(mlx): run model auto-discovery on every darwin-rebuild switch

### DIFF
--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -82,6 +82,13 @@ in
       run ${pkgs.python3}/bin/python3 "${./seed-config.py}" "${llamaSwapConfigFile}" "${llamaSwapRuntimeConfigPath}"
     '';
 
+    home.activation.discoverMlxModels = lib.hm.dag.entryAfter [ "seedLlamaSwapConfig" ] ''
+      export MLX_HF_HOME="${cfg.huggingFaceHome}"
+      export MLX_LLAMA_SWAP_CONFIG="${llamaSwapRuntimeConfigPath}"
+      export MLX_LLAMA_SWAP_BASE_CONFIG="${llamaSwapConfigFile}"
+      run ${pkgs.python3}/bin/python3 "${./discover-models.py}" --quiet || true
+    '';
+
     launchd.agents.vllm-mlx-logrotate = {
       enable = true;
       config = {

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -84,13 +84,13 @@ in
       '';
 
       # Auto-discover newly downloaded HF models and register them with llama-swap.
-      # Runs after seeding so the runtime config exists. Uses || true so a transient
-      # HF volume absence does not abort the activation.
+      # Runs after seeding so the runtime config exists. The script exits 0 when
+      # the HF volume is absent (scan_models returns []), so no || true needed.
       activation.discoverMlxModels = lib.hm.dag.entryAfter [ "seedLlamaSwapConfig" ] ''
         export MLX_HF_HOME="${cfg.huggingFaceHome}"
         export MLX_LLAMA_SWAP_CONFIG="${llamaSwapRuntimeConfigPath}"
         export MLX_LLAMA_SWAP_BASE_CONFIG="${llamaSwapConfigFile}"
-        run ${pkgs.python3}/bin/python3 "${./discover-models.py}" --quiet || true
+        run ${pkgs.python3}/bin/python3 "${./discover-models.py}" --quiet
       '';
     };
 

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -60,34 +60,39 @@ in
       };
     };
 
-    # ==========================================================================
-    # Log Rotation (closes #255)
-    # ==========================================================================
-    # newsyslog rotates logs when they exceed 10MB, keeping 3 compressed archives.
-    # Stock macOS newsyslog only reads /etc/newsyslog.d/ (requires root), so a
-    # companion LaunchAgent invokes it hourly with our user-level config.
-    home.file.".config/newsyslog.d/vllm-mlx.conf".text = ''
-      # logfilename                                                                [owner:group]  mode  count  size  when  flags
-      ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log        :              644   3      10240 *     J
-      ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log              :              644   3      10240 *     J
-    '';
+    home = {
+      # ==========================================================================
+      # Log Rotation (closes #255)
+      # ==========================================================================
+      # newsyslog rotates logs when they exceed 10MB, keeping 3 compressed archives.
+      # Stock macOS newsyslog only reads /etc/newsyslog.d/ (requires root), so a
+      # companion LaunchAgent invokes it hourly with our user-level config.
+      file.".config/newsyslog.d/vllm-mlx.conf".text = ''
+        # logfilename                                                                [owner:group]  mode  count  size  when  flags
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log        :              644   3      10240 *     J
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log              :              644   3      10240 *     J
+      '';
 
-    # ==========================================================================
-    # Runtime Config Seeding
-    # ==========================================================================
-    # On activation (darwin-rebuild switch), seed the mutable runtime config
-    # from the Nix-generated base config. Preserves runtime-discovered models
-    # by only overwriting when the base config has actually changed.
-    home.activation.seedLlamaSwapConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      run ${pkgs.python3}/bin/python3 "${./seed-config.py}" "${llamaSwapConfigFile}" "${llamaSwapRuntimeConfigPath}"
-    '';
+      # ==========================================================================
+      # Runtime Config Seeding and Model Discovery
+      # ==========================================================================
+      # On activation (darwin-rebuild switch), seed the mutable runtime config
+      # from the Nix-generated base config. Preserves runtime-discovered models
+      # by only overwriting when the base config has actually changed.
+      activation.seedLlamaSwapConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        run ${pkgs.python3}/bin/python3 "${./seed-config.py}" "${llamaSwapConfigFile}" "${llamaSwapRuntimeConfigPath}"
+      '';
 
-    home.activation.discoverMlxModels = lib.hm.dag.entryAfter [ "seedLlamaSwapConfig" ] ''
-      export MLX_HF_HOME="${cfg.huggingFaceHome}"
-      export MLX_LLAMA_SWAP_CONFIG="${llamaSwapRuntimeConfigPath}"
-      export MLX_LLAMA_SWAP_BASE_CONFIG="${llamaSwapConfigFile}"
-      run ${pkgs.python3}/bin/python3 "${./discover-models.py}" --quiet || true
-    '';
+      # Auto-discover newly downloaded HF models and register them with llama-swap.
+      # Runs after seeding so the runtime config exists. Uses || true so a transient
+      # HF volume absence does not abort the activation.
+      activation.discoverMlxModels = lib.hm.dag.entryAfter [ "seedLlamaSwapConfig" ] ''
+        export MLX_HF_HOME="${cfg.huggingFaceHome}"
+        export MLX_LLAMA_SWAP_CONFIG="${llamaSwapRuntimeConfigPath}"
+        export MLX_LLAMA_SWAP_BASE_CONFIG="${llamaSwapConfigFile}"
+        run ${pkgs.python3}/bin/python3 "${./discover-models.py}" --quiet || true
+      '';
+    };
 
     launchd.agents.vllm-mlx-logrotate = {
       enable = true;


### PR DESCRIPTION
## Summary

Auto-discover newly downloaded HuggingFace models on every `darwin-rebuild switch` without manual `mlx-discover` invocation. The `home.activation.discoverMlxModels` hook runs `discover-models.py` after `seedLlamaSwapConfig`, registering new models with llama-swap atomically.

## Changes

- Add `home.activation.discoverMlxModels` to `modules/mlx/launchd.nix` — runs after `seedLlamaSwapConfig` on every rebuild
- Models registered in `~/.config/mlx/llama-swap.json` are skipped on subsequent rebuilds (skip already-registered entries before computing sizes)
- Runtime overhead negligible on common case (no new models): sysctl + directory glob only
- Merge repeated `home.*` attributes into single `home = { ... }` block (fixes statix W20)
- Remove `|| true` guard from activation hook — errors are now visible during rebuild

## Test Plan

- [ ] `darwin-rebuild switch` with no new models: activation completes, no changes to `~/.config/mlx/llama-swap.json`
- [ ] `darwin-rebuild switch` after downloading a new model: model appears in `curl http://127.0.0.1:11434/v1/models` output
- [ ] `darwin-rebuild switch` with HF volume unmounted: activation succeeds (handles missing mount gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)