### PR TITLE
docs: add CI badge to nix-ai README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nix-ai
 
+[![CI](https://github.com/JacobPEvans/nix-ai/actions/workflows/ci-gate.yml/badge.svg)](https://github.com/JacobPEvans/nix-ai/actions/workflows/ci-gate.yml)
+
 ## Your AI coding toolkit, declared once. Reproduced everywhere
 
 Ever spent hours configuring Claude Code plugins, Gemini settings, and MCP servers


### PR DESCRIPTION
## Summary

Auto-generated documentation improvement from the Daily Polish routine (2026-04-28).

Adds a CI status badge to the README, linking to the `ci-gate.yml` workflow.

## Changes

- README.md: Added CI badge after repo title

## Notes

- Original commit (ed75d31) was unsigned (cloud sandbox limitation)
- Re-signed in-place to 59bbd89 via `git commit --amend -S` + force-push-with-lease
- Commit message: `docs(nix-ai): add CI badge [daily-polish-2026-04-28]`

---

Generated by [Daily Polish](https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/daily-polish.prompt.md)