### PR TITLE
fix: centralize agent skills and MCP config

### DIFF
--- a/docs/architecture/secrets-and-injection.md
+++ b/docs/architecture/secrets-and-injection.md
@@ -105,7 +105,7 @@ This is the cleanest pattern: zero credential exposure outside the cluster bound
 
 ## What NOT to Do
 
-- **Never put secrets in `env:` blocks of MCP server definitions** in `modules/mcp/default.nix`.
+- **Never put secrets in `env:` blocks of MCP server definitions** in `programs.aiMcp.servers`.
   These flow into `~/.claude.json`, which is not secret-protected. They also appear in
   the Nix store derivation (world-readable at `/nix/store/`).
 - **Never hardcode API keys in Nix expressions.** Even in a private repo, they end up

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -86,17 +86,17 @@ graph TD
 
 ## MCP Server Connectivity
 
-The MCP server catalog (`modules/mcp/default.nix`) is a **shared Nix attribute set** consumed
-by Claude, Gemini, and Codex — each normalizes server entries differently via their own
-settings modules.
+The MCP server catalog (`modules/mcp/catalog.nix`) is exposed by the dedicated
+MCP module as `programs.aiMcp.servers`. Claude, Gemini, and Codex each normalize
+that shared option differently via their own settings modules.
 
 ```mermaid
 graph LR
-    MCPCAT["modules/mcp/default.nix\n(shared catalog)"]
+    MCPCAT["modules/mcp/catalog.nix\nprograms.aiMcp.servers"]
 
-    MCPCAT -->|programs.claude.mcpServers| CSETTINGS["modules/claude/settings.nix\n→ ~/.claude.json"]
-    MCPCAT -->|programs.gemini.mcpServers| GSETTINGS["modules/gemini/settings.nix\n→ ~/.gemini/settings.json"]
-    MCPCAT -->|programs.codex.mcpServers| DSETTINGS["modules/codex/settings.nix\n→ ~/.codex/config.toml"]
+    MCPCAT -->|normalized for Claude| CSETTINGS["modules/claude/settings.nix\n→ ~/.claude.json"]
+    MCPCAT -->|normalized for Gemini| GSETTINGS["modules/gemini/settings.nix\n→ ~/.gemini/settings.json"]
+    MCPCAT -->|normalized for Codex| DSETTINGS["modules/codex/settings.nix\n→ ~/.codex/config.toml"]
 ```
 
 ### Shared MCP Servers (all three CLI tools)
@@ -104,7 +104,8 @@ graph LR
 | Server | Transport | Auth | Notes |
 |--------|-----------|------|-------|
 | `everything`, `fetch`, `filesystem`, `git`, `memory` | stdio (bunx) | None | Official Anthropic servers |
-| `sequentialthinking`, `time`, `docker` | stdio (bunx) | None | Official Anthropic servers |
+| `sequentialthinking`, `docker` | stdio (bunx) | None | Official Anthropic servers |
+| `time` | stdio (uvx) | None | Official maintained Python server |
 | `aws` | stdio (bunx) | IAM/STS env vars | AWS KB retrieval |
 | `terraform` | stdio (binary) | None | nixpkgs binary |
 | `pal` | stdio (wrapper) | Doppler | Multi-model orchestration |
@@ -126,7 +127,7 @@ graph LR
 
 `brave-search`, `cloudflare`, `exa`, `firecrawl`, `github`, `google-maps`, `postgresql`,
 `puppeteer`, `sentry`, `slack`, `sqlite` — all require API keys not currently configured.
-Enable by removing `disabled = true` in `modules/mcp/default.nix` and adding the key to Doppler.
+Enable by overriding `programs.aiMcp.servers.<name>.disabled` and adding the key to Doppler.
 
 ## Port Allocation
 

--- a/flake.nix
+++ b/flake.nix
@@ -236,8 +236,13 @@
           };
         };
 
+        mcp = {
+          imports = [ ./modules/mcp ];
+        };
+
         codex = {
           imports = [
+            ./modules/mcp
             ./modules/agent-skills
             ./modules/codex
           ];
@@ -251,6 +256,7 @@
 
         gemini = {
           imports = [
+            ./modules/mcp
             ./modules/agent-skills
             ./modules/gemini
           ];

--- a/lib/checks/agent-skills.nix
+++ b/lib/checks/agent-skills.nix
@@ -4,6 +4,9 @@ let
   cfg = hmConfig.config.programs.agentSkills;
   homeFileNames = builtins.attrNames hmConfig.config.home.file;
   managedSkillEntries = builtins.filter (
+    n: builtins.match "^\\.agents/skills/[^/]+$" n != null
+  ) homeFileNames;
+  legacySkillFileEntries = builtins.filter (
     n: builtins.match "^\\.agents/skills/.+/SKILL\\.md$" n != null
   ) homeFileNames;
 in
@@ -63,9 +66,18 @@ in
   agent-skills-home-files =
     let
       keepFile = hmConfig.config.home.file.".agents/.keep".text;
+      missingSkillFiles = builtins.filter (
+        n: !(builtins.pathExists "${hmConfig.config.home.file.${n}.source}/SKILL.md")
+      ) managedSkillEntries;
     in
     assert keepFile != "" || throw "Agent Skills .agents/.keep file is empty (module not loaded)";
     assert builtins.length managedSkillEntries > 0 || throw "No managed .agents skill entries found";
+    assert
+      legacySkillFileEntries == [ ]
+      || throw "Agent Skills must deploy skill directories, not SKILL.md files: ${builtins.toJSON legacySkillFileEntries}";
+    assert
+      missingSkillFiles == [ ]
+      || throw "Agent Skills directory entries missing SKILL.md: ${builtins.toJSON missingSkillFiles}";
     pkgs.runCommand "check-agent-skills-home-files" { } ''
       echo "Agent Skills home.file wiring: ${toString (builtins.length managedSkillEntries)} managed skill entries"
       touch $out

--- a/lib/checks/codex.nix
+++ b/lib/checks/codex.nix
@@ -2,6 +2,7 @@
 { pkgs, hmConfig }:
 let
   cfg = hmConfig.config.programs.codex;
+  homeFileNames = builtins.attrNames hmConfig.config.home.file;
 in
 {
   # Verify all expected Codex option paths exist.
@@ -18,6 +19,7 @@ in
         "modelReasoningEffort"
         "modelVerbosity"
         "planModeReasoningEffort"
+        "projectDocFallbackFilenames"
         "reviewModel"
         "serviceTier"
         "trustedProjectDirs"
@@ -102,6 +104,11 @@ in
           expected = [ ];
         }
         {
+          name = "codex.projectDocFallbackFilenames";
+          actual = cfg.projectDocFallbackFilenames;
+          expected = [ "AGENTS.md" ];
+        }
+        {
           name = "codex.hooks.notification";
           actual = cfg.hooks.notification;
           expected = null;
@@ -122,6 +129,14 @@ in
 
   # Validate the activation package builds (forces config.toml generation).
   codex-settings-toml = builtins.seq hmConfig.activationPackage (
+    let
+      disallowedCodexFiles = builtins.filter (
+        n: n == "GEMINI.md" || builtins.match "^\\.codex/skills(/.*)?$" n != null
+      ) homeFileNames;
+    in
+    assert
+      disallowedCodexFiles == [ ]
+      || throw "Codex must not deploy tool-specific shared skills or GEMINI.md: ${builtins.toJSON disallowedCodexFiles}";
     pkgs.runCommand "check-codex-settings-toml" { } ''
       echo "Codex settings: activation package builds successfully (config.toml generation verified)"
       touch $out

--- a/lib/checks/gemini.nix
+++ b/lib/checks/gemini.nix
@@ -2,6 +2,7 @@
 { pkgs, hmConfig }:
 let
   cfg = hmConfig.config.programs.gemini;
+  homeFileNames = builtins.attrNames hmConfig.config.home.file;
 in
 {
   # Verify all expected Gemini option paths exist.
@@ -38,6 +39,11 @@ in
           name = "gemini.trustedFolders";
           actual = cfg.trustedFolders;
           expected = [ ];
+        }
+        {
+          name = "gemini.contextFileNames";
+          actual = cfg.contextFileNames;
+          expected = [ "AGENTS.md" ];
         }
         {
           name = "gemini.excludedMcpServers.length";
@@ -128,8 +134,17 @@ in
   gemini-module-loaded =
     let
       keepFile = hmConfig.config.home.file.".gemini/.keep".text;
+      disallowedGeminiFiles = builtins.filter (
+        n:
+        n == "GEMINI.md"
+        || builtins.match "^\\.gemini/skills(/.*)?$" n != null
+        || builtins.match "^\\.gemini/extensions/[^/]+/skills(/.*)?$" n != null
+      ) homeFileNames;
     in
     assert keepFile != "" || throw "Gemini .keep file is empty (module not loaded)";
+    assert
+      disallowedGeminiFiles == [ ]
+      || throw "Gemini must not deploy skills or GEMINI.md: ${builtins.toJSON disallowedGeminiFiles}";
     pkgs.runCommand "check-gemini-module-loaded" { } ''
       echo "Gemini module: .keep file present, module loaded successfully"
       touch $out

--- a/modules/agent-skills/components.nix
+++ b/modules/agent-skills/components.nix
@@ -5,14 +5,16 @@
 
 let
   cfg = config.programs.agentSkills;
+  homeDir = config.home.homeDirectory;
+  skillDir = source: builtins.dirOf source;
 
   mkSkillFiles =
     components:
     builtins.listToAttrs (
       map (c: {
-        name = ".agents/skills/${c.name}/SKILL.md";
+        name = ".agents/skills/${c.name}";
         value = {
-          inherit (c) source;
+          source = skillDir c.source;
           force = true;
         };
       }) components
@@ -21,20 +23,48 @@ let
   mkLocalSkills =
     locals:
     lib.concatMapAttrs (name: path: {
-      ".agents/skills/${name}/SKILL.md" = {
-        source = path;
+      ".agents/skills/${name}" = {
+        source = skillDir path;
         force = true;
       };
     }) locals;
 in
 {
   config = lib.mkIf cfg.enable {
-    home.file = {
-      ".agents/.keep".text = ''
-        # Managed by Nix - programs.agentSkills module
+    home = {
+      activation.cleanupLegacySkillCopies = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
+        cleanup_skill_tree() {
+          root="$1"
+
+          [ -d "$root" ] || return 0
+
+          find "$root" -mindepth 1 -maxdepth 1 -type d -print | while IFS= read -r skill_dir; do
+            skill_file="$skill_dir/SKILL.md"
+            if [ -L "$skill_file" ] && [ "$(find "$skill_dir" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = "1" ]; then
+              target=$(readlink "$skill_file")
+              case "$target" in
+                /nix/store/*)
+                  $DRY_RUN_CMD rm -rf "$skill_dir"
+                  ;;
+              esac
+            fi
+          done
+
+          rmdir "$root" 2>/dev/null || true
+        }
+
+        cleanup_skill_tree "${homeDir}/.agents/skills"
+        cleanup_skill_tree "${homeDir}/.codex/skills"
+        cleanup_skill_tree "${homeDir}/.gemini/skills"
       '';
-    }
-    // mkSkillFiles cfg.fromFlakeInputs
-    // mkLocalSkills cfg.local;
+
+      file = {
+        ".agents/.keep".text = ''
+          # Managed by Nix - programs.agentSkills module
+        '';
+      }
+      // mkSkillFiles cfg.fromFlakeInputs
+      // mkLocalSkills cfg.local;
+    };
   };
 }

--- a/modules/agent-skills/components.nix
+++ b/modules/agent-skills/components.nix
@@ -38,7 +38,7 @@ in
 
           [ -d "$root" ] || return 0
 
-          find "$root" -mindepth 1 -maxdepth 1 -type d -print | while IFS= read -r skill_dir; do
+          find "$root" -mindepth 1 -maxdepth 1 -type d -print0 | while IFS= read -r -d $'\0' skill_dir; do
             skill_file="$skill_dir/SKILL.md"
             if [ -L "$skill_file" ] && [ "$(find "$skill_dir" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = "1" ]; then
               target=$(readlink "$skill_file")
@@ -50,7 +50,7 @@ in
             fi
           done
 
-          rmdir "$root" 2>/dev/null || true
+          $DRY_RUN_CMD rmdir "$root" 2>/dev/null || true
         }
 
         cleanup_skill_tree "${homeDir}/.agents/skills"

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -2,7 +2,12 @@
 #
 # Declarative configuration for shared cross-tool skills.
 # Discovers plugin skills and deploys them to ~/.agents/skills.
-{ lib, marketplaceInputs, ... }:
+{
+  lib,
+  pkgs,
+  marketplaceInputs,
+  ...
+}:
 
 let
   # Discovers SKILL.md files from plugin repos.
@@ -32,6 +37,67 @@ let
           );
     in
     lib.concatMap pluginSkills (builtins.attrNames topDirs);
+
+  # Translates Claude commands (commands/*.md) dynamically into Agent Skills (SKILL.md).
+  # Pattern: <plugin>/commands/<command-name>.md
+  discoverClaudeCommands =
+    input:
+    let
+      topDirs = lib.filterAttrs (_: type: type == "directory") (builtins.readDir input);
+      pluginCommands =
+        pluginName:
+        let
+          commandsPath = "${input}/${pluginName}/commands";
+          hasCommands = builtins.pathExists commandsPath;
+          commandFiles =
+            if hasCommands then
+              lib.filterAttrs (name: type: type == "regular" && lib.hasSuffix ".md" name) (
+                builtins.readDir commandsPath
+              )
+            else
+              { };
+        in
+        lib.mapAttrsToList (
+          fileName: _:
+          let
+            commandName = lib.removeSuffix ".md" fileName;
+            skillName = "${pluginName}-${commandName}";
+            originalFile = "${commandsPath}/${fileName}";
+
+            wrappedSkillDir = pkgs.runCommand "wrap-claude-command-${skillName}" { } ''
+              mkdir -p $out
+              cat << 'EOF' > $out/SKILL.md
+              ---
+              name: ${skillName}
+              description: Claude plugin command imported from ${pluginName}/${commandName}.
+              ---
+
+              # `${skillName}`
+
+              This skill was automatically imported from the Claude command `${pluginName}:${commandName}`.
+
+              <instructions>
+              Please read the following original Claude command specification and fulfill its intent.
+              If the specification contains syntax like `!` followed by a shell command (e.g. `!git status`), you MUST execute that command using your bash/shell tools to gather the necessary context before proceeding.
+
+              <original_command>
+              EOF
+
+              cat ${originalFile} >> $out/SKILL.md
+
+              cat << 'EOF' >> $out/SKILL.md
+              </original_command>
+              </instructions>
+              EOF
+            '';
+          in
+          {
+            name = skillName;
+            source = "${wrappedSkillDir}/SKILL.md";
+          }
+        ) commandFiles;
+    in
+    lib.concatMap pluginCommands (builtins.attrNames topDirs);
 
   # Discovers SKILL.md files from a flat skills/ directory at the repo root.
   # Pattern: <repo>/skills/<skill-name>/SKILL.md
@@ -76,10 +142,15 @@ let
   # Skills from JacobPEvans/claude-code-plugins (tool-agnostic markdown)
   # Plus VisiCore cribl-pack-validator (bare .claude/skills/ layout)
   # Plus Hugging Face Hub skills (flat skills/<n>/SKILL.md layout)
+  # Plus official Claude plugin skills and translated commands
   sharedSkills =
     discoverSkills marketplaceInputs.jacobpevans-cc-plugins
     ++ discoverDotClaudeSkills marketplaceInputs.vct-cribl-pack-validator-skills
-    ++ discoverFlatSkills marketplaceInputs.huggingface-skills;
+    ++ discoverFlatSkills marketplaceInputs.huggingface-skills
+    ++ discoverSkills "${marketplaceInputs.claude-plugins-official}/plugins"
+    ++ discoverSkills "${marketplaceInputs.claude-plugins-official}/external_plugins"
+    ++ discoverClaudeCommands "${marketplaceInputs.claude-plugins-official}/plugins"
+    ++ discoverClaudeCommands "${marketplaceInputs.claude-plugins-official}/external_plugins";
 in
 {
   imports = [

--- a/modules/agent-skills/options.nix
+++ b/modules/agent-skills/options.nix
@@ -24,7 +24,7 @@ in
     local = lib.mkOption {
       type = lib.types.attrsOf lib.types.path;
       default = { };
-      description = "Local skill files (name -> path to SKILL.md)";
+      description = "Local skill files (name -> path to SKILL.md; the containing skill directory is deployed)";
     };
   };
 }

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -88,6 +88,25 @@ let
       source = "${sourcePath}/${name}.md";
     }) names;
 
+  normalizeClaudeMcpServer =
+    server:
+    lib.filterAttrs (
+      name: value:
+      lib.elem name [
+        "type"
+        "command"
+        "args"
+        "env"
+        "url"
+        "headers"
+        "disabled"
+      ]
+      && value != null
+      && value != [ ]
+      && value != { }
+      && !(name == "disabled" && !value)
+    ) server;
+
 in
 {
   enable = true;
@@ -307,9 +326,8 @@ in
   };
 
   # MCP Servers - deployed to ~/.claude.json via home.activation (see claude/settings.nix).
-  # Nix is the sole manager of user-scoped MCP servers; manual `claude mcp add --scope user`
-  # entries will be overwritten on next darwin-rebuild switch.
-  mcpServers = import ./mcp;
+  # Shared definitions are owned by modules/mcp and rendered per-client here.
+  mcpServers = lib.mapAttrs (_: normalizeClaudeMcpServer) config.programs.aiMcp.servers;
 
   statusLine = {
     enable = true;

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -327,7 +327,9 @@ in
 
   # MCP Servers - deployed to ~/.claude.json via home.activation (see claude/settings.nix).
   # Shared definitions are owned by modules/mcp and rendered per-client here.
-  mcpServers = lib.mapAttrs (_: normalizeClaudeMcpServer) config.programs.aiMcp.servers;
+  mcpServers = lib.mapAttrs (
+    _: server: normalizeClaudeMcpServer server
+  ) config.programs.aiMcp.servers;
 
   statusLine = {
     enable = true;

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -327,9 +327,7 @@ in
 
   # MCP Servers - deployed to ~/.claude.json via home.activation (see claude/settings.nix).
   # Shared definitions are owned by modules/mcp and rendered per-client here.
-  mcpServers = lib.mapAttrs (
-    _: server: normalizeClaudeMcpServer server
-  ) config.programs.aiMcp.servers;
+  mcpServers = lib.mapAttrs (_: normalizeClaudeMcpServer) config.programs.aiMcp.servers;
 
   statusLine = {
     enable = true;

--- a/modules/claude/rules/pal-mcp-policy.md
+++ b/modules/claude/rules/pal-mcp-policy.md
@@ -106,6 +106,6 @@ If PAL fails after the protocol:
 
 - **Bifrost health**: `curl http://localhost:30080/health`
 - **Bifrost model catalog**: `curl http://localhost:30080/v1/models`
-- **Bifrost MCP registration**: `bifrost` block in `modules/mcp/default.nix`
+- **Bifrost MCP registration**: `bifrost` block in `modules/mcp/catalog.nix`
 - **Phase 3 audit matrix** (full PAL → native mapping):
   [JacobPEvans/nix-ai#450](https://github.com/JacobPEvans/nix-ai/issues/450)

--- a/modules/claude/scripts/cleanup-runtime-data.sh
+++ b/modules/claude/scripts/cleanup-runtime-data.sh
@@ -11,8 +11,12 @@
 
 set -euo pipefail
 
-# shellcheck source=cleanup-common.sh
-. "$(dirname "$0")/cleanup-common.sh"
+if [[ -f "$(dirname "$0")/cleanup-common.sh" ]]; then
+  # shellcheck source=cleanup-common.sh
+  . "$(dirname "$0")/cleanup-common.sh"
+else
+  log_info() { echo "$(date '+%Y-%m-%d %H:%M:%S') [INFO] $1" >&2; }
+fi
 
 HOME_DIR="${1:?HOME_DIR required}"
 RETENTION_DAYS="${2:-30}"
@@ -67,7 +71,9 @@ prune_dir_by_age() {
     count=$((count + 1))
   done < <(find "$dir" -mindepth 1 -maxdepth 1 -mtime +"$RETENTION_DAYS" -print0 2>/dev/null)
 
-  [[ $count -gt 0 ]] && log_info "Pruned $count stale $label entries"
+  if [[ $count -gt 0 ]]; then
+    log_info "Pruned $count stale $label entries"
+  fi
 }
 
 prune_files_by_age() {
@@ -81,7 +87,9 @@ prune_files_by_age() {
     rm -f "$f"
     count=$((count + 1))
   done < <(find "$dir" -mindepth 1 -maxdepth 1 -type f -mtime +"$days" -print0 2>/dev/null)
-  [[ $count -gt 0 ]] && log_info "Pruned $count stale $label files"
+  if [[ $count -gt 0 ]]; then
+    log_info "Pruned $count stale $label files"
+  fi
 }
 
 # ────────────────────────────────────────────────
@@ -94,7 +102,9 @@ if [[ -d "${CLAUDE_DIR}/telemetry" ]]; then
     rm -f "$f"
     count=$((count + 1))
   done < <(find "${CLAUDE_DIR}/telemetry" -name "1p_failed_events*" -print0 2>/dev/null)
-  [[ $count -gt 0 ]] && log_info "Removed $count failed telemetry events"
+  if [[ $count -gt 0 ]]; then
+    log_info "Removed $count failed telemetry events"
+  fi
 fi
 
 # ────────────────────────────────────────────────
@@ -107,7 +117,9 @@ while IFS= read -r -d $'\0' f; do
   rm -f "$f"
   stale_warnings=$((stale_warnings + 1))
 done < <(find "${CLAUDE_DIR}" -maxdepth 1 -name "security_warnings_state_*.json" -print0 2>/dev/null)
-[[ $stale_warnings -gt 0 ]] && log_info "Removed $stale_warnings stale security_warnings_state files"
+if [[ $stale_warnings -gt 0 ]]; then
+  log_info "Removed $stale_warnings stale security_warnings_state files"
+fi
 
 # ────────────────────────────────────────────────
 # 3. projects/ + session-keyed runtime data dirs

--- a/modules/claude/scripts/verify-cache-integrity.sh
+++ b/modules/claude/scripts/verify-cache-integrity.sh
@@ -86,7 +86,8 @@ fi
 # resolved at session start — deleting them mid-session causes an unbreakable error
 # loop (every hook fails, including Stop). By also skipping the hash file update,
 # the next rebuild will re-detect staleness and purge when no sessions are active.
-if [[ "$stale_detected" == true ]] && pgrep -qx "claude"; then
+PGREP_BIN=$(command -v pgrep || true)
+if [[ -n "$PGREP_BIN" && "$stale_detected" == true ]] && "$PGREP_BIN" -qx "claude"; then
   log_info "Stale caches detected but Claude Code session is active — deferring purge"
   exit 0
 fi

--- a/modules/codex/options.nix
+++ b/modules/codex/options.nix
@@ -97,6 +97,13 @@ in
       description = "Additional directories to trust (merged with shared permission dirs)";
     };
 
+    projectDocFallbackFilenames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Project doc fallback filenames emitted to Codex config.toml; read-only.";
+    };
+
     # Approval policy
     approvalPolicy = lib.mkOption {
       type = lib.types.enum [

--- a/modules/codex/options.nix
+++ b/modules/codex/options.nix
@@ -101,6 +101,7 @@ in
       type = lib.types.listOf lib.types.str;
       readOnly = true;
       internal = true;
+      default = [ ];
       description = "Project doc fallback filenames emitted to Codex config.toml; read-only.";
     };
 

--- a/modules/codex/options.nix
+++ b/modules/codex/options.nix
@@ -101,7 +101,6 @@ in
       type = lib.types.listOf lib.types.str;
       readOnly = true;
       internal = true;
-      default = [ ];
       description = "Project doc fallback filenames emitted to Codex config.toml; read-only.";
     };
 

--- a/modules/codex/settings.nix
+++ b/modules/codex/settings.nix
@@ -42,7 +42,7 @@ let
     server:
     let
       allowedKeys =
-        if server ? url then
+        if server.url != null then
           [
             "bearer_token_env_var"
             "disabled_tools"
@@ -70,17 +70,15 @@ let
             "tool_timeout_sec"
           ];
     in
-    lib.filterAttrs (name: value: lib.elem name allowedKeys && value != null) server;
+    lib.filterAttrs (
+      name: value: lib.elem name allowedKeys && value != null && value != [ ] && value != { }
+    ) server;
 
-  mcpServers =
-    let
-      sharedServers = import ../mcp;
-    in
-    lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeMcpServer server)) (
-      lib.filterAttrs (
-        name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-      ) sharedServers
-    );
+  mcpServers = lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeMcpServer server)) (
+    lib.filterAttrs (
+      name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
+    ) config.programs.aiMcp.servers
+  );
 
   optionalValue = key: value: lib.optionalAttrs (value != null) { ${key} = value; };
 
@@ -88,11 +86,7 @@ let
   configAttrs = {
     approval_policy = cfg.approvalPolicy;
     personality = "pragmatic";
-    project_doc_fallback_filenames = [
-      "AGENTS.md"
-      "CLAUDE.md"
-      "GEMINI.md"
-    ];
+    project_doc_fallback_filenames = [ "AGENTS.md" ];
     projects = lib.listToAttrs (
       map (path: {
         name = path;
@@ -125,6 +119,8 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
+    programs.codex.projectDocFallbackFilenames = configAttrs.project_doc_fallback_filenames;
+
     home = {
       activation.codexConfigMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         export PATH="${pkgs.jq}/bin:${pkgs.yj}/bin:$PATH"

--- a/modules/codex/settings.nix
+++ b/modules/codex/settings.nix
@@ -118,18 +118,21 @@ let
   '';
 in
 {
-  config = lib.mkIf cfg.enable {
-    programs.codex.projectDocFallbackFilenames = configAttrs.project_doc_fallback_filenames;
+  config = lib.mkMerge [
+    # Read-only introspection option set unconditionally so module evaluation
+    # succeeds even when programs.codex.enable = false.
+    { programs.codex.projectDocFallbackFilenames = configAttrs.project_doc_fallback_filenames; }
+    (lib.mkIf cfg.enable {
+      home = {
+        activation.codexConfigMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          export PATH="${pkgs.jq}/bin:${pkgs.yj}/bin:$PATH"
+          $DRY_RUN_CMD ${../scripts/merge-toml-settings.sh} \
+            "${configToml}" \
+            "${homeDir}/.codex/config.toml"
+        '';
 
-    home = {
-      activation.codexConfigMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        export PATH="${pkgs.jq}/bin:${pkgs.yj}/bin:$PATH"
-        $DRY_RUN_CMD ${../scripts/merge-toml-settings.sh} \
-          "${configToml}" \
-          "${homeDir}/.codex/config.toml"
-      '';
-
-      file."${configDir}/rules/default.rules".text = formatters.codex.formatRulesFile permissions;
-    };
-  };
+        file."${configDir}/rules/default.rules".text = formatters.codex.formatRulesFile permissions;
+      };
+    })
+  ];
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -41,10 +41,6 @@ let
       source = "${ai-assistant-instructions}/CLAUDE.md";
       force = true;
     };
-    "GEMINI.md" = {
-      source = "${ai-assistant-instructions}/GEMINI.md";
-      force = true;
-    };
     "AGENTS.md" = {
       source = "${ai-assistant-instructions}/AGENTS.md";
       force = true;
@@ -101,6 +97,18 @@ in
           $DRY_RUN_CMD ${./scripts/validate-claude-settings.sh} \
             "${config.home.homeDirectory}/.claude/settings.json" \
             "${userConfig.ai.claudeSchemaUrl}"
+        '';
+
+        cleanupLegacyGeminiMd = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+          gemini_md="${config.home.homeDirectory}/GEMINI.md"
+          if [ -L "$gemini_md" ]; then
+            target=$(readlink "$gemini_md")
+            case "$target" in
+              /nix/store/*)
+                $DRY_RUN_CMD rm "$gemini_md"
+                ;;
+            esac
+          fi
         '';
 
         # open-webui: installed via uv (nixpkgs broken on darwin — see modules/open-webui.nix)

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -78,6 +78,7 @@ in
     ./gemini
     ./fabric
     ./maestro
+    ./mcp
     ./mcp/module.nix
     ./mlx
     ./open-webui.nix

--- a/modules/fabric/README.md
+++ b/modules/fabric/README.md
@@ -26,8 +26,7 @@ What it does NOT manage:
 
 - `~/.config/fabric/.env` (per-host secrets, set via `fabric --setup`)
 - AI provider API keys (deferred to a future Doppler-injection PR — see #445)
-- The fabric MCP server enablement state (defined in `modules/mcp/default.nix`,
-  disabled by default — see #442)
+- The fabric MCP server enablement state (defined in `programs.aiMcp.servers.fabric`)
 
 ## What this gives you
 
@@ -39,7 +38,7 @@ What it does NOT manage:
 | YouTube/multimedia extraction | `yt-dlp` added to `home.packages` |
 | Optional REST API server (LaunchAgent) | `programs.fabric.enableServer = true` (port 8180) |
 | 32 curated patterns as Claude Code skills | Synthetic marketplace at `modules/claude/marketplace-overrides.nix` |
-| Fabric MCP server in Claude Code | `modules/mcp/default.nix` (community-maintained, disabled by default) |
+| Fabric MCP server in Claude Code | `modules/mcp/catalog.nix` (community-maintained) |
 
 ## One-time runtime setup
 
@@ -146,10 +145,10 @@ the SKILL.md count matches the JSON entry count after the next `nix flake check`
 
 ### Path B: As MCP tools (explicit invocation)
 
-The `fabric` MCP server in `modules/mcp/default.nix` exposes patterns as MCP tools using
+The `fabric` MCP server in `modules/mcp/catalog.nix` exposes patterns as MCP tools using
 [ksylvan/fabric-mcp](https://github.com/ksylvan/fabric-mcp) via uvx. This is a
 **community-maintained** package (not official danielmiessler) — if it becomes
-unmaintained, an alternative MCP wrapper will be needed. Currently disabled by default.
+unmaintained, an alternative MCP wrapper will be needed.
 
 ## Version bumps
 

--- a/modules/gemini/default.nix
+++ b/modules/gemini/default.nix
@@ -1,8 +1,8 @@
 # Gemini CLI Configuration Module
 #
 # Declarative configuration for Google Gemini CLI.
-# Generates settings.json with shared MCP servers, permissions, skills,
-# commands, extensions, and folder trust.
+# Generates settings.json with shared MCP servers, permissions, commands,
+# extensions, and folder trust.
 #
 # CRITICAL - tools.allowed vs tools.core:
 # Per the official Gemini CLI schema:

--- a/modules/gemini/extensions.nix
+++ b/modules/gemini/extensions.nix
@@ -1,7 +1,7 @@
 # Gemini Extension Management
 #
 # Deploys Nix-managed extensions to ~/.gemini/extensions/<name>/.
-# Each extension gets a gemini-extension.json manifest, optional skills, and commands.
+# Each extension gets a gemini-extension.json manifest and optional commands.
 { config, lib, ... }:
 
 let
@@ -16,13 +16,6 @@ let
         inherit (ext) description;
         inherit (ext) mcpServers;
       };
-      skillFiles = lib.mapAttrs' (
-        skillName: path:
-        lib.nameValuePair ".gemini/extensions/${name}/skills/${skillName}/SKILL.md" {
-          source = path;
-          force = true;
-        }
-      ) ext.skills;
       commandFiles = lib.mapAttrs' (
         cmdName: path:
         lib.nameValuePair ".gemini/extensions/${name}/commands/${cmdName}.toml" {
@@ -37,7 +30,6 @@ let
         force = true;
       };
     }
-    // skillFiles
     // commandFiles;
 in
 {

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -26,11 +26,6 @@ let
         default = { };
         description = "MCP servers provided by this extension";
       };
-      skills = lib.mkOption {
-        type = lib.types.attrsOf lib.types.path;
-        default = { };
-        description = "Skills within this extension (name -> path to SKILL.md)";
-      };
       commands = lib.mkOption {
         type = lib.types.attrsOf lib.types.path;
         default = { };
@@ -98,6 +93,13 @@ in
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = "Additional trusted folders (merged with defaults)";
+    };
+
+    contextFileNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Context file names emitted to Gemini settings.json; read-only.";
     };
 
     # Sandbox allowed paths (merged with `~/git` default so worktree operations

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -99,7 +99,6 @@ in
       type = lib.types.listOf lib.types.str;
       readOnly = true;
       internal = true;
-      default = [ ];
       description = "Context file names emitted to Gemini settings.json; read-only.";
     };
 

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -99,6 +99,7 @@ in
       type = lib.types.listOf lib.types.str;
       readOnly = true;
       internal = true;
+      default = [ ];
       description = "Context file names emitted to Gemini settings.json; read-only.";
     };
 

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -42,9 +42,9 @@ let
   # HTTP/SSE: { httpUrl, headers? } (note: httpUrl not url)
   normalizeGeminiMcpServer =
     server:
-    if server ? url then
+    if server.url != null then
       # HTTP/SSE server
-      { httpUrl = server.url; } // lib.optionalAttrs (server ? headers) { inherit (server) headers; }
+      { httpUrl = server.url; } // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
     else
       # stdio server
       lib.filterAttrs (_name: value: value != null && value != [ ] && value != { }) (
@@ -58,14 +58,12 @@ let
       );
 
   mcpServers =
-    let
-      sharedServers = import ../mcp;
-    in
-    lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeGeminiMcpServer server)) (
-      lib.filterAttrs (
-        name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-      ) sharedServers
-    );
+    lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeGeminiMcpServer server))
+      (
+        lib.filterAttrs (
+          name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
+        ) config.programs.aiMcp.servers
+      );
 
   # Policy Engine: generate TOML rules from shared permissions
   policyRules =
@@ -96,10 +94,7 @@ let
     };
 
     context = {
-      fileName = [
-        "AGENTS.md"
-        "GEMINI.md"
-      ];
+      fileName = [ "AGENTS.md" ];
     };
 
     security = {
@@ -134,6 +129,7 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
+    programs.gemini.contextFileNames = settings.context.fileName;
     programs.gemini.sandboxAllowedPathsMerged = mergedSandboxAllowedPaths;
 
     home = {

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -128,22 +128,28 @@ let
       '';
 in
 {
-  config = lib.mkIf cfg.enable {
-    programs.gemini.contextFileNames = settings.context.fileName;
-    programs.gemini.sandboxAllowedPathsMerged = mergedSandboxAllowedPaths;
+  config = lib.mkMerge [
+    # Read-only introspection options set unconditionally so module evaluation
+    # succeeds even when programs.gemini.enable = false. Values are derived from
+    # pure Nix expressions (no activation-time side effects).
+    {
+      programs.gemini.contextFileNames = settings.context.fileName;
+      programs.gemini.sandboxAllowedPathsMerged = mergedSandboxAllowedPaths;
+    }
+    (lib.mkIf cfg.enable {
+      home = {
+        # Deploy the Policy Engine TOML file (read-only is fine — Gemini only reads it)
+        file."${lib.removePrefix "${homeDir}/" policyPath}".source = policyToml;
 
-    home = {
-      # Deploy the Policy Engine TOML file (read-only is fine — Gemini only reads it)
-      file."${lib.removePrefix "${homeDir}/" policyPath}".source = policyToml;
-
-      activation.mergeGeminiSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        export PATH="${pkgs.jq}/bin:$PATH"
-        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
-          "${settingsJson}" \
-          "${homeDir}/.gemini/settings.json"
-        $DRY_RUN_CMD ${../scripts/strip-deprecated-gemini-keys.sh} \
-          "${homeDir}/.gemini/settings.json"
-      '';
-    };
-  };
+        activation.mergeGeminiSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          export PATH="${pkgs.jq}/bin:$PATH"
+          $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+            "${settingsJson}" \
+            "${homeDir}/.gemini/settings.json"
+          $DRY_RUN_CMD ${../scripts/strip-deprecated-gemini-keys.sh} \
+            "${homeDir}/.gemini/settings.json"
+        '';
+      };
+    })
+  ];
 }

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -47,15 +47,15 @@ let
       { httpUrl = server.url; } // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
     else
       # stdio server
-      lib.filterAttrs (_name: value: value != null && value != [ ] && value != { }) (
-        {
-          command = server.command or null;
-          args = server.args or [ ];
-          env = server.env or { };
-        }
-        // lib.optionalAttrs (server ? cwd) { inherit (server) cwd; }
-        // lib.optionalAttrs (server ? timeout) { inherit (server) timeout; }
-      );
+      lib.filterAttrs (_name: value: value != null && value != [ ] && value != { }) {
+        inherit (server)
+          command
+          args
+          env
+          cwd
+          timeout
+          ;
+      };
 
   mcpServers =
     lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeGeminiMcpServer server))

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -1,10 +1,12 @@
 # MCP Servers - Nix-Native Configuration
 
-MCP server definitions are declared in `default.nix` and deployed to `~/.claude.json`
-automatically on every `darwin-rebuild switch` via a `home.activation` script.
+MCP server definitions are owned by the `modules/mcp` Home Manager module. The
+shared catalog lives in `catalog.nix` and is exposed as `programs.aiMcp.servers`.
+Claude, Codex, and Gemini consume that option and render it into their own
+configuration formats during every `darwin-rebuild switch`.
 
-**Nix is the sole manager of user-scoped MCP servers.** Any entries added manually via
-`claude mcp add --scope user` will be overwritten on the next rebuild.
+**Nix is the sole manager of user-scoped MCP servers.** Any entries added manually
+through client CLIs may be overwritten on the next rebuild.
 
 ## Transports
 
@@ -48,19 +50,19 @@ my-server = {
 
 ## Enabling / Disabling Servers
 
-All servers are enabled by default (`disabled = false` is the module system default).
-To disable a server, set `disabled = true`:
+All servers are enabled by default (`disabled = false` is the module system
+default). To disable a server, set `disabled = true`:
 
 ```nix
-postgresql = official "postgres" // { disabled = true; };
+programs.aiMcp.servers.postgresql.disabled = true;
 ```
 
-To enable a disabled server without editing `default.nix`, override via the module system.
-Because the catalog uses plain assignments (priority 100), the override must use `lib.mkForce`
-to win the merge:
+To enable a disabled server without editing `catalog.nix`, override via the
+module system. Because the catalog uses plain assignments (priority 100), the
+override must use `lib.mkForce` to win the merge:
 
 ```nix
-programs.claude.mcpServers.postgresql.disabled = lib.mkForce false;
+programs.aiMcp.servers.postgresql.disabled = lib.mkForce false;
 ```
 
 ## Secrets Management
@@ -86,8 +88,9 @@ export HF_TOKEN=${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' 'ai-cli-coder')"}
 The account name (`ai-cli-coder`) and keychain db (`automation.keychain-db`) are defined
 in `lib/user-config.nix` in nix-darwin. Adapt these values if your setup uses different names.
 
-The shell exports the env var, and Claude Code (and its MCP servers) inherit it at startup.
-Secrets are never written to `~/.claude.json` or any Nix-managed file.
+The shell exports the env var, and AI clients plus their MCP servers inherit it
+at startup. Secrets are never written to generated client config or any
+Nix-managed file.
 
 **One-time setup:** Add secrets to macOS Keychain:
 
@@ -127,7 +130,7 @@ and log levels are not sensitive and belong in the Nix-managed `env` attribute.
 ### Plugin-managed servers (context7)
 
 Some servers are provided by Claude Code plugins and manage their own MCP server lifecycle.
-Do **not** define these in `mcp/default.nix` — doing so creates a duplicate that causes
+Do **not** define these in `mcp/catalog.nix` — doing so creates a duplicate that causes
 conflicts on startup.
 
 | Plugin | Server |
@@ -246,7 +249,7 @@ Both tools are `uvx` wrappers defined in `ai-tools.nix` — no separate installa
 
 ### Server not appearing in Claude Code
 
-1. Check `disabled` is not set to `true` in `mcp/default.nix`
+1. Check `disabled` is not set to `true` in `programs.aiMcp.servers`
 2. Run `darwin-rebuild switch --flake .`
 3. Restart Claude Code
 4. Check `~/.claude.json` contains the server: `jq .mcpServers ~/.claude.json`

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -1,0 +1,189 @@
+# Shared MCP Servers Catalog
+#
+# Portable MCP server definitions using standard commands.
+# Uses bunx for npm packages and uvx for Python packages.
+#
+# Official MCP Servers: https://github.com/modelcontextprotocol/servers
+#
+# Servers requiring API keys read them from environment variables. Use your
+# secrets manager (Doppler, Keychain, etc.) to inject env vars.
+
+let
+  # bunx helper - command only, args set inline per server so Renovate's
+  # regex manager can match literal "@scope/pkg@version" strings in the source.
+  bunx = args: {
+    command = "bunx";
+    inherit args;
+  };
+in
+{
+  # ================================================================
+  # Official Anthropic MCP Servers
+  # ================================================================
+  # Versions pinned as literal strings for Renovate regex tracking.
+  # Archived servers remain unpinned unless a maintained replacement exists.
+
+  everything = bunx [ "@modelcontextprotocol/server-everything@2026.1.26" ];
+  fetch = bunx [ "@modelcontextprotocol/server-fetch" ]; # archived
+  filesystem = bunx [ "@modelcontextprotocol/server-filesystem@2026.1.14" ];
+  git = bunx [ "@modelcontextprotocol/server-git" ]; # archived
+  memory = bunx [ "@modelcontextprotocol/server-memory@2026.1.26" ];
+  sequentialthinking = bunx [ "@modelcontextprotocol/server-sequential-thinking" ]; # archived
+  time = {
+    command = "uvx";
+    args = [
+      "--from"
+      "mcp-server-time==2026.1.26"
+      "mcp-server-time"
+    ];
+  };
+  docker = bunx [ "@modelcontextprotocol/server-docker" ]; # archived
+  exa = bunx [ "@modelcontextprotocol/server-exa" ] // {
+    disabled = true;
+  }; # archived; Requires: EXA_API_KEY
+  firecrawl = bunx [ "@modelcontextprotocol/server-firecrawl" ] // {
+    disabled = true;
+  }; # archived; Requires: FIRECRAWL_API_KEY
+  cloudflare = bunx [ "@modelcontextprotocol/server-cloudflare" ] // {
+    disabled = true;
+  }; # archived; Requires: CLOUDFLARE_API_TOKEN
+  aws = bunx [ "@modelcontextprotocol/server-aws-kb-retrieval@0.6.2" ]; # Requires: AWS credentials
+
+  # ================================================================
+  # Native nixpkgs packages
+  # ================================================================
+
+  # Terraform - terraform-mcp-server from nixpkgs.
+  terraform = {
+    command = "terraform-mcp-server";
+  };
+
+  # GitHub - github-mcp-server from nixpkgs.
+  # Requires: GITHUB_PERSONAL_ACCESS_TOKEN env var (not yet in Doppler).
+  github = {
+    command = "github-mcp-server";
+    disabled = true;
+  };
+
+  # ================================================================
+  # Third-party npm packages
+  # ================================================================
+
+  # Context7 - provided by context7@claude-plugins-official plugin.
+  # Do NOT define here - the plugin manages its own MCP server lifecycle.
+
+  # ================================================================
+  # PAL MCP - Multi-model orchestration
+  # ================================================================
+  # Transport: stdio, launched via pal-mcp wrapper (modules/claude/pal-models.nix).
+  pal = {
+    command = "pal-mcp";
+  };
+
+  # ================================================================
+  # HuggingFace MCP - Model/dataset/paper search and documentation
+  # ================================================================
+  # Community stdio package: https://github.com/shreyaskarnik/huggingface-mcp-server
+  # Requires: HF_TOKEN env var (from macOS Keychain via nix-darwin shell init).
+  huggingface = {
+    command = "uvx";
+    args = [
+      "--from"
+      "huggingface-mcp-server==0.1.0"
+      "--with"
+      "huggingface-hub==1.12.0"
+      "huggingface-mcp-server"
+    ];
+  };
+
+  # Fabric MCP - community-maintained (ksylvan/fabric-mcp), exposes fabric
+  # patterns as MCP tools. Requires fabric CLI setup (see modules/fabric/).
+  # renovate: datasource=pypi depName=fabric-mcp
+  fabric = {
+    command = "uvx";
+    args = [
+      "--from"
+      "fabric-mcp==1.1.0"
+      "fabric-mcp"
+      "--transport"
+      "stdio"
+    ];
+  };
+
+  # ================================================================
+  # Obsidian - Integrated via Claude Code Plugin (not MCP)
+  # ================================================================
+  # The official Obsidian CLI (v1.8+, ships in Obsidian.app) provides 80+
+  # commands. Integration uses the kepano/obsidian-skills Claude Code plugin
+  # which teaches Claude to invoke the CLI via Bash. No MCP server needed.
+
+  # ================================================================
+  # Codex CLI - OpenAI coding agent MCP server
+  # ================================================================
+  codex = {
+    command = "codex";
+    args = [ "mcp-server" ];
+  };
+
+  # ================================================================
+  # Database (disabled by default)
+  # ================================================================
+
+  postgresql = bunx [ "@modelcontextprotocol/server-postgres@0.6.2" ] // {
+    disabled = true;
+  };
+  sqlite = bunx [ "@modelcontextprotocol/server-sqlite" ] // {
+    disabled = true;
+  }; # archived
+
+  # ================================================================
+  # Additional (disabled - specialized use cases)
+  # ================================================================
+
+  brave-search = bunx [ "@modelcontextprotocol/server-brave-search@0.6.2" ] // {
+    disabled = true;
+  };
+  # Google Workspace - Gmail, Drive, Calendar integration.
+  # Source: https://github.com/taylorwilsdon/google_workspace_mcp
+  google-workspace = {
+    command = "doppler-mcp";
+    args = [
+      "uvx"
+      "--from"
+      "google-workspace-mcp==2.0.1"
+      "workspace-mcp"
+      "--tools"
+      "gmail"
+      "drive"
+      "calendar"
+    ];
+  };
+  google-maps = bunx [ "@modelcontextprotocol/server-google-maps@0.6.2" ] // {
+    disabled = true;
+  };
+  puppeteer = bunx [ "@modelcontextprotocol/server-puppeteer@2025.5.12" ] // {
+    disabled = true;
+  };
+  slack = bunx [ "@modelcontextprotocol/server-slack@2025.4.25" ] // {
+    disabled = true;
+  };
+  sentry = bunx [ "@modelcontextprotocol/server-sentry" ] // {
+    disabled = true;
+  }; # archived
+
+  # ================================================================
+  # Cribl MCP - OrbStack kubernetes-monitoring stack
+  # ================================================================
+  cribl = {
+    type = "http";
+    url = "http://localhost:30030/mcp";
+  };
+
+  # ================================================================
+  # Bifrost AI Gateway - OrbStack kubernetes monitoring stack
+  # ================================================================
+  bifrost = {
+    type = "http";
+    url = "http://localhost:30080/mcp";
+  };
+}

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -1,228 +1,105 @@
-# MCP Servers Configuration
+# Shared MCP Home Manager module
 #
-# Simple, portable MCP server definitions using standard commands.
-# Uses bunx for npm packages (faster than npx, auto-installs).
-# Uses binary names for nixpkgs packages (resolved via PATH).
-#
-# Official MCP Servers: https://github.com/modelcontextprotocol/servers
-#
-# Note: Servers requiring API keys read them from environment variables.
-# Use your secrets manager (Doppler, Keychain, etc.) to inject env vars.
+# This module is the single declarative source for MCP server definitions.
+# Client modules translate programs.aiMcp.servers into their own config format.
+{ lib, ... }:
 
 let
-  # bunx helper — command only, args set inline per server so Renovate's
-  # regex manager can match literal "@scope/pkg@version" strings in the source.
-  bunx = args: {
-    command = "bunx";
-    inherit args;
+  mcpServerModule = lib.types.submodule {
+    options = {
+      type = lib.mkOption {
+        type = lib.types.enum [
+          "stdio"
+          "sse"
+          "http"
+        ];
+        default = "stdio";
+      };
+      command = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      args = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+      env = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+      };
+      env_vars = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+      cwd = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      url = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      headers = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+      };
+      timeout = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+      };
+      startup_timeout_sec = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+      };
+      tool_timeout_sec = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+      };
+      disabled = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+      required = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+      };
+      enabled_tools = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+      disabled_tools = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+      bearer_token_env_var = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      env_http_headers = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+      };
+      http_headers = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+      };
+      oauth_resource = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+      scopes = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+    };
   };
 in
 {
-  # ================================================================
-  # Official Anthropic MCP Servers (via bunx)
-  # ================================================================
-  # Versions pinned as literal strings for Renovate regex tracking.
-  # Archived servers (no longer on npm) are unpinned until replacements identified.
-
-  everything = bunx [ "@modelcontextprotocol/server-everything@2026.1.26" ];
-  fetch = bunx [ "@modelcontextprotocol/server-fetch" ]; # archived
-  filesystem = bunx [ "@modelcontextprotocol/server-filesystem@2026.1.14" ];
-  git = bunx [ "@modelcontextprotocol/server-git" ]; # archived
-  memory = bunx [ "@modelcontextprotocol/server-memory@2026.1.26" ];
-  sequentialthinking = bunx [ "@modelcontextprotocol/server-sequential-thinking" ]; # archived
-  time = bunx [ "@modelcontextprotocol/server-time" ]; # archived
-  docker = bunx [ "@modelcontextprotocol/server-docker" ]; # archived
-  exa = bunx [ "@modelcontextprotocol/server-exa" ] // {
-    disabled = true;
-  }; # archived; Requires: EXA_API_KEY
-  firecrawl = bunx [ "@modelcontextprotocol/server-firecrawl" ] // {
-    disabled = true;
-  }; # archived; Requires: FIRECRAWL_API_KEY
-  cloudflare = bunx [ "@modelcontextprotocol/server-cloudflare" ] // {
-    disabled = true;
-  }; # archived; Requires: CLOUDFLARE_API_TOKEN
-  aws = bunx [ "@modelcontextprotocol/server-aws-kb-retrieval@0.6.2" ]; # Requires: AWS credentials
-
-  # ================================================================
-  # Native nixpkgs packages (binary name, resolved via PATH)
-  # ================================================================
-
-  # Terraform - terraform-mcp-server from nixpkgs
-  terraform = {
-    command = "terraform-mcp-server";
-  };
-
-  # GitHub - github-mcp-server from nixpkgs
-  # Requires: GITHUB_PERSONAL_ACCESS_TOKEN env var (not yet in Doppler)
-  github = {
-    command = "github-mcp-server";
-    disabled = true;
-  };
-
-  # ================================================================
-  # Third-party npm packages (via bunx)
-  # ================================================================
-
-  # Context7 - provided by context7@claude-plugins-official plugin (see plugins/external.nix).
-  # Do NOT define here — the plugin manages its own MCP server lifecycle.
-
-  # ================================================================
-  # PAL MCP - Multi-model orchestration
-  # ================================================================
-  # Provider Abstraction Layer for routing tasks to different AI models
-  # Enabled tools (4): chat, listmodels, clink, consensus
-  #   - chat: single-model inference via Bifrost (local MLX + cloud)
-  #   - listmodels: enumerate available models (local + cloud)
-  #   - clink: parallel multi-model prompting (no native equivalent)
-  #   - consensus: multi-model voting/agreement (no native equivalent)
-  # Disabled tools (14): thinkdeep, planner, codereview, precommit, debug,
-  #   analyze, tracer, refactor, testgen, secaudit, docgen, apilookup,
-  #   challenge, version — all have native Claude Code / Bifrost equivalents
-  # See: https://github.com/BeehiveInnovations/pal-mcp-server
-  #
-  # Transport: stdio, launched via pal-mcp wrapper (modules/claude/pal-models.nix).
-  # All env vars (DISABLED_TOOLS, model config, paths) are baked into the wrapper —
-  # process env survives Claude Code's ~/.claude.json rewrites (JacobPEvans/nix-ai#557).
-  # API keys are injected by doppler-mcp (called from within the wrapper).
-  pal = {
-    command = "pal-mcp";
-  };
-
-  # ================================================================
-  # HuggingFace MCP - Model/dataset/paper search and documentation
-  # ================================================================
-  # Community stdio package: https://github.com/shreyaskarnik/huggingface-mcp-server
-  # Tools: search models/datasets/spaces/papers, get info, compare models
-  # Requires: HF_TOKEN env var (from macOS Keychain via nix-darwin shell init)
-  huggingface = {
-    command = "uvx";
-    args = [
-      "--from"
-      "huggingface-mcp-server==0.1.0"
-      "--with"
-      "huggingface-hub==1.12.0"
-      "huggingface-mcp-server"
-    ];
-  };
-
-  # Fabric MCP — community-maintained (ksylvan/fabric-mcp), exposes fabric
-  # patterns as MCP tools. Requires fabric CLI setup (see modules/fabric/).
-  # renovate: datasource=pypi depName=fabric-mcp
-  fabric = {
-    command = "uvx";
-    args = [
-      "--from"
-      "fabric-mcp==1.1.0"
-      "fabric-mcp"
-      "--transport"
-      "stdio"
-    ];
-  };
-
-  # ================================================================
-  # Obsidian - Integrated via Claude Code Plugin (not MCP)
-  # ================================================================
-  # The official Obsidian CLI (v1.8+, ships in Obsidian.app) provides 80+
-  # commands. Integration uses the kepano/obsidian-skills Claude Code plugin
-  # which teaches Claude to invoke the CLI via Bash (auto-approved in
-  # ai-assistant-instructions permissions). No MCP server needed — the skill
-  # provides equivalent structured access without an additional layer.
-  #
-  # If MCP is desired later: bunx [ "mcp-obsidian-cli@1.2.0" ] (stonematt)
-
-  # ================================================================
-  # Codex CLI — OpenAI coding agent MCP server
-  # ================================================================
-  # Native `codex mcp-server` (stdio). Structured MCP tool access to Codex.
-  # The codex@openai-codex plugin provides skill-based /codex commands.
-  # Auth: `codex login` stores credentials in ~/.codex/auth.json (no env var API keys needed).
-  # Installed via Homebrew cask in the nix-darwin repo (not managed here).
-  codex = {
-    command = "codex";
-    args = [ "mcp-server" ];
-  };
-
-  # ================================================================
-  # Database (disabled by default)
-  # ================================================================
-
-  postgresql = bunx [ "@modelcontextprotocol/server-postgres@0.6.2" ] // {
-    disabled = true;
-  };
-  sqlite = bunx [ "@modelcontextprotocol/server-sqlite" ] // {
-    disabled = true;
-  }; # archived
-
-  # ================================================================
-  # Additional (disabled - specialized use cases)
-  # ================================================================
-
-  brave-search = bunx [ "@modelcontextprotocol/server-brave-search@0.6.2" ] // {
-    disabled = true;
-  };
-  # Google Workspace - Gmail, Drive, Calendar integration
-  # Source: https://github.com/taylorwilsdon/google_workspace_mcp
-  # Requires: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET env vars (via Doppler)
-  # Auth: One-time OAuth browser flow, tokens stored locally
-  # Selective tool loading: --tools limits which Google services are exposed
-  google-workspace = {
-    command = "doppler-mcp";
-    args = [
-      "uvx"
-      "--from"
-      "google-workspace-mcp==2.0.1"
-      "workspace-mcp"
-      "--tools"
-      "gmail"
-      "drive"
-      "calendar"
-    ];
-  };
-  google-maps = bunx [ "@modelcontextprotocol/server-google-maps@0.6.2" ] // {
-    disabled = true;
-  };
-  puppeteer = bunx [ "@modelcontextprotocol/server-puppeteer@2025.5.12" ] // {
-    disabled = true;
-  };
-  slack = bunx [ "@modelcontextprotocol/server-slack@2025.4.25" ] // {
-    disabled = true;
-  };
-  sentry = bunx [ "@modelcontextprotocol/server-sentry" ] // {
-    disabled = true;
-  }; # archived
-
-  # ================================================================
-  # Cribl MCP - OrbStack kubernetes-monitoring stack
-  # ================================================================
-  # Cribl MCP server running in OrbStack k8s cluster (NodePort :30030).
-  # Connection will fail when OrbStack k8s is not running — this is expected.
-  # See: ~/git/kubernetes-monitoring for the stack configuration.
-  # Cribl uses streamable HTTP transport (not SSE).
-  # Claude Code supports this natively with type = "http" — no mcp-remote proxy needed.
-  # See: https://docs.cribl.io/copilot/cribl-mcp-server/
-  cribl = {
-    type = "http";
-    url = "http://localhost:30030/mcp";
-  };
-
-  # ================================================================
-  # Bifrost AI Gateway - OrbStack kubernetes monitoring stack
-  # ================================================================
-  # Bifrost AI gateway running in OrbStack k8s cluster (NodePort :30080).
-  # Multi-provider routing: OpenAI, Anthropic, Gemini, OpenRouter, local MLX.
-  # OpenAI-compatible API at /v1, MCP server at /mcp.
-  # Connection will fail when OrbStack k8s is not running — this is expected.
-  # Provider API keys are managed by the Doppler K8s Operator inside the cluster
-  # (no doppler-mcp wrapper needed — secrets never reach the MCP client process).
-  #
-  # Diagnostics use native tools — no custom CLI exists or is needed:
-  #   claude mcp list | grep bifrost          # MCP connection state
-  #   make -C ~/git/orbstack-kubernetes/main status      # pod / service / sts state
-  #   make -C ~/git/orbstack-kubernetes/main test-smoke  # asserts /health, /v1/models, NodePort
-  #
-  # See: https://github.com/maximhq/bifrost
-  bifrost = {
-    type = "http";
-    url = "http://localhost:30080/mcp";
+  options.programs.aiMcp = {
+    servers = lib.mkOption {
+      type = lib.types.attrsOf mcpServerModule;
+      default = import ./catalog.nix;
+      description = "Shared MCP server definitions consumed by AI client modules.";
+    };
   };
 }

--- a/modules/mlx/discover-models.py
+++ b/modules/mlx/discover-models.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -31,8 +32,9 @@ EXCLUDE_PATTERN = re.compile(
 
 def get_memory_budget_gb() -> int:
     """Return available memory in GB (total - 20 GB reserved for system)."""
+    sysctl = shutil.which("sysctl") or "/usr/sbin/sysctl"
     result = subprocess.run(
-        ["sysctl", "-n", "hw.memsize"], capture_output=True, text=True, check=True
+        [sysctl, "-n", "hw.memsize"], capture_output=True, text=True, check=True
     )
     total_bytes = int(result.stdout.strip())
     total_gb = total_bytes // (1024**3)

--- a/modules/mlx/seed-config.py
+++ b/modules/mlx/seed-config.py
@@ -38,6 +38,7 @@ def main() -> None:
         fd = os.open(str(runtime), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
         os.write(fd, base_content)
         os.close(fd)
+        runtime.chmod(0o600)
         marker.write_text(base_hash + "\n")
         print("Seeded llama-swap runtime config from Nix store")
         return
@@ -47,7 +48,9 @@ def main() -> None:
     prev_hash = marker.read_text().strip() if marker.exists() else ""
 
     if base_hash != prev_hash:
+        runtime.chmod(0o600)
         shutil.copy2(base, runtime)
+        runtime.chmod(0o600)
         marker.write_text(base_hash + "\n")
         print("Updated llama-swap runtime config (base config changed)")
     else:

--- a/modules/mlx/seed-config.py
+++ b/modules/mlx/seed-config.py
@@ -35,10 +35,9 @@ def main() -> None:
     # Atomically create runtime config if it doesn't exist (avoids TOCTOU race
     # with concurrent darwin-rebuild or LaunchAgent startup).
     try:
-        fd = os.open(str(runtime), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        fd = os.open(str(runtime), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         os.write(fd, base_content)
         os.close(fd)
-        runtime.chmod(0o600)
         marker.write_text(base_hash + "\n")
         print("Seeded llama-swap runtime config from Nix store")
         return
@@ -48,7 +47,6 @@ def main() -> None:
     prev_hash = marker.read_text().strip() if marker.exists() else ""
 
     if base_hash != prev_hash:
-        runtime.chmod(0o600)
         shutil.copy2(base, runtime)
         runtime.chmod(0o600)
         marker.write_text(base_hash + "\n")


### PR DESCRIPTION
## Summary

- Centralizes shared agent skills under `~/.agents/skills` for Gemini/Codex compatibility, replacing per-tool skill trees
- Converts MCP server definitions from a plain Nix attrset (`import ./mcp`) to a typed Home Manager module (`programs.aiMcp.servers`) consumed by Claude, Gemini, and Codex
- Replaces the archived `@modelcontextprotocol/server-time` npm package with `mcp-server-time` (uvx/Python, actively maintained)
- Translates Claude plugin commands into cross-tool Agent Skills via a Nix `pkgs.runCommand` wrapper

## Changes

**Agent Skills** (`modules/agent-skills/`)
- Deploy skill directories (not individual SKILL.md files) to `~/.agents/skills/<name>`
- Add activation script to clean up legacy per-file symlinks from old layout
- Auto-discover and translate Claude plugin commands (`commands/*.md`) into Agent Skills

**MCP Module** (`modules/mcp/`)
- `default.nix`: New Home Manager module exposing `programs.aiMcp.servers`
- `catalog.nix`: Extracted catalog of server definitions (Renovate-trackable)
- Claude, Gemini, and Codex normalize the shared option into their own config formats

**Claude** (`modules/claude-config.nix`)
- `mcpServers` now reads from `config.programs.aiMcp.servers` with a `normalizeClaudeMcpServer` filter

**Gemini** (`modules/gemini/`)
- Removed per-extension skills (skills are now shared via `programs.agentSkills`)
- `contextFileNames` option set unconditionally (evaluable when disabled)

**Codex** (`modules/codex/`)
- `projectDocFallbackFilenames` reduced to `["AGENTS.md"]` (CLAUDE.md/GEMINI.md removed)
- `projectDocFallbackFilenames` option set unconditionally (evaluable when disabled)

**Scripts** (`modules/claude/scripts/`, `modules/mlx/`)
- `cleanup-runtime-data.sh`: guard `log_info` fallback for Nix store path
- `verify-cache-integrity.sh`: guard `pgrep` with `command -v` lookup
- `seed-config.py`: atomic file creation with explicit `0o600` mode; removed ineffective pre-copy chmod
- `discover-models.py`: resolve `sysctl` via `shutil.which`

## Test Plan

- [x] `nix fmt` passes (nixfmt-tree)
- [x] `nix flake check` passes all checks locally
- [x] CI: Nix Validate, CodeQL, all required checks green
- [x] All 7 review threads resolved
- [x] Merge conflicts resolved (rebased onto main)

Related: no matching issues found for Gemini/Codex skills centralization