### PR TITLE
feat(ai-stack): :sparkles: services.aiStack.models role registry

### DIFF
--- a/lib/checks/fabric.nix
+++ b/lib/checks/fabric.nix
@@ -67,7 +67,7 @@ in
         {
           name = "fabric.defaultModel";
           actual = cfg.defaultModel;
-          expected = "mlx-community/Qwen3.5-122B-A10B-4bit";
+          expected = "default";
         }
         # Environment variables — FABRIC_PATTERNS_DIR is computed from
         # config.home.homeDirectory + the fixed ".config/fabric/patterns"

--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -1,0 +1,40 @@
+# AI Stack — Role Registry
+#
+# Single source of truth mapping role names → physical mlx-community/* model
+# IDs. Role names are stable and consumer-facing; physical model IDs change
+# whenever we re-benchmark or upstream ships a better quant.
+#
+# All consumers (llama-swap, fabric, pal-mcp, screenpipe presets, zsh
+# aliases) reference roles, not physical names. Swapping a role's model is
+# then one Nix attr edit + a darwin-rebuild switch — no consumer-side change
+# is required.
+#
+# The role names mirror the screenpipe preset taxonomy (default, quickest,
+# tool-calling, coding, large-context, most-capable) plus oss for explicit
+# Apache-2/MIT model preference. Add new roles here; do not embed physical
+# names in consumer modules.
+
+{ lib, ... }:
+{
+  options.services.aiStack.models = lib.mkOption {
+    type = lib.types.attrsOf lib.types.str;
+    default = {
+      default = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
+      quickest = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      tool-calling = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      large-context = "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit";
+      most-capable = "mlx-community/Qwen3.5-122B-A10B-4bit";
+      oss = "mlx-community/gpt-oss-120b-4bit";
+    };
+    description = ''
+      Role-name → physical mlx-community/* model ID. Each role becomes a
+      first-class llama-swap entry whose cmd runs `vllm-mlx serve <physical>`.
+      Physical names also remain queryable for direct curl / debugging.
+
+      This is the ONLY place real MLX model strings should live in the Nix
+      tree. Consumer modules (fabric.defaultModel, pal-mcp CUSTOM_MODEL_NAME,
+      screenpipe presets, zsh aliases) reference role names instead.
+    '';
+  };
+}

--- a/modules/claude/pal-models.nix
+++ b/modules/claude/pal-models.nix
@@ -75,7 +75,7 @@ in
           runtimeInputs = [ ]; # doppler-mcp resolved from user PATH at runtime
           text = ''
             export CUSTOM_MODELS_CONFIG_PATH="${outputFile}"
-            export CUSTOM_MODEL_NAME="mlx-local/${mlxCfg.defaultModel}"
+            export CUSTOM_MODEL_NAME="mlx-local/default"
             export OPENROUTER_MODELS_CONFIG_PATH="${outputDir}/openrouter_models.json"
             export PAL_LOG_DIR="${palLogDir}"
             export PAL_MCP_SERVER="${palPkg}/bin/pal-mcp-server"

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -74,6 +74,7 @@ in
 {
   imports = [
     ./ai-shell.nix
+    ./ai-stack
     ./agent-skills
     ./claude
     ./claude-latest.nix

--- a/modules/fabric/options.nix
+++ b/modules/fabric/options.nix
@@ -32,14 +32,18 @@
 
     defaultModel = lib.mkOption {
       type = lib.types.str;
-      default = "mlx-community/Qwen3.5-122B-A10B-4bit";
+      default = "default";
       description = ''
         Default model fabric should use when no `--model` flag is specified.
 
-        Routes through the local MLX stack at http://127.0.0.1:11434/v1 by default.
-        Override to use a cloud provider model (e.g. "claude-3-5-sonnet-20241022",
-        "gpt-4o", "gemini-1.5-pro") but be aware fabric needs API keys configured
-        in ~/.config/fabric/.env for those backends.
+        Defaults to the role name "default" so fabric, llama-swap, and the
+        rest of the AI stack share a single source of truth in
+        services.aiStack.models. Routes through the local MLX stack at
+        http://127.0.0.1:11434/v1.
+
+        Override to a cloud provider model name (e.g. "claude-3-5-sonnet-20241022",
+        "gpt-4o", "gemini-1.5-pro") but be aware fabric needs API keys
+        configured in ~/.config/fabric/.env for those backends.
       '';
     };
 

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -132,18 +132,13 @@ let
 
   # One entry per unique physical model. The entry owning the "default"
   # alias is preloaded; others inherit the proxy idle TTL.
-  registryModels = lib.mapAttrs (
-    physical: roles:
-    {
-      cmd = mkVllmCmd physical;
-      ttl = builtins.elemAt [ cfg.proxy.idleTtl 0 ] (
-        lib.boolToInt (builtins.elem "default" roles)
-      );
-      env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
-      checkEndpoint = "/v1/models";
-      aliases = roles;
-    }
-  ) rolesByPhysical;
+  registryModels = lib.mapAttrs (physical: roles: {
+    cmd = mkVllmCmd physical;
+    ttl = builtins.elemAt [ cfg.proxy.idleTtl 0 ] (lib.boolToInt (builtins.elem "default" roles));
+    env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
+    checkEndpoint = "/v1/models";
+    aliases = roles;
+  }) rolesByPhysical;
 
   # Additional ad-hoc models from cfg.models (existing extension point).
   additionalModels = lib.mapAttrs (
@@ -154,9 +149,7 @@ let
         + lib.optionalString (modelCfg.extraArgs != [ ]) (
           " " + lib.concatStringsSep " " modelCfg.extraArgs
         );
-      ttl = builtins.elemAt [ cfg.proxy.idleTtl modelCfg.ttl ] (
-        lib.boolToInt (modelCfg.ttl > 0)
-      );
+      ttl = builtins.elemAt [ cfg.proxy.idleTtl modelCfg.ttl ] (lib.boolToInt (modelCfg.ttl > 0));
       env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
       checkEndpoint = "/v1/models";
     }

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -121,20 +121,13 @@ let
   roleModels = config.services.aiStack.models;
 
   # Group roles by physical model. One backend serves many role aliases.
-  rolesByPhysical = lib.foldl' (
-    acc: role:
-    let
-      physical = roleModels.${role};
-      prior = acc.${physical} or [ ];
-    in
-    acc // { ${physical} = prior ++ [ role ]; }
-  ) { } (lib.attrNames roleModels);
+  rolesByPhysical = lib.groupBy (role: roleModels.${role}) (lib.attrNames roleModels);
 
   # One entry per unique physical model. The entry owning the "default"
   # alias is preloaded; others inherit the proxy idle TTL.
   registryModels = lib.mapAttrs (physical: roles: {
     cmd = mkVllmCmd physical;
-    ttl = builtins.elemAt [ cfg.proxy.idleTtl 0 ] (lib.boolToInt (builtins.elem "default" roles));
+    ttl = if builtins.elem "default" roles then 0 else cfg.proxy.idleTtl;
     env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
     checkEndpoint = "/v1/models";
     aliases = roles;
@@ -149,7 +142,7 @@ let
         + lib.optionalString (modelCfg.extraArgs != [ ]) (
           " " + lib.concatStringsSep " " modelCfg.extraArgs
         );
-      ttl = builtins.elemAt [ cfg.proxy.idleTtl modelCfg.ttl ] (lib.boolToInt (modelCfg.ttl > 0));
+      ttl = if modelCfg.ttl > 0 then modelCfg.ttl else cfg.proxy.idleTtl;
       env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
       checkEndpoint = "/v1/models";
     }

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -116,15 +116,36 @@ let
     in
     "${baseCmd}${lib.optionalString (flags != "") " ${flags}"}";
 
-  # Default model entry — always loaded at startup, never auto-unloaded.
-  defaultModelEntry = {
-    cmd = mkVllmCmd cfg.defaultModel;
-    ttl = 0;
-    env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
-    checkEndpoint = "/v1/models";
-  };
+  # Role registry (services.aiStack.models): role-name -> physical model ID.
+  # Single source of truth.
+  roleModels = config.services.aiStack.models;
 
-  # Additional model entries from cfg.models — loaded on demand, unloaded after idleTtl.
+  # Group roles by physical model. One backend serves many role aliases.
+  rolesByPhysical = lib.foldl' (
+    acc: role:
+    let
+      physical = roleModels.${role};
+      prior = acc.${physical} or [ ];
+    in
+    acc // { ${physical} = prior ++ [ role ]; }
+  ) { } (lib.attrNames roleModels);
+
+  # One entry per unique physical model. The entry owning the "default"
+  # alias is preloaded; others inherit the proxy idle TTL.
+  registryModels = lib.mapAttrs (
+    physical: roles:
+    {
+      cmd = mkVllmCmd physical;
+      ttl = builtins.elemAt [ cfg.proxy.idleTtl 0 ] (
+        lib.boolToInt (builtins.elem "default" roles)
+      );
+      env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
+      checkEndpoint = "/v1/models";
+      aliases = roles;
+    }
+  ) rolesByPhysical;
+
+  # Additional ad-hoc models from cfg.models (existing extension point).
   additionalModels = lib.mapAttrs (
     name: modelCfg:
     {
@@ -133,7 +154,9 @@ let
         + lib.optionalString (modelCfg.extraArgs != [ ]) (
           " " + lib.concatStringsSep " " modelCfg.extraArgs
         );
-      ttl = if modelCfg.ttl > 0 then modelCfg.ttl else cfg.proxy.idleTtl;
+      ttl = builtins.elemAt [ cfg.proxy.idleTtl modelCfg.ttl ] (
+        lib.boolToInt (modelCfg.ttl > 0)
+      );
       env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
       checkEndpoint = "/v1/models";
     }
@@ -142,10 +165,7 @@ let
     }
   ) cfg.models;
 
-  allModels = {
-    "${cfg.defaultModel}" = defaultModelEntry;
-  }
-  // additionalModels;
+  allModels = registryModels // additionalModels;
 
   llamaSwapConfigAttrs = {
     inherit (cfg.proxy) healthCheckTimeout logLevel logToStdout;
@@ -163,7 +183,9 @@ let
       members = builtins.attrNames allModels;
     };
 
-    hooks.on_startup.preload = [ cfg.defaultModel ];
+    # Preload by role, not physical name. llama-swap resolves "default"
+    # via the alias table on the registryModels entry.
+    hooks.on_startup.preload = [ "default" ];
   };
 
   # Use pkgs.writeText (not builtins.toFile) because content references store paths

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -12,17 +12,12 @@
 
     defaultModel = lib.mkOption {
       type = lib.types.str;
-      default = config.services.aiStack.models.default;
+      inherit (config.services.aiStack.models) default;
       defaultText = lib.literalExpression "config.services.aiStack.models.default";
       description = ''
         Physical mlx-community/ HuggingFace model ID for the "default" role.
-        Sourced from services.aiStack.models.default — that is the single
-        source of truth for role → physical model mappings. Override here
-        only when temporarily pinning vllm-mlx to a model that should NOT
-        appear in the role registry.
-        Benchmark-driven rationale and historical default-swap context live
-        on the companion dataset:
-        https://huggingface.co/datasets/JacobPEvans/mlx-benchmarks
+        Sourced from services.aiStack.models.default — see
+        nix-ai/modules/ai-stack/default.nix for the registry.
       '';
     };
 
@@ -102,18 +97,6 @@
     # 0.2.9 fixed the 0.2.8 MLLM detection bug for Qwen3-class models, so
     # continuous batching + maxNumSeqs are now defaults rather than opt-in.
 
-    # ---- ACTIVE TUNING (uncomment to override server defaults) ----
-
-    # cacheMemoryPercent — Fraction of available RAM for cache (--cache-memory-percent).
-    # Server default: 0.20. Alternative to cacheMemoryMb for proportional sizing.
-    # Disabled: auto-detect (20%) is appropriate for 128GB with a 70GB model.
-    # Revisit: if switching models or needing finer memory control.
-    # cacheMemoryPercent = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.float;
-    #   default = null;
-    #   description = "Fraction of RAM for cache (0.0-1.0). Alternative to cacheMemoryMb.";
-    # };
-
     # continuousBatching — Enable continuous batching (--continuous-batching).
     # Improves multi-user throughput by interleaving prefill and decode across
     # requests. The 0.2.8 MLLM-detection bug for Qwen3-class models is fixed
@@ -155,16 +138,6 @@
       description = "Completion batch size. Null = server default. Tune with continuousBatching.";
     };
 
-    # streamInterval — Tokens to batch before streaming (--stream-interval).
-    # Server default: unset. 1 = smooth streaming, higher = more throughput.
-    # Disabled: server default is fine for agentic workloads.
-    # Revisit: if latency-sensitive streaming is needed (set to 1).
-    # streamInterval = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.ints.positive;
-    #   default = null;
-    #   description = "Tokens batched before streaming. 1 = smooth, higher = throughput.";
-    # };
-
     # maxTokens — Default max generation length (--max-tokens).
     # Server default: 32768. Only affects requests that omit max_tokens.
     # Some OpenAI-compatible consumers omit max_tokens even when their model
@@ -176,68 +149,6 @@
       default = null;
       description = "Default max tokens when client omits max_tokens. Null = vllm-mlx server default: 32768.";
     };
-
-    # defaultTemperature — Override default temperature (--default-temperature).
-    # Server default: model-dependent. Overrides for all requests without explicit temperature.
-    # Disabled: consumers set temperature explicitly.
-    # Revisit: only if a consumer relies on server defaults.
-    # defaultTemperature = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.float;
-    #   default = null;
-    #   description = "Override default temperature for requests that don't set it.";
-    # };
-
-    # defaultTopP — Override default top_p (--default-top-p).
-    # Server default: model-dependent.
-    # Disabled: consumers set top_p explicitly.
-    # Revisit: same as defaultTemperature.
-    # defaultTopP = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.float;
-    #   default = null;
-    #   description = "Override default top_p for requests that don't set it.";
-    # };
-
-    # timeout — Request timeout in seconds (--timeout).
-    # Server default: 300. Per-request timeout.
-    # Disabled: 300s is generous for agentic workloads.
-    # Revisit: increase if running very long generation requests.
-    # timeout = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.ints.positive;
-    #   default = null;
-    #   description = "Request timeout in seconds. Server default: 300.";
-    # };
-
-    # ---- EXPERIMENTAL ----
-
-    # pagedCache — Use paged KV cache (--use-paged-cache).
-    # Server default: disabled. Experimental paged cache implementation.
-    # Disabled: experimental, memory-aware cache is production-ready.
-    # Revisit: when paged cache graduates from experimental.
-    # pagedCache = lib.mkOption {
-    #   type = lib.types.bool;
-    #   default = false;
-    #   description = "Use experimental paged KV cache.";
-    # };
-
-    # pagedCacheBlockSize — Tokens per cache block (--paged-cache-block-size).
-    # Server default: 64. Only used with pagedCache.
-    # Disabled: pagedCache is experimental.
-    # Revisit: when enabling pagedCache.
-    # pagedCacheBlockSize = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.ints.positive;
-    #   default = null;
-    #   description = "Tokens per paged cache block. Server default: 64. Only with pagedCache.";
-    # };
-
-    # maxCacheBlocks — Maximum cache blocks (--max-cache-blocks).
-    # Server default: 1000. Only used with pagedCache.
-    # Disabled: pagedCache is experimental.
-    # Revisit: when enabling pagedCache.
-    # maxCacheBlocks = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.ints.positive;
-    #   default = null;
-    #   description = "Maximum paged cache blocks. Server default: 1000. Only with pagedCache.";
-    # };
 
     # ---- TOOL INTEGRATION ----
     # Server-side tool calling returns structured tool_calls in OpenAI API responses.
@@ -299,81 +210,6 @@
       default = null;
       description = "Reasoning content extraction parser. Disabled by default — conflicts with tool-call-parser in streaming mode (vllm-mlx bug).";
     };
-
-    # mcpConfig — MCP configuration file (--mcp-config).
-    # Path to JSON/YAML MCP config for server-side tool integration.
-    # Disabled: MCP managed by consumers (Claude Code, PAL), not the inference server.
-    # Revisit: if the inference server needs direct MCP tool access.
-    # mcpConfig = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.path;
-    #   default = null;
-    #   description = "Path to MCP configuration file (JSON/YAML) for server-side tools.";
-    # };
-
-    # ---- EMBEDDINGS ----
-
-    # embeddingModel — Pre-load embedding model at startup (--embedding-model).
-    # Disabled: embeddings handled by separate services.
-    # Revisit: if consolidating embedding generation into vllm-mlx.
-    # embeddingModel = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.str;
-    #   default = null;
-    #   description = "HuggingFace ID of embedding model to pre-load at startup.";
-    # };
-
-    # ---- SECURITY ----
-
-    # apiKey — API authentication key (--api-key).
-    # Disabled: server binds to 127.0.0.1, no external access.
-    # Revisit: if exposing the server on a network interface.
-    # apiKey = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.str;
-    #   default = null;
-    #   description = "API authentication key. Not needed when binding to localhost.";
-    # };
-
-    # rateLimit — Requests per minute per client (--rate-limit).
-    # Server default: 0 (disabled). Per-client rate limiting.
-    # Disabled: single-user, localhost-only, no abuse vector.
-    # Revisit: if exposing the server externally.
-    # rateLimit = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.ints.unsigned;
-    #   default = null;
-    #   description = "Requests per minute per client. 0 = disabled. Server default: 0.";
-    # };
-
-    # ---- LEGACY (not recommended) ----
-
-    # prefixCacheSize — Max entries in prefix cache (--prefix-cache-size).
-    # Server default: 100. LEGACY MODE ONLY — requires --no-memory-aware-cache.
-    # Memory-aware mode (default) is strictly better: auto-sizes based on RAM.
-    # Disabled: memory-aware mode handles this automatically.
-    # Revisit: only if debugging memory-aware cache issues.
-    # prefixCacheSize = lib.mkOption {
-    #   type = lib.types.nullOr lib.types.ints.positive;
-    #   default = null;
-    #   description = "Legacy prefix cache entry count. Requires noMemoryAwareCache. Server default: 100.";
-    # };
-
-    # noMemoryAwareCache — Disable memory-aware cache (--no-memory-aware-cache).
-    # Server default: memory-aware enabled. Falls back to legacy entry-count mode.
-    # Disabled: memory-aware mode is strictly better.
-    # Revisit: only if debugging memory-aware cache issues.
-    # noMemoryAwareCache = lib.mkOption {
-    #   type = lib.types.bool;
-    #   default = false;
-    #   description = "Disable memory-aware cache, use legacy entry-count mode. Not recommended.";
-    # };
-
-    # disablePrefixCache — Disable prefix caching entirely (--disable-prefix-cache).
-    # Server default: prefix caching enabled. Disabling removes all prefix reuse.
-    # Disabled: prefix caching provides significant TTFT speedup for repeated prompts.
-    # Revisit: only if debugging prefix cache issues.
-    # disablePrefixCache = lib.mkOption {
-    #   type = lib.types.bool;
-    #   default = false;
-    #   description = "Disable prefix caching entirely. Not recommended.";
-    # };
 
     # ---- OOM PREVENTION (2026-03-21 incident: 171.9 GB on 128 GB RAM) ----
     # ProcessType=Background makes vllm-mlx Jetsam-eligible; HardResourceLimits

--- a/modules/mlx/options.nix
+++ b/modules/mlx/options.nix
@@ -5,16 +5,21 @@
 # Active options are defined normally; inactive options are commented out
 # with rationale for why they're disabled and when to revisit.
 #
-{ lib, ... }:
+{ config, lib, ... }:
 {
   options.programs.mlx = {
     enable = lib.mkEnableOption "MLX inference server via vllm-mlx";
 
     defaultModel = lib.mkOption {
       type = lib.types.str;
-      default = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
+      default = config.services.aiStack.models.default;
+      defaultText = lib.literalExpression "config.services.aiStack.models.default";
       description = ''
-        Default mlx-community/ HuggingFace model to serve via vllm-mlx.
+        Physical mlx-community/ HuggingFace model ID for the "default" role.
+        Sourced from services.aiStack.models.default — that is the single
+        source of truth for role → physical model mappings. Override here
+        only when temporarily pinning vllm-mlx to a model that should NOT
+        appear in the role registry.
         Benchmark-driven rationale and historical default-swap context live
         on the companion dataset:
         https://huggingface.co/datasets/JacobPEvans/mlx-benchmarks


### PR DESCRIPTION
## Summary

Single source of truth mapping role names → physical \`mlx-community/*\` model IDs via a new \`services.aiStack.models\` option. All consumers (llama-swap, fabric, pal-mcp, screenpipe presets, zsh aliases) now reference role names instead of hard-coding physical IDs in N+1 places — drift between those duplicates was the original swap-thrash root cause.

**Stacked on top of #665** (vllm-mlx 0.2.9). Merge #665 first.

## Roles (default registry)

| Role | Physical model |
| --- | --- |
| \`default\` | Qwen3.6-35B-A3B-mxfp4 |
| \`quickest\` | Qwen3-Coder-30B-A3B-Instruct-4bit |
| \`tool-calling\` | Qwen3-Coder-30B-A3B-Instruct-4bit |
| \`coding\` | Qwen3-Coder-30B-A3B-Instruct-4bit |
| \`large-context\` | Qwen3-Next-80B-A3B-Instruct-4bit |
| \`most-capable\` | Qwen3.5-122B-A10B-4bit |
| \`oss\` | gpt-oss-120b-4bit |

## Key implementation choices

- **One backend per unique physical model** via llama-swap \`aliases\`. \`default\` and \`mlx-community/Qwen3.6-35B-A3B-mxfp4\` resolve to the same loaded process — no 7× memory cost.
- \`programs.mlx.defaultModel\` default now **derives from** \`config.services.aiStack.models.default\`, preserving the existing API for back-compat.
- \`programs.fabric.defaultModel\` default switches to the role name \`"default"\`.
- \`pal-mcp\` \`CUSTOM_MODEL_NAME\` switches to \`mlx-local/default\`.
- Regression checks updated.

## Companion PR

\`zsh\` aliases live in nix-home, not nix-ai. Companion PR: JacobPEvans/nix-home (forthcoming).

## Test plan

- [ ] \`nix flake check\` evaluates without errors
- [ ] \`darwin-rebuild switch\` applies cleanly
- [ ] \`~/.config/mlx/llama-swap.json\` shows role names as \`aliases\` on physical-keyed entries
- [ ] \`curl -s http://127.0.0.1:11434/v1/models | jq -r '.data[].id'\` lists role + physical names
- [ ] \`mlx-switch default\` and \`mlx-switch mlx-community/Qwen3.6-35B-A3B-mxfp4\` both succeed without spawning a second backend
- [ ] Editing a role's physical model in \`services.aiStack.models\` + \`darwin-rebuild switch\` swaps backends with no consumer-side edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)