### PR TITLE
feat(ai-stack): export aiStackModels as flake output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ prefix-free without duplicating the registry.
 ```nix
 inputs.nix-ai.url = "github:JacobPEvans/nix-ai";
 # ...
-# Build Bifrost alias table: default → mlx-local/mlx-community/Qwen3.6-35B-A3B-mxfp4
+# Build Bifrost alias table from role names to mlx-local/ prefixed physical IDs
 aliases = lib.mapAttrs
   (_role: physical: "mlx-local/${physical}")
   inputs.nix-ai.lib.aiStackModels;

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ nix-ai exports [home-manager](https://github.com/nix-community/home-manager) mod
 | `homeManagerModules.maestro` | Just Maestro orchestration |
 | `lib.ci.claudeSettingsJson` | Pure JSON for CI validation (no derivations needed) |
 | `lib.ci.codexRules` | Codex rules export for CI validation and downstream consumers |
+| `lib.aiStackModels` | Role-name → physical model ID registry (plain attrset, no module system needed) |
+
+### Cross-repo consumption — `lib.aiStackModels`
+
+`lib.aiStackModels` is a plain attrset (no home-manager module system required) mapping stable
+capability-class names to physical `mlx-community/*` model IDs. Foreign consumers such as the
+orbstack-kubernetes Bifrost gateway can import it directly so `model: "default"` resolves
+prefix-free without duplicating the registry.
+
+```nix
+inputs.nix-ai.url = "github:JacobPEvans/nix-ai";
+# ...
+# Build Bifrost alias table: default → mlx-local/mlx-community/Qwen3.6-35B-A3B-mxfp4
+aliases = lib.mapAttrs
+  (_role: physical: "mlx-local/${physical}")
+  inputs.nix-ai.lib.aiStackModels;
+```
+
+The module option `services.aiStack.models` remains the public API for nix-ai home-manager
+consumers; `lib.aiStackModels` is for foreign consumers that do not import the module.
 
 ### Self-contained design
 

--- a/flake.nix
+++ b/flake.nix
@@ -324,6 +324,14 @@
         claude-registry = import ./lib/claude-registry.nix;
         versions = import ./lib/versions.nix;
 
+        # Role-name → physical mlx-community/* model ID registry.
+        # Exported as a plain attrset so foreign consumers (e.g.
+        # orbstack-kubernetes Bifrost config) can consume it without
+        # importing the home-manager module system. The module at
+        # modules/ai-stack/default.nix uses this same file as its option
+        # default — one source of truth.
+        aiStackModels = import ./lib/ai-stack-models.nix;
+
         # Shared permission + formatter engine. Exposed for cross-flake consumers
         # (e.g., nix-ai-claude) so the source of truth for tool-agnostic command
         # permissions stays in this flake. Callers pass { lib, config,

--- a/lib/ai-stack-models.nix
+++ b/lib/ai-stack-models.nix
@@ -1,0 +1,22 @@
+# AI Stack — Role Registry (pure attrset, no module-system dependency)
+#
+# This file is the single source of truth for role-name → physical model ID
+# mappings. It is intentionally a plain attrset so foreign consumers (e.g.
+# orbstack-kubernetes Bifrost config) can import it without instantiating the
+# home-manager module system.
+#
+# To reference this registry from Nix flake consumers:
+#   inputs.nix-ai.lib.aiStackModels
+#
+# Role names are stable and consumer-facing. Physical model IDs change when
+# we re-benchmark or upstream ships a better quant. All consumers should
+# reference role names, not physical names.
+{
+  default = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
+  quickest = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+  tool-calling = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+  coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+  large-context = "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit";
+  most-capable = "mlx-community/Qwen3.5-122B-A10B-4bit";
+  oss = "mlx-community/gpt-oss-120b-4bit";
+}

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -49,6 +49,7 @@ let
   };
 in
 (import ./checks/lint.nix { inherit pkgs src; })
+// (import ./checks/ai-stack.nix { inherit pkgs; })
 // (import ./checks/claude.nix { inherit pkgs hmConfig; })
 // (import ./checks/agent-skills.nix { inherit pkgs hmConfig; })
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })

--- a/lib/checks/ai-stack.nix
+++ b/lib/checks/ai-stack.nix
@@ -1,0 +1,54 @@
+# lib.aiStackModels regression tests
+# Verifies the role → physical-id registry that is exported as a public flake output.
+{ pkgs }:
+let
+  models = import ../ai-stack-models.nix;
+
+  expectedRoles = [
+    "coding"
+    "default"
+    "large-context"
+    "most-capable"
+    "oss"
+    "quickest"
+    "tool-calling"
+  ];
+
+  actualRoles = builtins.sort builtins.lessThan (builtins.attrNames models);
+
+  missingRoles = builtins.filter (r: !(builtins.hasAttr r models)) expectedRoles;
+in
+{
+  # Verify the exported registry contains exactly the expected role set.
+  ai-stack-models-keys =
+    assert
+      missingRoles == [ ] || throw "lib.aiStackModels missing roles: ${builtins.toJSON missingRoles}";
+    assert
+      actualRoles == expectedRoles
+      || throw "lib.aiStackModels role set changed: expected ${builtins.toJSON expectedRoles}, got ${builtins.toJSON actualRoles}";
+    pkgs.runCommand "check-ai-stack-models-keys" { } ''
+      echo "lib.aiStackModels: ${toString (builtins.length expectedRoles)} roles verified"
+      touch $out
+    '';
+
+  # Verify all physical IDs are non-empty mlx-community/ strings.
+  ai-stack-models-physical-ids =
+    let
+      invalidEntries = builtins.filter (
+        role:
+        let
+          physical = models.${role};
+        in
+        !(builtins.isString physical)
+        || physical == ""
+        || builtins.match "mlx-community/.+" physical == null
+      ) (builtins.attrNames models);
+    in
+    assert
+      invalidEntries == [ ]
+      || throw "lib.aiStackModels physical IDs invalid for roles: ${builtins.toJSON invalidEntries}";
+    pkgs.runCommand "check-ai-stack-models-physical-ids" { } ''
+      echo "lib.aiStackModels: ${toString (builtins.length (builtins.attrNames models))} physical IDs verified as mlx-community/* strings"
+      touch $out
+    '';
+}

--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -18,15 +18,7 @@
 {
   options.services.aiStack.models = lib.mkOption {
     type = lib.types.attrsOf lib.types.str;
-    default = {
-      default = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
-      quickest = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-      tool-calling = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-      coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-      large-context = "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit";
-      most-capable = "mlx-community/Qwen3.5-122B-A10B-4bit";
-      oss = "mlx-community/gpt-oss-120b-4bit";
-    };
+    default = import ../../lib/ai-stack-models.nix;
     description = ''
       Role-name → physical mlx-community/* model ID. Each role becomes a
       first-class llama-swap entry whose cmd runs `vllm-mlx serve <physical>`.


### PR DESCRIPTION
## Summary

Extracts the role→physical model ID registry to a pure `lib/ai-stack-models.nix` attrset and exposes it as `lib.aiStackModels` in flake outputs. Enables foreign consumers (e.g., orbstack-kubernetes Bifrost config) to reference the registry without instantiating home-manager modules. Pure refactor with no value changes.

## Changes

- **lib/ai-stack-models.nix** — New module: plain attrset mapping 7 AI stack roles (default, quickest, coding, tool-calling, large-context, most-capable, oss) to physical mlx-community/* model IDs
- **flake.nix** — Export `lib.aiStackModels` as top-level output
- **modules/ai-stack/default.nix** — Import registry from lib; no logic changes
- **lib/checks/ai-stack.nix** — Regression checks: key set completeness and physical ID format validation
- **README.md** — Remove hardcoded versioned model name from comment

## Test Plan

- [x] `nix eval .#lib.aiStackModels --json` returns all 7 role entries with correct physical IDs
- [x] `nix flake check` passes (deadnix, statix, formatting, shellcheck, regression checks)
- [x] Registry values unchanged — pure refactor, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)