### PR TITLE
feat(gemini): add defaultModel and gemmaModelRouter options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ new ports to avoid collisions (e.g., the 11434/11435/11436 fragmentation during 
 | 11436 | vllm-mlx backend (internal, managed by llama-swap) | HTTP | `modules/mlx/` |
 | 8080 | Open WebUI | HTTP | `modules/open-webui.nix` |
 | 8180 | Fabric REST API (opt-in LaunchAgent) | HTTP + Swagger UI | `modules/fabric/` |
+| 9379 | LiteRT-LM classifier (Gemini CLI gemma router, opt-in) | HTTP | `modules/gemini/` |
 
 **Reserved/conflicting ports to avoid:**
 

--- a/lib/checks/gemini.nix
+++ b/lib/checks/gemini.nix
@@ -10,6 +10,8 @@ in
     let
       expectedOptions = [
         "commands"
+        "contextFileNames"
+        "defaultApprovalMode"
         "defaultModel"
         "enable"
         "excludedMcpServers"
@@ -17,7 +19,10 @@ in
         "gemmaModelRouter"
         "hooks"
         "sandbox"
+        "sandboxAllowedPaths"
+        "sandboxAllowedPathsMerged"
         "trustedFolders"
+        "worktrees"
       ];
       actualOptions = builtins.attrNames cfg;
       missingOptions = builtins.filter (o: !(builtins.elem o actualOptions)) expectedOptions;
@@ -116,6 +121,11 @@ in
           name = "gemini.gemmaModelRouter.binaryPath";
           actual = cfg.gemmaModelRouter.binaryPath;
           expected = "";
+        }
+        {
+          name = "gemini.gemmaModelRouter.classifierModel";
+          actual = cfg.gemmaModelRouter.classifierModel;
+          expected = "gemma3-1b-gpu-custom";
         }
       ];
       failures = builtins.filter (c: c.actual != c.expected) checks;

--- a/lib/checks/gemini.nix
+++ b/lib/checks/gemini.nix
@@ -10,9 +10,11 @@ in
     let
       expectedOptions = [
         "commands"
+        "defaultModel"
         "enable"
         "excludedMcpServers"
         "extensions"
+        "gemmaModelRouter"
         "hooks"
         "sandbox"
         "trustedFolders"
@@ -89,6 +91,31 @@ in
           name = "gemini.sandboxAllowedPaths";
           actual = cfg.sandboxAllowedPaths;
           expected = [ ];
+        }
+        {
+          name = "gemini.defaultModel";
+          actual = cfg.defaultModel;
+          expected = null;
+        }
+        {
+          name = "gemini.gemmaModelRouter.enable";
+          actual = cfg.gemmaModelRouter.enable;
+          expected = false;
+        }
+        {
+          name = "gemini.gemmaModelRouter.autoStartServer";
+          actual = cfg.gemmaModelRouter.autoStartServer;
+          expected = false;
+        }
+        {
+          name = "gemini.gemmaModelRouter.port";
+          actual = cfg.gemmaModelRouter.port;
+          expected = 9379;
+        }
+        {
+          name = "gemini.gemmaModelRouter.binaryPath";
+          actual = cfg.gemmaModelRouter.binaryPath;
+          expected = "";
         }
       ];
       failures = builtins.filter (c: c.actual != c.expected) checks;

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -185,7 +185,8 @@ in
         the current accepted values.
         null leaves Gemini CLI's own model resolution alone.
         NOTE: Google-hosted model values execute in Google's cloud. For
-        on-device generation see modules/gemini/README.md.
+        on-device generation via local MLX inference, configure
+        GOOGLE_GEMINI_BASE_URL to point at the Bifrost genai translator.
       '';
     };
 

--- a/modules/gemini/options.nix
+++ b/modules/gemini/options.nix
@@ -171,6 +171,59 @@ in
       '';
     };
 
+    # Default chat model
+    defaultModel = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Pin Gemini CLI's default chat model (sets model.name in settings.json).
+        Accepts any value the upstream CLI accepts: tier aliases ("pro", "flash",
+        "flash-lite"), "auto" family aliases, or explicit model IDs from the
+        upstream registry. Prefer aliases over versioned IDs so this option
+        does not go stale when upstream ships new models.
+        See the in-CLI /model dialog or upstream settings.schema.json for
+        the current accepted values.
+        null leaves Gemini CLI's own model resolution alone.
+        NOTE: Google-hosted model values execute in Google's cloud. For
+        on-device generation see modules/gemini/README.md.
+      '';
+    };
+
+    # Experimental local Gemma classifier router (LiteRT-LM)
+    gemmaModelRouter = {
+      enable = lib.mkEnableOption "experimental local Gemma classifier router (LiteRT-LM)";
+
+      autoStartServer = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Automatically start the LiteRT-LM server when Gemini CLI starts.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 9379;
+        description = "Local port for the LiteRT-LM classifier HTTP server.";
+      };
+
+      classifierModel = lib.mkOption {
+        type = lib.types.str;
+        default = "gemma3-1b-gpu-custom";
+        description = ''
+          LiteRT-LM bundle name used by the local classifier. This is a
+          LiteRT-LM identifier, NOT an MLX model ID — different runtime,
+          different catalog. Discover available bundles via the runtime's
+          list-models subcommand. Cannot reference services.aiStack.models
+          (those are MLX models served by a different stack).
+        '';
+      };
+
+      binaryPath = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "Override path to the LiteRT-LM binary. Empty string uses Gemini CLI's default (~/.gemini/bin/litert/).";
+      };
+    };
+
     # MCP servers to exclude from shared definitions
     excludedMcpServers = lib.mkOption {
       type = lib.types.listOf lib.types.str;

--- a/modules/gemini/settings.nix
+++ b/modules/gemini/settings.nix
@@ -111,9 +111,24 @@ let
 
     experimental = {
       inherit (cfg) worktrees;
+    }
+    // lib.optionalAttrs cfg.gemmaModelRouter.enable {
+      gemmaModelRouter = {
+        enabled = true;
+        inherit (cfg.gemmaModelRouter) autoStartServer binaryPath;
+        classifier = {
+          host = "http://localhost:${toString cfg.gemmaModelRouter.port}";
+          model = cfg.gemmaModelRouter.classifierModel;
+        };
+      };
     };
 
     inherit mcpServers;
+  }
+  // lib.optionalAttrs (cfg.defaultModel != null) {
+    model = {
+      name = cfg.defaultModel;
+    };
   };
 
   settingsJson =


### PR DESCRIPTION
## Summary

- Add `programs.gemini.defaultModel` to pin Gemini CLI's default chat model
- Add `programs.gemini.gemmaModelRouter` to wire up experimental LiteRT-LM classifier for model routing (cloud Gemini, not local generation)
- Complete regression test suite for all Gemini module options and add port 9379 to allocation table

## Changes

- `modules/gemini/default.nix` — New options for Gemini CLI configuration
- `modules/gemini/` — Regression tests covering defaultModel, gemmaModelRouter, and expectedOptions validation
- `CLAUDE.md` — Port 9379 registered for gemmaModelRouter classifier service
- Follow-up fixes: completed expectedOptions list, added classifierModel default validation, removed stale README reference from option description

## Test Plan

- [ ] `nix flake check` passes (formatting, statix, deadnix, regression tests)
- [ ] Build with `programs.gemini.defaultModel = "gemini-3.5-sonnet"` and verify `.gemini/config.json` contains setting
- [ ] Build with `programs.gemini.gemmaModelRouter.enable = true` and verify LiteRT-LM classifier is wired to port 9379
- [ ] Verify regression tests validate all new options and detect breaking changes
- [ ] Test in live session: start fresh Claude Code and confirm Gemini module loads without errors