### PR TITLE
ci: remove deprecated app-id secret passthrough

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -26,7 +26,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -29,5 +29,4 @@ jobs:
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,5 +13,4 @@ jobs:
       pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -19,5 +19,4 @@ jobs:
   retrigger:
     uses: JacobPEvans/.github/.github/workflows/_retrigger-pr-checks.yml@main
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Removes hardcoded `GH_ACTION_JACOBPEVANS_APP_ID` secret passthrough from reusable workflow callers, completing the migration to centralized GitHub App Client ID management via repository variables.

## Changes

- Remove `GH_ACTION_JACOBPEVANS_APP_ID` from `secrets:` blocks in:
  - deps-update-flake.yml
  - gh-aw-pin-refresh.yml
  - release-please.yml
  - retrigger-pr-checks.yml
- Central reusable workflows now read `vars.GH_APP_CLIENT_ID` directly (no explicit passthrough needed)

## Test Plan

- [x] Verify no secrets are explicitly passed to callers
- [x] Confirm vars.GH_APP_CLIENT_ID is available in reusable workflow context
- [x] Run one update cycle (deps-update-flake) to confirm App auth still works