### PR TITLE
refactor(docs): path-scope rules and trim CLAUDE.md (Tier 2)

### DIFF
--- a/.claude/rules/plugin-cache-architecture.md
+++ b/.claude/rules/plugin-cache-architecture.md
@@ -1,3 +1,13 @@
+---
+description: Marketplace symlinks vs cache, never delete cache mid-session, never mutate cache from activation scripts
+paths:
+  - "**/.claude/plugins/**"
+  - "**/modules/claude/**"
+  - "**/plugins.nix"
+  - "**/plugins/*.nix"
+  - "**/orphan-cleanup.nix"
+---
+
 # Plugin Cache Architecture
 
 ## Marketplace Symlinks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,131 +68,31 @@ constraints and on-demand patterns.
 
 ## Architecture Documentation
 
-Cross-cutting architecture views live in `docs/architecture/`:
-
-- [`system-integration-map.md`](docs/architecture/system-integration-map.md) — How all 10 AI products connect
-- [`model-discovery-flow.md`](docs/architecture/model-discovery-flow.md) — MLX → PAL model data flow (debugging reference)
-- [`config-lifecycle.md`](docs/architecture/config-lifecycle.md) — Build → activation → runtime config pipeline
-- [`secrets-and-injection.md`](docs/architecture/secrets-and-injection.md) — Doppler, Keychain, K8s Operator patterns
-
-Design decisions: [`docs/adr/`](docs/adr/README.md)
+Cross-cutting views live in [`docs/architecture/`](docs/architecture/README.md):
+system-integration-map (topology + ports), model-discovery-flow, config-lifecycle,
+secrets-and-injection, mlx-stack. Design decisions in [`docs/adr/`](docs/adr/README.md).
 
 ## Key Files
 
-- `modules/default.nix` — Module entry point (imports all AI modules)
-- `modules/claude/` — Claude Code module (plugins, hooks, agents, commands, rules); see [`modules/claude/README.md`](modules/claude/README.md)
+- `modules/default.nix` — Module entry point
+- `modules/claude/` — Claude Code module ([README](modules/claude/README.md))
 - `modules/mcp/` — MCP server definitions
-- `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools, perf tuning)
+- `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools)
 - `modules/common/` — Shared permission engine and formatters
-- `lib/claude-settings.nix` — Pure settings generator (CI-only; deployment uses modules/claude/settings.nix)
+- `lib/claude-settings.nix` — Pure settings generator (CI-only)
 - `lib/claude-registry.nix` — Marketplace format functions
-- `lib/checks.nix` — Check aggregator (imports lib/checks/{lint,claude,mlx}.nix)
-- `lib/checks/lint.nix` — Formatting, statix, deadnix, shellcheck
-- `lib/checks/claude.nix` — Claude module regression tests, settings-json, maestro-script
-- `lib/checks/mlx.nix` — MLX option/defaults regression, LaunchAgent flag validation
+- `lib/checks/` — Per-domain regression tests (lint, claude, mlx)
 
-## MLX Ecosystem Stack
+## MLX Ecosystem
 
-Three user-facing tools built on the MLX core framework for Apple Silicon inference:
-
-| Role | Package | Purpose | Install Method |
-| ---- | ------- | ------- | -------------- |
-| Ears (Audio) | `parakeet-mlx` | Real-time speech-to-text | `uvx` wrapper (Nix derivation) |
-| Eyes (Vision) | `mlx-vlm` | Screen/camera image analysis | `uvx` wrapper (Nix derivation) |
-| Brain (LLM) | `vllm-mlx` | LLM inference API server | `uvx` wrapper (LaunchAgent) |
-
-### Dependency graph
-
-```mermaid
-graph TD
-    subgraph "MLX Inference Stack"
-        subgraph "User-Facing Tools"
-            EARS["Ears — parakeet-mlx<br/><i>Speech-to-text</i>"]
-            EYES["Eyes — mlx-vlm<br/><i>Vision analysis</i>"]
-            BRAIN["Brain — vllm-mlx<br/><i>LLM inference API</i>"]
-        end
-
-        subgraph "Shared Libraries"
-            MLX_LM["mlx-lm"]
-            MLX_EMB["mlx-embeddings"]
-            TRANSFORMERS["transformers"]
-            HF_HUB["huggingface-hub"]
-        end
-
-        subgraph "Foundation"
-            MLX["mlx<br/><i>Core framework</i>"]
-        end
-    end
-
-    subgraph "System Dependencies"
-        FFMPEG["ffmpeg"]
-        OPENCV["opencv-python"]
-    end
-
-    EARS --> MLX
-    EARS --> HF_HUB
-    EARS --> FFMPEG
-
-    EYES --> MLX_LM
-    EYES --> MLX
-    EYES --> TRANSFORMERS
-    EYES --> OPENCV
-
-    BRAIN --> MLX_LM
-    BRAIN --> EYES
-    BRAIN --> MLX_EMB
-    BRAIN --> TRANSFORMERS
-    BRAIN --> HF_HUB
-
-    MLX_LM --> MLX
-    MLX_LM --> TRANSFORMERS
-    MLX_EMB --> MLX
-    MLX_EMB --> EYES
-```
-
-### Version management
-
-- **Version constants**: `modules/mlx/default.nix` — single source of truth with Renovate annotations
-- **uvx wrappers**: `modules/mlx/packages.nix` — declarative Nix derivations for the MLX tools
-- **Auto-update**: Renovate annotation-based manager bumps version constants, weekly schedule
-
-### Operational Notes
-
-**Tool-call parser compatibility**: vllm-mlx defaults to `--tool-call-parser hermes`. Only Qwen
-models pass tool-calling validation with this parser; GLM and Seed-OSS models fail with output
-format errors despite correct reasoning. To use non-Qwen models for tool calling, switch to
-`auto` or a model-specific parser in the llama-swap config.
-
-**Idle penalty**: After ~1 hour idle, macOS memory compression evicts the model from active
-memory. The next request triggers a full reload, causing 300s+ timeouts through Bifrost.
-Restore with `mlx-default` to return to normal latency.
-
-**MoE vs dense throughput** (M4 Max, 128GB): 122B MoE models achieve ~24 tok/s; dense models
-of similar parameter count (~123B) top out at ~6.6 tok/s. Prefer MoE for throughput-sensitive
-tasks. Cold-start overhead: preloaded 35B adds ~1.5s; 122B MoE from disk adds ~86s.
-
-## Port Allocation
-
-Services managed by nix-ai and their assigned ports. Check this table before assigning
-new ports to avoid collisions (e.g., the 11434/11435/11436 fragmentation during the MLX arc).
-
-| Port | Service | Protocol | Module |
-| ---- | ------- | -------- | ------ |
-| 11434 | llama-swap proxy (routes to vllm-mlx) | HTTP (OpenAI-compatible) | `modules/mlx/` |
-| 11436 | vllm-mlx backend (internal, managed by llama-swap) | HTTP | `modules/mlx/` |
-| 8080 | Open WebUI | HTTP | `modules/open-webui.nix` |
-| 8180 | Fabric REST API (opt-in LaunchAgent) | HTTP + Swagger UI | `modules/fabric/` |
-| 9379 | LiteRT-LM classifier (Gemini CLI gemma router, opt-in) | HTTP | `modules/gemini/` |
-
-**Reserved/conflicting ports to avoid:**
-
-- 11435: reserved — external macOS app conflict (see PR #230)
+Three tools — `parakeet-mlx` (audio), `mlx-vlm` (vision), `vllm-mlx` (LLM) — installed
+as `uvx` wrappers; vllm-mlx runs as a LaunchAgent fronted by llama-swap. Full dependency
+graph, version management, and operational notes (tool-call parser, idle eviction, MoE
+throughput) in [`docs/architecture/mlx-stack.md`](docs/architecture/mlx-stack.md).
+Port allocation lives in [`docs/architecture/system-integration-map.md`](docs/architecture/system-integration-map.md).
 
 ## Related Repos
 
-| Repo | Purpose |
-| ---- | ------- |
-| **nix-ai** (this repo) | AI coding tools |
-| [nix-devenv](https://github.com/JacobPEvans/nix-devenv) | Reusable dev shells (Terraform, Ansible, K8s, AI/ML) |
-| [nix-home](https://github.com/JacobPEvans/nix-home) | Dev environment (git, zsh, VS Code, tmux) |
-| [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes the others) |
+Quartet membership and roles are documented in `~/git/CLAUDE.md`. This repo exports
+home-manager modules consumed by `nix-darwin`; sibling repos are `nix-home` (dev env)
+and `nix-devenv` (reusable dev shells).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ secrets-and-injection, mlx-stack. Design decisions in [`docs/adr/`](docs/adr/REA
 - `modules/mcp/` — MCP server definitions
 - `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools)
 - `modules/common/` — Shared permission engine and formatters
-- `lib/claude-settings.nix` — Pure settings generator (CI-only)
+- `lib/claude-settings.nix` — Pure settings generator (CI-only; deployment uses `modules/claude/settings.nix`)
 - `lib/claude-registry.nix` — Marketplace format functions
 - `lib/checks/` — Per-domain regression tests (lint, claude, mlx)
 
@@ -93,6 +93,6 @@ Port allocation lives in [`docs/architecture/system-integration-map.md`](docs/ar
 
 ## Related Repos
 
-Quartet membership and roles are documented in `~/git/CLAUDE.md`. This repo exports
-home-manager modules consumed by `nix-darwin`; sibling repos are `nix-home` (dev env)
-and `nix-devenv` (reusable dev shells).
+This repo exports home-manager modules consumed by [`nix-darwin`](https://github.com/JacobPEvans/nix-darwin).
+Sibling repos: [`nix-home`](https://github.com/JacobPEvans/nix-home) (user dev environment) and
+[`nix-devenv`](https://github.com/JacobPEvans/nix-devenv) (reusable dev shells).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -52,6 +52,15 @@ use which pattern and explains the trust boundary each pattern enforces.
 **Read when**: Adding a new MCP server that needs API keys, debugging secrets not reaching
 a subprocess, or auditing where credentials flow.
 
+### [mlx-stack.md](mlx-stack.md)
+
+The three user-facing MLX tools (parakeet-mlx, mlx-vlm, vllm-mlx) and their shared library
+dependencies. Includes the dependency graph, version management strategy, and operational
+notes covering tool-call parser compatibility, idle eviction, and MoE vs dense throughput.
+
+**Read when**: Adding a new MLX tool, debugging a model loading or tool-calling issue,
+or understanding why the 35B model is preloaded vs the 122B MoE.
+
 ## ADRs
 
 [`docs/adr/`](../adr/README.md) contains the decisions behind non-obvious design choices.

--- a/docs/architecture/mlx-stack.md
+++ b/docs/architecture/mlx-stack.md
@@ -1,0 +1,87 @@
+# MLX Inference Stack
+
+Three user-facing tools built on the MLX core framework for Apple Silicon inference,
+plus shared libraries and operational behaviour.
+
+## Tools
+
+| Role | Package | Purpose | Install Method |
+| ---- | ------- | ------- | -------------- |
+| Ears (Audio) | `parakeet-mlx` | Real-time speech-to-text | `uvx` wrapper (Nix derivation) |
+| Eyes (Vision) | `mlx-vlm` | Screen/camera image analysis | `uvx` wrapper (Nix derivation) |
+| Brain (LLM) | `vllm-mlx` | LLM inference API server | `uvx` wrapper (LaunchAgent) |
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    subgraph "MLX Inference Stack"
+        subgraph "User-Facing Tools"
+            EARS["Ears — parakeet-mlx<br/><i>Speech-to-text</i>"]
+            EYES["Eyes — mlx-vlm<br/><i>Vision analysis</i>"]
+            BRAIN["Brain — vllm-mlx<br/><i>LLM inference API</i>"]
+        end
+
+        subgraph "Shared Libraries"
+            MLX_LM["mlx-lm"]
+            MLX_EMB["mlx-embeddings"]
+            TRANSFORMERS["transformers"]
+            HF_HUB["huggingface-hub"]
+        end
+
+        subgraph "Foundation"
+            MLX["mlx<br/><i>Core framework</i>"]
+        end
+    end
+
+    subgraph "System Dependencies"
+        FFMPEG["ffmpeg"]
+        OPENCV["opencv-python"]
+    end
+
+    EARS --> MLX
+    EARS --> HF_HUB
+    EARS --> FFMPEG
+
+    EYES --> MLX_LM
+    EYES --> MLX
+    EYES --> TRANSFORMERS
+    EYES --> OPENCV
+
+    BRAIN --> MLX_LM
+    BRAIN --> EYES
+    BRAIN --> MLX_EMB
+    BRAIN --> TRANSFORMERS
+    BRAIN --> HF_HUB
+
+    MLX_LM --> MLX
+    MLX_LM --> TRANSFORMERS
+    MLX_EMB --> MLX
+    MLX_EMB --> EYES
+```
+
+## Version Management
+
+- **Version constants**: `modules/mlx/default.nix` — single source of truth with Renovate annotations
+- **uvx wrappers**: `modules/mlx/packages.nix` — declarative Nix derivations for the MLX tools
+- **Auto-update**: Renovate annotation-based manager bumps version constants, weekly schedule
+
+## Operational Notes
+
+**Tool-call parser compatibility**: vllm-mlx defaults to `--tool-call-parser hermes`. Only Qwen
+models pass tool-calling validation with this parser; GLM and Seed-OSS models fail with output
+format errors despite correct reasoning. To use non-Qwen models for tool calling, switch to
+`auto` or a model-specific parser in the llama-swap config.
+
+**Idle penalty**: After ~1 hour idle, macOS memory compression evicts the model from active
+memory. The next request triggers a full reload, causing 300s+ timeouts through Bifrost.
+Restore with `mlx-default` to return to normal latency.
+
+**MoE vs dense throughput** (M4 Max, 128GB): 122B MoE models achieve ~24 tok/s; dense models
+of similar parameter count (~123B) top out at ~6.6 tok/s. Prefer MoE for throughput-sensitive
+tasks. Cold-start overhead: preloaded 35B adds ~1.5s; 122B MoE from disk adds ~86s.
+
+## Related
+
+- [system-integration-map.md](system-integration-map.md) — Port allocation table, full topology
+- [model-discovery-flow.md](model-discovery-flow.md) — How model data flows from Nix → llama-swap → PAL

--- a/docs/architecture/mlx-stack.md
+++ b/docs/architecture/mlx-stack.md
@@ -49,7 +49,6 @@ graph TD
     EYES --> OPENCV
 
     BRAIN --> MLX_LM
-    BRAIN --> EYES
     BRAIN --> MLX_EMB
     BRAIN --> TRANSFORMERS
     BRAIN --> HF_HUB
@@ -57,7 +56,6 @@ graph TD
     MLX_LM --> MLX
     MLX_LM --> TRANSFORMERS
     MLX_EMB --> MLX
-    MLX_EMB --> EYES
 ```
 
 ## Version Management

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -137,6 +137,7 @@ Enable by overriding `programs.aiMcp.servers.<name>.disabled` and adding the key
 | 11436+ | vllm-mlx backends | HTTP (managed by llama-swap) | `modules/mlx/` |
 | 8080 | Open WebUI | HTTP | `modules/open-webui.nix` |
 | 8180 | Fabric REST API (opt-in) | HTTP + Swagger UI | `modules/fabric/` |
+| 9379 | LiteRT-LM classifier (Gemini CLI gemma router, opt-in) | HTTP | `modules/gemini/` |
 | 30080 | Bifrost AI gateway | HTTP | `orbstack-kubernetes` repo |
 | 30030 | Cribl MCP | HTTP | `orbstack-kubernetes` repo |
 

--- a/modules/claude/rules/pal-mcp-policy.md
+++ b/modules/claude/rules/pal-mcp-policy.md
@@ -1,5 +1,16 @@
 ---
 description: PAL MCP availability protocol — clink/consensus have no native fallback; chat/listmodels re-enabled
+paths:
+  - "**/.claude/**"
+  - "**/.gemini/**"
+  - "**/.copilot/**"
+  - "**/modules/claude/**"
+  - "**/modules/gemini/**"
+  - "**/modules/mcp/**"
+  - "**/bifrost*/**"
+  - "**/pal*/**"
+  - "**/llama-swap*/**"
+  - "**/mlx*/**"
 ---
 
 # PAL MCP Policy


### PR DESCRIPTION
## Summary

Tier 2 of the context token optimization plan ([#693](https://github.com/JacobPEvans/nix-ai/pull/693)).
Reduces always-loaded session context overhead by path-scoping two rule files
and extracting non-orchestrator content from \`CLAUDE.md\` into architecture docs.

## Changes

- **\`.claude/rules/plugin-cache-architecture.md\`**: add \`paths:\` frontmatter
  scoping to \`**/.claude/plugins/**\`, \`**/modules/claude/**\`, \`**/plugins.nix\`,
  \`**/plugins/*.nix\`, \`**/orphan-cleanup.nix\`. Loads only when working on
  plugin/Nix module files.
- **\`modules/claude/rules/pal-mcp-policy.md\`**: add \`paths:\` frontmatter
  scoping to \`.claude/\`, \`.gemini/\`, \`.copilot/\`, \`modules/{claude,gemini,mcp}/\`,
  and \`bifrost*\`/\`pal*\`/\`llama-swap*\`/\`mlx*\` paths. Loads only when working
  on AI tool / MCP files where \`clink\`/\`consensus\` are likely to be invoked.
- **\`docs/architecture/mlx-stack.md\`** (new): MLX dependency graph, version
  management, operational notes (tool-call parser compatibility, idle eviction,
  MoE vs dense throughput) extracted from \`CLAUDE.md\`.
- **\`CLAUDE.md\`**: trim ~133 lines (≈1k tokens) by replacing the inline MLX
  section, port allocation table, and related-repos table with links to the
  architecture docs and \`~/git/CLAUDE.md\`.
- **\`docs/architecture/README.md\`**: add the new \`mlx-stack.md\` to the
  documents-in-this-directory section.

## Token Savings

- \`CLAUDE.md\`: ~1974 → ~995 tokens (always loaded → ~1k saved)
- \`pal-mcp-policy.md\` (~480 tokens): now path-scoped → ~480 saved on non-AI work
- \`plugin-cache-architecture.md\` (~440 tokens): now path-scoped → ~440 saved
  on non-plugin work

Combined savings depend on the working file mix; expected ~1-2k tokens per
session for typical non-AI/non-plugin work, ~1k tokens always.

## Out of Scope

The plan also called for trimming \`~/CLAUDE.md\` and \`~/git/CLAUDE.md\` and
adding \`agentsmd/rules/repo-map.md\` — those live in
\`ai-assistant-instructions\` and ship in a separate PR there. \`MEMORY.md\`
trim is a direct user-level edit, also separate.

## Test plan

- [x] \`nix flake check\` passes (formatting, statix, deadnix, shellcheck,
      regression tests all green)
- [ ] After merge: \`darwin-rebuild switch --flake ~/git/nix-darwin/main
      --override-input nix-ai .\` and confirm in a fresh Claude Code session
      via \`/context\` that \`CLAUDE.md\` and the path-scoped rules behave as
      expected (universal CLAUDE.md still loads; rules load only on matching
      file paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)