### PR TITLE
refactor(browser-use): consolidate duplicate renovate pins

### DIFF
--- a/lib/checks/fabric.nix
+++ b/lib/checks/fabric.nix
@@ -159,6 +159,7 @@ in
         inherit (pkgs) lib;
         # The browser-use and jacobpevans wrappers also live in this file but
         # are unused by the fabric check — pass nulls to satisfy module args.
+        browserUseVersion = null;
         marketplaceInputs = {
           browser-use-skills = null;
           jacobpevans-cc-plugins = null;

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -10,6 +10,7 @@
   marketplaceInputs,
   claude-cookbooks,
   fabric-src,
+  browserUseVersion,
   ...
 }:
 
@@ -71,6 +72,7 @@ let
       marketplaceInputs
       fabric-src
       fabricVersion
+      browserUseVersion
       ;
   };
   inherit (marketplaceOverrides)

--- a/modules/claude/marketplace-overrides.nix
+++ b/modules/claude/marketplace-overrides.nix
@@ -9,6 +9,7 @@
   marketplaceInputs,
   fabric-src,
   fabricVersion,
+  browserUseVersion,
   ...
 }:
 
@@ -16,9 +17,6 @@
   # Synthetic marketplace wrapper for browser-use skills (repo lacks .claude-plugin structure)
   browserUseMarketplace =
     let
-      # Pinned to match uv-installed CLI version (modules/default.nix installBrowserUse)
-      # renovate: datasource=pypi depName=browser-use
-      browserUseVersion = "0.12.6";
       manifestJson = builtins.toFile "marketplace.json" (
         builtins.toJSON {
           name = "browser-use-skills";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -32,6 +32,7 @@ let
       marketplaceInputs
       claude-cookbooks
       fabric-src
+      browserUseVersion
       ;
   };
 
@@ -69,10 +70,8 @@ let
 
   # renovate: datasource=pypi depName=open-webui
   openWebuiVersion = "0.9.2";
-  # Keep in sync with modules/claude/marketplace-overrides.nix browserUseVersion.
-  # Renovate updates both files in a single PR (same datasource+depName = one update).
   # renovate: datasource=pypi depName=browser-use
-  browserUseInstallVersion = "0.12.6";
+  browserUseVersion = "0.12.6";
 in
 {
   imports = [
@@ -132,7 +131,7 @@ in
         installBrowserUse = lib.hm.dag.entryAfter [ "writeBoundary" "knownMarketplacesMerge" ] ''
           if ! ${lib.getExe pkgs.uv} tool list 2>/dev/null | grep -q "^browser-use"; then
             echo "-> Installing browser-use via uv..."
-            $DRY_RUN_CMD ${lib.getExe pkgs.uv} tool install "browser-use==${browserUseInstallVersion}"
+            $DRY_RUN_CMD ${lib.getExe pkgs.uv} tool install "browser-use==${browserUseVersion}"
           fi
         '';
       };


### PR DESCRIPTION
## Summary

Unifies two identically-annotated Renovate datasource pins for the browser-use PyPI package into a single source of truth. Previously maintained separate `browserUseInstallVersion` (modules/default.nix) and `browserUseVersion` (modules/claude/marketplace-overrides.nix) variables, each with duplicate `# renovate: datasource=pypi depName=browser-use` annotations.

Now defines `browserUseVersion` once in modules/default.nix (where uv install runs) and threads it through claude-config.nix → marketplace-overrides.nix as a function argument, mirroring the existing fabricVersion pattern.

## Changes

- Collapsed dual version variables into single `browserUseVersion` in modules/default.nix
- Threaded browserUseVersion through claude-config.nix to marketplace-overrides.nix via argument inheritance
- Eliminated duplicate Renovate datasource annotation (one PR per release instead of multiple)
- Fixed lib/checks/fabric.nix to pass browserUseVersion = null in its null-placeholder arguments for marketplace-overrides.nix import

## Test Plan

- [x] `nix eval .#homeManagerModules --apply 'x: builtins.typeOf x'` returns "set" cleanly
- [ ] Home-manager rebuild on darwin host; confirm `~/.claude/marketplaces/browser-use/.claude-plugin/plugin.json` contains correct version
- [ ] `uv tool list | grep browser-use` shows active version; activation is idempotent (no change expected)
- [ ] Grep for Renovate annotation: `grep -rn "depName=browser-use" modules/` returns exactly one line