### PR TITLE
refactor(versions): centralize huggingface-hub version in lib/versions.nix

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -12,4 +12,11 @@
 # - .github/workflows/ci-eol-check.yml - end-of-life validation
 {
   stableVersion = "25.11";
+
+  # Package version pins — single source of truth for cross-module shared deps.
+  # Each entry must have a `# renovate:` annotation immediately above it so the
+  # org-wide customManager regex tracks it (datasource= depName= on one line).
+
+  # renovate: datasource=pypi depName=huggingface-hub
+  huggingfaceHub = "1.13.0";
 }

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -14,8 +14,9 @@
   stableVersion = "25.11";
 
   # Package version pins — single source of truth for cross-module shared deps.
-  # Each entry must have a `# renovate:` annotation immediately above it so the
-  # org-wide customManager regex tracks it (datasource= depName= on one line).
+  # Each pin entry (below) must have a `# renovate:` annotation immediately above
+  # it so the org-wide customManager regex tracks it (datasource= depName= on one
+  # line). `stableVersion` above is informational and not tracked by Renovate.
 
   # renovate: datasource=pypi depName=huggingface-hub
   huggingfaceHub = "1.13.0";

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -74,6 +74,7 @@
 
 { pkgs, ... }:
 let
+  versions = import ../lib/versions.nix;
   # renovate: datasource=npm depName=@felixgeelhaar/cclint
   cclintVersion = "0.12.1";
   # renovate: datasource=npm depName=@githubnext/github-copilot-cli
@@ -84,8 +85,6 @@ let
   claudeFlowVersion = "3.6.12";
   # renovate: datasource=npm depName=@googleworkspace/cli
   gwsCliVersion = "0.22.5";
-  # renovate: datasource=pypi depName=huggingface-hub
-  huggingfaceHubVersion = "1.13.0";
 in
 {
   # AI-specific development tools
@@ -193,7 +192,7 @@ in
     # PyPI: huggingface-hub (provides `hf` entry point)
     # Requires: HF_TOKEN env var (from macOS Keychain via nix-darwin shell init)
     (writeShellScriptBin "hf" ''
-      exec ${uv}/bin/uvx --from "huggingface-hub==${huggingfaceHubVersion}" hf "$@"
+      exec ${uv}/bin/uvx --from "huggingface-hub==${versions.huggingfaceHub}" hf "$@"
     '')
 
     # ==========================================================================

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -15,6 +15,8 @@ let
     inherit args;
   };
 
+  versions = import ../../lib/versions.nix;
+
   # ================================================================
   # Package version pins — Renovate tracks these via annotation comments
   # ================================================================
@@ -42,8 +44,6 @@ let
   mcpServerTimeVersion = "2026.1.26";
   # renovate: datasource=pypi depName=huggingface-mcp-server
   hfMcpServerVersion = "0.1.0";
-  # renovate: datasource=pypi depName=huggingface-hub
-  huggingfaceHubVersion = "1.13.0";
   # renovate: datasource=pypi depName=fabric-mcp
   fabricMcpVersion = "1.1.0";
   # renovate: datasource=pypi depName=google-workspace-mcp
@@ -124,7 +124,7 @@ in
       "--from"
       "huggingface-mcp-server==${hfMcpServerVersion}"
       "--with"
-      "huggingface-hub==${huggingfaceHubVersion}"
+      "huggingface-hub==${versions.huggingfaceHub}"
       "huggingface-mcp-server"
     ];
   };


### PR DESCRIPTION
## Summary

- Move the duplicated `huggingfaceHub = "1.13.0"` pin out of `modules/ai-tools.nix` and `modules/mcp/catalog.nix`
- Extend `lib/versions.nix` to host the pin as the single source of truth
- Both consumers import `lib/versions.nix` and reference `versions.huggingfaceHub`
- Clarify the lib/versions.nix comment to note `stableVersion` is informational and exempt from the Renovate annotation requirement

## Changes

Previously, `huggingfaceHubVersion = "1.13.0"` existed in two files with identical `# renovate:` annotations. Renovate kept them in sync only because both annotations existed — drop either one and the values silently drift. This PR collapses them into one canonical entry.

## Test Plan

- [ ] `nix flake check` passes
- [ ] `nix eval .#lib.versions.huggingfaceHub` returns `"1.13.0"`
- [ ] `grep -r "huggingfaceHubVersion" --include="*.nix"` returns no results