### PR TITLE
refactor(versions): hoist all renovate pins to lib/versions.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,8 +119,11 @@
     };
 
     # Fabric - Daniel Miessler's 252+ AI prompt pattern framework (Go CLI).
-    # Source of both the fabric binary and the pattern library. Pinned to a
-    # release tag; Renovate bumps via the annotation in modules/fabric/package.nix.
+    # Source of both the fabric binary and the pattern library. The flake input
+    # tag and lib/versions.nix.fabric must stay in sync — Renovate opens separate
+    # PRs for each (nix manager for this URL, custom.regex for the version).
+    # scripts/check-fabric-version-sync.sh catches label drift; vendorHash
+    # catches source changes that weren't accompanied by a version bump.
     fabric-src = {
       url = "github:danielmiessler/fabric/v1.4.444";
       flake = false;

--- a/lib/checks/fabric.nix
+++ b/lib/checks/fabric.nix
@@ -141,6 +141,35 @@ in
       touch $out
     '';
 
+  # Assert the fabric version in lib/versions.nix matches the version tag of
+  # the fabric-src flake input in flake.nix. Renovate's nix manager bumps
+  # fabric-src; the customManager regex bumps lib/versions.nix.fabric. The
+  # vendorHash only validates the fetched Go source tree — it does NOT detect
+  # label drift. This is the Nix-native equivalent of
+  # scripts/check-fabric-version-sync.sh and runs in every `nix flake check`.
+  fabric-version-sync =
+    let
+      flakeSrc = builtins.readFile "${src}/flake.nix";
+      versions = import "${src}/lib/versions.nix";
+      flakeMatch = builtins.match ".*github:danielmiessler/fabric/v([0-9][^\"]*)\".*" flakeSrc;
+    in
+    assert pkgs.lib.assertMsg (
+      flakeMatch != null
+    ) "fabric-version-sync: could not parse fabric-src tag from flake.nix";
+    let
+      flakeVersion = builtins.elemAt flakeMatch 0;
+      pinVersion = versions.fabric or "";
+    in
+    assert pkgs.lib.assertMsg (
+      pinVersion != ""
+    ) "fabric-version-sync: lib/versions.nix has no `fabric` entry";
+    assert pkgs.lib.assertMsg (flakeVersion == pinVersion)
+      "fabric version drift: flake.nix fabric-src=v${flakeVersion} but lib/versions.nix.fabric=${pinVersion}";
+    pkgs.runCommand "check-fabric-version-sync" { } ''
+      echo "Fabric version sync: flake.nix v${flakeVersion} == lib/versions.nix.fabric ${pinVersion}"
+      touch $out
+    '';
+
   # Build the synthetic fabric-patterns marketplace and assert the SKILL.md
   # count matches the curated JSON entry count. Catches silent JSON edits.
   fabric-marketplace-build =

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -85,8 +85,12 @@
   browserUse = "0.12.6";
 
   # Fabric Go CLI (github-releases)
-  # The flake input fabric-src is ALSO tracked by Renovate's nix manager.
-  # Both must be bumped together — CI catches mismatches via vendorHash.
+  # The flake input fabric-src is ALSO tracked by Renovate's nix manager and
+  # must be bumped to the same tag. vendorHash only validates the fetched Go
+  # source tree — it does NOT detect label drift between this pin and the
+  # fabric-src input. The fabric-version-sync regression check in
+  # lib/checks/fabric.nix (and scripts/check-fabric-version-sync.sh for
+  # pre-commit / manual runs) compares the two and fails on drift.
   # renovate: datasource=github-releases depName=danielmiessler/fabric
   fabric = "1.4.444";
 }

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -12,4 +12,11 @@
 # - .github/workflows/ci-eol-check.yml - end-of-life validation
 {
   stableVersion = "25.11";
+
+  # Package version pins — single source of truth for cross-module shared deps.
+  # Each entry must have a `# renovate:` annotation immediately above it so the
+  # org-wide customManager regex tracks it (datasource= depName= on one line).
+
+  # renovate: datasource=pypi depName=huggingface-hub
+  huggingfaceHub = "1.13.0";
 }

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -83,4 +83,10 @@
   openWebui = "0.9.2";
   # renovate: datasource=pypi depName=browser-use
   browserUse = "0.12.6";
+
+  # Fabric Go CLI (github-releases)
+  # The flake input fabric-src is ALSO tracked by Renovate's nix manager.
+  # Both must be bumped together — CI catches mismatches via vendorHash.
+  # renovate: datasource=github-releases depName=danielmiessler/fabric
+  fabric = "1.4.444";
 }

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -18,6 +18,69 @@
   # it so the org-wide customManager regex tracks it (datasource= depName= on one
   # line). `stableVersion` above is informational and not tracked by Renovate.
 
+  # HuggingFace stack
   # renovate: datasource=pypi depName=huggingface-hub
   huggingfaceHub = "1.13.0";
+  # renovate: datasource=pypi depName=huggingface-mcp-server
+  hfMcpServer = "0.1.0";
+
+  # AI CLI tools (npm)
+  # renovate: datasource=npm depName=@felixgeelhaar/cclint
+  cclint = "0.12.1";
+  # renovate: datasource=npm depName=@githubnext/github-copilot-cli
+  ghCopilot = "0.1.36";
+  # renovate: datasource=npm depName=chatgpt-cli
+  chatgptCli = "3.3.0";
+  # renovate: datasource=npm depName=claude-flow
+  claudeFlow = "3.6.12";
+  # renovate: datasource=npm depName=@googleworkspace/cli
+  gwsCli = "0.22.5";
+
+  # MCP servers (npm)
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-everything
+  mcpEverything = "2026.1.26";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-filesystem
+  mcpFilesystem = "2026.1.14";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-memory
+  mcpMemory = "2026.1.26";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-aws-kb-retrieval
+  mcpAws = "0.6.2";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-postgres
+  mcpPostgres = "0.6.2";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-brave-search
+  mcpBraveSearch = "0.6.2";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-google-maps
+  mcpGoogleMaps = "0.6.2";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-puppeteer
+  mcpPuppeteer = "2025.5.12";
+  # renovate: datasource=npm depName=@modelcontextprotocol/server-slack
+  mcpSlack = "2025.4.25";
+
+  # MCP servers (pypi)
+  # renovate: datasource=pypi depName=mcp-server-time
+  mcpServerTime = "2026.1.26";
+  # renovate: datasource=pypi depName=pal-mcp-server
+  palMcpServer = "9.8.2";
+  # renovate: datasource=pypi depName=fabric-mcp
+  fabricMcp = "1.1.0";
+  # renovate: datasource=pypi depName=google-workspace-mcp
+  gwsMcp = "2.0.1";
+
+  # MLX inference stack (pypi)
+  # renovate: datasource=pypi depName=vllm-mlx
+  vllmMlx = "0.2.9";
+  # renovate: datasource=pypi depName=parakeet-mlx
+  parakeetMlx = "0.5.1";
+  # renovate: datasource=pypi depName=mlx-vlm
+  mlxVlm = "0.4.4";
+  # renovate: datasource=pypi depName=mlx-lm
+  mlxLm = "0.31.3";
+  # renovate: datasource=pypi depName=lm-eval
+  lmEval = "0.4.11";
+
+  # AI tools (pypi)
+  # renovate: datasource=pypi depName=open-webui
+  openWebui = "0.9.2";
+  # renovate: datasource=pypi depName=browser-use
+  browserUse = "0.12.6";
 }

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -14,8 +14,9 @@
   stableVersion = "25.11";
 
   # Package version pins — single source of truth for cross-module shared deps.
-  # Each entry must have a `# renovate:` annotation immediately above it so the
-  # org-wide customManager regex tracks it (datasource= depName= on one line).
+  # Each pin entry (below) must have a `# renovate:` annotation immediately above
+  # it so the org-wide customManager regex tracks it (datasource= depName= on one
+  # line). `stableVersion` above is informational and not tracked by Renovate.
 
   # renovate: datasource=pypi depName=huggingface-hub
   huggingfaceHub = "1.13.0";

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -75,16 +75,11 @@
 { pkgs, ... }:
 let
   versions = import ../lib/versions.nix;
-  # renovate: datasource=npm depName=@felixgeelhaar/cclint
-  cclintVersion = "0.12.1";
-  # renovate: datasource=npm depName=@githubnext/github-copilot-cli
-  ghCopilotVersion = "0.1.36";
-  # renovate: datasource=npm depName=chatgpt-cli
-  chatgptCliVersion = "3.3.0";
-  # renovate: datasource=npm depName=claude-flow
-  claudeFlowVersion = "3.6.12";
-  # renovate: datasource=npm depName=@googleworkspace/cli
-  gwsCliVersion = "0.22.5";
+  cclintVersion = versions.cclint;
+  ghCopilotVersion = versions.ghCopilot;
+  chatgptCliVersion = versions.chatgptCli;
+  claudeFlowVersion = versions.claudeFlow;
+  gwsCliVersion = versions.gwsCli;
 in
 {
   # AI-specific development tools

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -74,6 +74,7 @@
 
 { pkgs, ... }:
 let
+  versions = import ../lib/versions.nix;
   # renovate: datasource=npm depName=@felixgeelhaar/cclint
   cclintVersion = "0.12.1";
   # renovate: datasource=npm depName=@githubnext/github-copilot-cli
@@ -84,8 +85,6 @@ let
   claudeFlowVersion = "3.6.12";
   # renovate: datasource=npm depName=@googleworkspace/cli
   gwsCliVersion = "0.22.5";
-  # renovate: datasource=pypi depName=huggingface-hub
-  huggingfaceHubVersion = "1.13.0";
 in
 {
   # AI-specific development tools
@@ -193,7 +192,7 @@ in
     # PyPI: huggingface-hub (provides `hf` entry point)
     # Requires: HF_TOKEN env var (from macOS Keychain via nix-darwin shell init)
     (writeShellScriptBin "hf" ''
-      exec ${uv}/bin/uvx --from "huggingface-hub==${huggingfaceHubVersion}" hf "$@"
+      exec ${uv}/bin/uvx --from "huggingface-hub==${versions.huggingfaceHub}" hf "$@"
     '')
 
     # ==========================================================================

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -68,8 +68,9 @@ let
     inherit (pkgs) fetchFromGitHub;
   };
 
-  openWebuiVersion = (import ../lib/versions.nix).openWebui;
-  browserUseVersion = (import ../lib/versions.nix).browserUse;
+  versions = import ../lib/versions.nix;
+  openWebuiVersion = versions.openWebui;
+  browserUseVersion = versions.browserUse;
 in
 {
   imports = [

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -68,10 +68,8 @@ let
     inherit (pkgs) fetchFromGitHub;
   };
 
-  # renovate: datasource=pypi depName=open-webui
-  openWebuiVersion = "0.9.2";
-  # renovate: datasource=pypi depName=browser-use
-  browserUseVersion = "0.12.6";
+  openWebuiVersion = (import ../lib/versions.nix).openWebui;
+  browserUseVersion = (import ../lib/versions.nix).browserUse;
 in
 {
   imports = [

--- a/modules/fabric/README.md
+++ b/modules/fabric/README.md
@@ -155,12 +155,16 @@ unmaintained, an alternative MCP wrapper will be needed.
 The fabric version is pinned in two places that MUST stay in sync:
 
 1. `flake.nix` input pin: `url = "github:danielmiessler/fabric/v1.4.444";`
-2. `modules/fabric/package.nix` version constant: `version = "1.4.444";`
+2. `lib/versions.nix`: `fabric = "1.4.444";` (read by `package.nix`)
 
-The marketplace metadata version is derived from `package.nix` at Nix eval time —
-no separate sync needed. Renovate manages bumps via the `# managed by: renovate`
-annotation in `package.nix`. The CI guard `scripts/check-fabric-version-sync.sh`
-asserts both stay in sync.
+`package.nix` derives `version` from `lib/versions.nix`, and the marketplace
+metadata version is derived from the same package at Nix eval time — no
+separate sync needed. Renovate manages bumps via the `# renovate:` annotation
+above the entry in `lib/versions.nix` (custom regex manager) and the `nix`
+manager for the flake input. The fabric-version-sync regression check in
+`lib/checks/fabric.nix` (and the equivalent
+`scripts/check-fabric-version-sync.sh` for pre-commit / manual runs) asserts
+both stay in sync.
 
 To bump manually: edit both values to the new version, run `nix build .#fabric-ai`,
 copy the new `vendorHash` from the error message, paste it into `package.nix`, and re-build.

--- a/modules/fabric/package.nix
+++ b/modules/fabric/package.nix
@@ -25,8 +25,7 @@
 
 buildGoModule rec {
   pname = "fabric-ai";
-  # managed by: renovate (datasource=github-releases depName=danielmiessler/fabric)
-  version = "1.4.444";
+  version = (import ../../lib/versions.nix).fabric;
 
   src = fabric-src;
 

--- a/modules/fabric/package.nix
+++ b/modules/fabric/package.nix
@@ -5,8 +5,12 @@
 # 252+ reusable AI prompt patterns for analysis, extraction, summarization, code
 # review, and content transformation.
 #
-# Pinned to a specific release tag. Version bumps managed by Renovate via the
-# datasource annotation above the version string.
+# Version pinning lives in two places that MUST stay in sync:
+#   - lib/versions.nix `fabric = "X.Y.Z"` — Renovate customManager bumps this
+#     (datasource=github-releases, depName=danielmiessler/fabric)
+#   - flake.nix `fabric-src` flake input — Renovate's nix manager bumps this
+# scripts/check-fabric-version-sync.sh and the fabric-version-sync regression
+# check in lib/checks/fabric.nix assert that the two stay aligned.
 #
 # Naming: "fabric-ai" avoids collision with the unrelated Python `fabric` package
 # in nixpkgs (pythonic remote execution). Both can coexist on PATH since the

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -39,8 +39,10 @@ in
   # ================================================================
   # Official Anthropic MCP Servers
   # ================================================================
-  # Versions are let-bound above with Renovate annotation comments for regex tracking.
-  # Archived servers remain unpinned unless a maintained replacement exists.
+  # Version pins live in lib/versions.nix where the Renovate annotations are
+  # tracked by the org-wide customManager regex; the let-bindings above are
+  # plain references. Archived servers remain unpinned unless a maintained
+  # replacement exists.
 
   everything = bunx [ "@modelcontextprotocol/server-everything@${mcpEverythingVersion}" ];
   fetch = bunx [ "@modelcontextprotocol/server-fetch" ]; # archived

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -15,6 +15,8 @@ let
     inherit args;
   };
 
+  versions = import ../../lib/versions.nix;
+
   # ================================================================
   # Package version pins — Renovate tracks these via annotation comments
   # ================================================================
@@ -42,8 +44,6 @@ let
   mcpServerTimeVersion = "2026.1.26";
   # renovate: datasource=pypi depName=huggingface-mcp-server
   hfMcpServerVersion = "0.1.0";
-  # renovate: datasource=pypi depName=huggingface-hub
-  huggingfaceHubVersion = "1.13.0";
   # renovate: datasource=pypi depName=fabric-mcp
   fabricMcpVersion = "1.1.0";
   # renovate: datasource=pypi depName=google-workspace-mcp
@@ -124,7 +124,7 @@ in
       "--from"
       "huggingface-mcp-server==${hfMcpServerVersion}"
       "--with"
-      "huggingface-hub==${huggingfaceHubVersion}"
+      "huggingface-hub==${versions.huggingfaceHub}"
       "huggingface-mcp-server"
     ];
   };

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -18,36 +18,22 @@ let
   versions = import ../../lib/versions.nix;
 
   # ================================================================
-  # Package version pins — Renovate tracks these via annotation comments
+  # Package version pins — sourced from lib/versions.nix
   # ================================================================
 
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-everything
-  mcpEverythingVersion = "2026.1.26";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-filesystem
-  mcpFilesystemVersion = "2026.1.14";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-memory
-  mcpMemoryVersion = "2026.1.26";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-aws-kb-retrieval
-  mcpAwsVersion = "0.6.2";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-postgres
-  mcpPostgresVersion = "0.6.2";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-brave-search
-  mcpBraveSearchVersion = "0.6.2";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-google-maps
-  mcpGoogleMapsVersion = "0.6.2";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-puppeteer
-  mcpPuppeteerVersion = "2025.5.12";
-  # renovate: datasource=npm depName=@modelcontextprotocol/server-slack
-  mcpSlackVersion = "2025.4.25";
-
-  # renovate: datasource=pypi depName=mcp-server-time
-  mcpServerTimeVersion = "2026.1.26";
-  # renovate: datasource=pypi depName=huggingface-mcp-server
-  hfMcpServerVersion = "0.1.0";
-  # renovate: datasource=pypi depName=fabric-mcp
-  fabricMcpVersion = "1.1.0";
-  # renovate: datasource=pypi depName=google-workspace-mcp
-  gwsMcpVersion = "2.0.1";
+  mcpEverythingVersion = versions.mcpEverything;
+  mcpFilesystemVersion = versions.mcpFilesystem;
+  mcpMemoryVersion = versions.mcpMemory;
+  mcpAwsVersion = versions.mcpAws;
+  mcpPostgresVersion = versions.mcpPostgres;
+  mcpBraveSearchVersion = versions.mcpBraveSearch;
+  mcpGoogleMapsVersion = versions.mcpGoogleMaps;
+  mcpPuppeteerVersion = versions.mcpPuppeteer;
+  mcpSlackVersion = versions.mcpSlack;
+  mcpServerTimeVersion = versions.mcpServerTime;
+  hfMcpServerVersion = versions.hfMcpServer;
+  fabricMcpVersion = versions.fabricMcp;
+  gwsMcpVersion = versions.gwsMcp;
 in
 {
   # ================================================================

--- a/modules/mcp/pal-package.nix
+++ b/modules/mcp/pal-package.nix
@@ -13,8 +13,7 @@
 { python3Packages, pal-mcp-server }:
 
 let
-  # renovate: datasource=pypi depName=pal-mcp-server
-  version = "9.8.2";
+  version = (import ../../lib/versions.nix).palMcpServer;
 in
 python3Packages.buildPythonApplication {
   pname = "pal-mcp-server";

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -30,12 +30,9 @@
 #
 let
   cfg = config.programs.mlx;
+  _versions = import ../../lib/versions.nix;
 
-  # Pinned versions — single source of truth. Shared via mlxShared so
-  # packages.nix uses the same values without duplication.
-  #
-  # Version history (kept above the renovate directive so the regex still
-  # matches the line immediately above the version pin):
+  # Version history for vllm-mlx (canonical pin in lib/versions.nix):
   #   - 0.2.6: stable baseline.
   #   - 0.2.7: regressed vllm_mlx/utils/tokenizer.py::load_model_with_fallback
   #     (the success path forgot to return, yielding None implicitly).
@@ -43,12 +40,9 @@ let
   #     MLLM continuous-batching path failed parallel text requests.
   #   - 0.2.9: ships Paged KV Cache + prefix sharing + continuous batching
   #     (MLLM-detection bug fixed). Loads gemma-4-e4b architectures.
-  # renovate: datasource=pypi depName=vllm-mlx
-  vllmMlxVersion = "0.2.9";
-  # renovate: datasource=pypi depName=parakeet-mlx
-  parakeetMlxVersion = "0.5.1";
-  # renovate: datasource=pypi depName=mlx-vlm
-  mlxVlmVersion = "0.4.4";
+  vllmMlxVersion = _versions.vllmMlx;
+  parakeetMlxVersion = _versions.parakeetMlx;
+  mlxVlmVersion = _versions.mlxVlm;
 
   # Central vllm-mlx wrapper — single source of truth for the pinned version.
   # The LaunchAgent needs a Nix store path (not a PATH lookup), so the

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -30,7 +30,7 @@
 #
 let
   cfg = config.programs.mlx;
-  _versions = import ../../lib/versions.nix;
+  versions = import ../../lib/versions.nix;
 
   # Version history for vllm-mlx (canonical pin in lib/versions.nix):
   #   - 0.2.6: stable baseline.
@@ -40,9 +40,9 @@ let
   #     MLLM continuous-batching path failed parallel text requests.
   #   - 0.2.9: ships Paged KV Cache + prefix sharing + continuous batching
   #     (MLLM-detection bug fixed). Loads gemma-4-e4b architectures.
-  vllmMlxVersion = _versions.vllmMlx;
-  parakeetMlxVersion = _versions.parakeetMlx;
-  mlxVlmVersion = _versions.mlxVlm;
+  vllmMlxVersion = versions.vllmMlx;
+  parakeetMlxVersion = versions.parakeetMlx;
+  mlxVlmVersion = versions.mlxVlm;
 
   # Central vllm-mlx wrapper — single source of truth for the pinned version.
   # The LaunchAgent needs a Nix store path (not a PATH lookup), so the

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -29,10 +29,10 @@ let
     llamaSwapConfigFile
     llamaSwapRuntimeConfigPath
     ;
-  _versions = import ../../lib/versions.nix;
+  versions = import ../../lib/versions.nix;
   vllmMlxPin = "vllm-mlx==${vllmMlxVersion}";
-  mlxLmVersion = _versions.mlxLm;
-  lmEvalVersion = _versions.lmEval;
+  mlxLmVersion = versions.mlxLm;
+  lmEvalVersion = versions.lmEval;
 in
 {
   config = lib.mkIf cfg.enable {

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -29,11 +29,10 @@ let
     llamaSwapConfigFile
     llamaSwapRuntimeConfigPath
     ;
+  _versions = import ../../lib/versions.nix;
   vllmMlxPin = "vllm-mlx==${vllmMlxVersion}";
-  # renovate: datasource=pypi depName=mlx-lm
-  mlxLmVersion = "0.31.3";
-  # renovate: datasource=pypi depName=lm-eval
-  lmEvalVersion = "0.4.11";
+  mlxLmVersion = _versions.mlxLm;
+  lmEvalVersion = _versions.lmEval;
 in
 {
   config = lib.mkIf cfg.enable {

--- a/scripts/check-fabric-version-sync.sh
+++ b/scripts/check-fabric-version-sync.sh
@@ -58,8 +58,10 @@ fi
 
 # Extract fabric version from lib/versions.nix via nix eval.
 # The version is now an attrset entry, not a plain string in package.nix.
+# The path is wrapped in Nix string quotes so that checkouts under directories
+# with spaces (e.g. iCloud "Mobile Documents") still parse as a path literal.
 package_version=$(
-  nix eval --raw --impure --expr "(import ${versions_nix}).fabric" 2>/dev/null \
+  nix eval --raw --impure --expr "(import \"${versions_nix}\").fabric" 2>/dev/null \
     || true
 )
 

--- a/scripts/check-fabric-version-sync.sh
+++ b/scripts/check-fabric-version-sync.sh
@@ -2,17 +2,17 @@
 # check-fabric-version-sync.sh
 #
 # CI guard: assert that the fabric version pin in flake.nix matches the
-# version constant in modules/fabric/package.nix.
+# version constant in lib/versions.nix.
 #
 # Why this exists:
 #   - Renovate's `nix` manager bumps `flake.nix` flake input pins automatically
-#   - The version constant in `modules/fabric/package.nix` is plain text that
-#     no manager updates
+#   - The `fabric` entry in `lib/versions.nix` is managed by the custom.regex
+#     manager — a separate Renovate PR
 #   - If they drift, the build still works (fabric-src is the actual source)
 #     but the version label becomes a lie
 #
 # The marketplace metadata version (used in fabric-curated-patterns marketplace)
-# is derived at Nix eval time from package.nix — no separate sync needed.
+# is derived at Nix eval time from lib/versions.nix — no separate sync needed.
 #
 # When to run:
 #   - Pre-commit (manual)
@@ -28,15 +28,15 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 flake_nix="${repo_root}/flake.nix"
-package_nix="${repo_root}/modules/fabric/package.nix"
+versions_nix="${repo_root}/lib/versions.nix"
 
 if [ ! -f "$flake_nix" ]; then
   echo "ERROR: flake.nix not found at $flake_nix" >&2
   exit 2
 fi
 
-if [ ! -f "$package_nix" ]; then
-  echo "ERROR: modules/fabric/package.nix not found at $package_nix" >&2
+if [ ! -f "$versions_nix" ]; then
+  echo "ERROR: lib/versions.nix not found at $versions_nix" >&2
   exit 2
 fi
 
@@ -56,31 +56,30 @@ if [ -z "$flake_version" ]; then
   exit 2
 fi
 
-# Extract version constant from package.nix: version = "1.4.444";
+# Extract fabric version from lib/versions.nix via nix eval.
+# The version is now an attrset entry, not a plain string in package.nix.
 package_version=$(
-  grep -oE 'version = "[0-9][^"]*"' "$package_nix" \
-    | head -1 \
-    | sed -E 's/version = "([^"]+)"/\1/' \
+  nix eval --raw --impure --expr "(import ${versions_nix}).fabric" 2>/dev/null \
     || true
 )
 
 if [ -z "$package_version" ]; then
-  echo "ERROR: could not parse version constant from $package_nix" >&2
-  echo "Expected pattern: version = \"<VERSION>\"" >&2
+  echo "ERROR: could not evaluate lib/versions.nix.fabric" >&2
+  echo "Expected: fabric = \"<VERSION>\"; in lib/versions.nix" >&2
   exit 2
 fi
 
 if [ "$flake_version" != "$package_version" ]; then
   echo "FAIL: fabric version drift detected" >&2
-  echo "  flake.nix fabric-src:                v${flake_version}" >&2
-  echo "  modules/fabric/package.nix version:  ${package_version}" >&2
+  echo "  flake.nix fabric-src:        v${flake_version}" >&2
+  echo "  lib/versions.nix fabric:     ${package_version}" >&2
   echo "" >&2
-  echo "The flake input pin and the package.nix version constant must stay in" >&2
-  echo "sync. Either Renovate bumped one but not the other, or you edited one" >&2
+  echo "The flake input pin and lib/versions.nix must stay in sync." >&2
+  echo "Either Renovate bumped one but not the other, or you edited one" >&2
   echo "manually without updating the other." >&2
   echo "" >&2
-  echo "Fix: edit both to the same version, then run nix build .#fabric-ai" >&2
-  echo "and update the vendorHash in package.nix from the error message." >&2
+  echo "Fix: update both to the same version, then run nix build .#fabric-ai" >&2
+  echo "and update the vendorHash in modules/fabric/package.nix." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Move all remaining `# renovate:`-annotated version pins from inline `let` blocks into `lib/versions.nix`
- After this PR, `lib/versions.nix` is the single source of truth for all 28 tracked dependency versions in this repo
- Consumer modules re-bind with local aliases (`cclintVersion = versions.cclint;`) — no call-site changes needed
- Rename `_versions` to `versions` in mlx modules for consistency with all other consumers

## Changes

Pins moved from these files into `lib/versions.nix`:
- `modules/ai-tools.nix` — 5 npm CLI tool pins (cclint, gh-copilot, chatgpt-cli, claude-flow, gws)
- `modules/mcp/catalog.nix` — 13 MCP server pins (npm + pypi)
- `modules/mcp/pal-package.nix` — palMcpServer
- `modules/mlx/default.nix` — vllmMlx, parakeetMlx, mlxVlm
- `modules/mlx/packages.nix` — mlxLm, lmEval
- `modules/default.nix` — openWebui, browserUse

## Test Plan

- [ ] `nix flake check` passes
- [ ] `nix eval .#lib.versions --json | jq` shows all 28 entries
- [ ] `grep -r "# renovate:" --include="*.nix" .` only matches `lib/versions.nix`