### PR TITLE
fix(claude): scope project plugins per-repo + raise skill listing budget

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -61,6 +61,16 @@ notes covering tool-call parser compatibility, idle eviction, and MoE vs dense t
 **Read when**: Adding a new MLX tool, debugging a model loading or tool-calling issue,
 or understanding why the 35B model is preloaded vs the 122B MoE.
 
+### [plugin-scoping.md](plugin-scoping.md)
+
+The two-layer model partitioning Claude Code plugins between user-level (every session)
+and per-repo (only inside specific worktrees). Covers the skill listing budget, the
+`enabledPlugins` deep-merge mechanism, and the mapping of project-specific plugins to
+consumer repos.
+
+**Read when**: `/doctor` reports "skill descriptions dropped", adding a new plugin to nix-ai,
+or enabling a project-specific plugin in a consumer repo.
+
 ## ADRs
 
 [`docs/adr/`](../adr/README.md) contains the decisions behind non-obvious design choices.

--- a/docs/architecture/plugin-scoping.md
+++ b/docs/architecture/plugin-scoping.md
@@ -6,9 +6,9 @@ How Claude Code plugins are partitioned between **user-level** (every session) a
 ## The problem
 
 Claude Code allocates a **skill listing budget** — by default, 1% of the context window
-(~2k tokens of 200k) for skill descriptions. With 45+ globally-enabled plugins generating
-~250 skills, descriptions overflow the budget and Claude Code silently drops most of them.
-`/doctor` reports lines like `237 skill descriptions dropped`.
+for skill descriptions. With many globally-enabled plugins generating hundreds of skills,
+descriptions overflow the budget and Claude Code silently drops most of them. `/doctor`
+reports them under "skill descriptions dropped".
 
 When descriptions are dropped, semantic skill discovery degrades — Claude can no longer
 match user requests to dropped skills because it cannot see what those skills do.
@@ -71,9 +71,10 @@ is gitignored and won't propagate to teammates or worktrees).
 ## Budget headroom
 
 `modules/claude/options.nix` sets `skillListingBudgetFraction = 0.03` (3%) — well above
-the 1% upstream default. This gives ~6k tokens for skill listings, comfortable headroom
-for the universal plugin set without dropping descriptions even if a few project plugins
-are also enabled per-repo.
+the 1% upstream default. The extra budget is comfortable headroom for the universal
+plugin set without dropping descriptions even if a few project plugins are also
+enabled per-repo. (3% of a 200k context window ≈ 6k tokens — adjust mental math
+if Claude Code's context window changes.)
 
 If `/doctor` ever reports drops again:
 
@@ -90,7 +91,7 @@ After changing user-level config in nix-ai:
 2. `darwin-rebuild switch` to deploy.
 3. Fresh Claude Code session in `~/git/nix-ai/main`:
    - `/doctor` → no "skill descriptions dropped" line.
-   - `/context` → Skills line ≤ 6k tokens.
+   - `/context` → Skills line within the configured budget fraction.
 
 After adding per-repo `.claude/settings.json` in a consumer repo:
 

--- a/docs/architecture/plugin-scoping.md
+++ b/docs/architecture/plugin-scoping.md
@@ -73,15 +73,14 @@ is gitignored and won't propagate to teammates or worktrees).
 `modules/claude/options.nix` sets `skillListingBudgetFraction = 0.03` (3%) — well above
 the 1% upstream default. The extra budget is comfortable headroom for the universal
 plugin set without dropping descriptions even if a few project plugins are also
-enabled per-repo. (3% of a 200k context window ≈ 6k tokens — adjust mental math
-if Claude Code's context window changes.)
+enabled per-repo.
 
 If `/doctor` ever reports drops again:
 
 1. Check whether new universal-tier plugins were added (Tier 1–4) — prefer pruning over
    raising the budget.
 2. If pruning is not viable, raise `skillListingBudgetFraction` in
-   `modules/claude/options.nix` (each 0.01 ≈ 2k tokens).
+   `modules/claude/options.nix`.
 
 ## Verification
 

--- a/docs/architecture/plugin-scoping.md
+++ b/docs/architecture/plugin-scoping.md
@@ -70,10 +70,9 @@ is gitignored and won't propagate to teammates or worktrees).
 
 ## Budget headroom
 
-`modules/claude/options.nix` sets `skillListingBudgetFraction = 0.03` (3%) — well above
-the 1% upstream default. The extra budget is comfortable headroom for the universal
-plugin set without dropping descriptions even if a few project plugins are also
-enabled per-repo.
+`modules/claude/options.nix` sets `skillListingBudgetFraction = 0.02` (2%) — double
+the 1% upstream default. The extra budget is headroom for the universal plugin set
+without dropping descriptions even if a few project plugins are also enabled per-repo.
 
 If `/doctor` ever reports drops again:
 

--- a/docs/architecture/plugin-scoping.md
+++ b/docs/architecture/plugin-scoping.md
@@ -1,0 +1,106 @@
+# Plugin Scoping — User-Level vs Per-Repo
+
+How Claude Code plugins are partitioned between **user-level** (every session) and
+**per-repo** (only sessions inside a specific worktree).
+
+## The problem
+
+Claude Code allocates a **skill listing budget** — by default, 1% of the context window
+(~2k tokens of 200k) for skill descriptions. With 45+ globally-enabled plugins generating
+~250 skills, descriptions overflow the budget and Claude Code silently drops most of them.
+`/doctor` reports lines like `237 skill descriptions dropped`.
+
+When descriptions are dropped, semantic skill discovery degrades — Claude can no longer
+match user requests to dropped skills because it cannot see what those skills do.
+
+## The two-layer model
+
+```text
+~/.claude/settings.json                   ← user-level (Nix-managed)
+  enabledPlugins:                            Universal-only: code-review, commit-commands,
+    "code-review@…": true                    document-skills, python-development, etc.
+    "ansible-workflows@…": false
+    "terraform-module-builder@…": false
+
+  +
+~/git/<repo>/main/.claude/settings.json   ← per-repo (committed, deep-merged on session start)
+  enabledPlugins:                            Project-specific overrides: ansible, terraform,
+    "ansible-workflows@…": true              proxmox, cribl-pack-validator, etc.
+    "proxmox-infrastructure@…": true
+```
+
+Claude Code deep-merges project-scoped settings on top of user settings on session start.
+A plugin disabled at user level can be re-enabled per-repo without touching global config.
+
+## Universal plugins (stay at user level)
+
+Tier 1–4 plugins in `modules/claude/plugins/` are universal or cross-cutting:
+code review, commits, PRs, document skills, Python/backend development helpers, etc.
+These apply to every session regardless of repo and stay enabled in
+`~/.claude/settings.json`.
+
+## Project-specific plugins (per-repo enable)
+
+Tier 5 plugins (`modules/claude/plugins/05-specialty.nix`) are disabled at user level
+and re-enabled per-repo. Mapping:
+
+| Repo | Plugins to enable in `<repo>/.claude/settings.json` |
+| --- | --- |
+| `terraform-proxmox` | `terraform-module-builder@claude-code-plugins-plus`, `infrastructure-as-code-generator@claude-code-plugins-plus`, `proxmox-infrastructure@lunar-claude` |
+| `terraform-aws`, `terraform-aws-bedrock`, `terraform-aws-static-website`, `terraform-runs-on` | `terraform-module-builder@claude-code-plugins-plus`, `infrastructure-as-code-generator@claude-code-plugins-plus` |
+| `ansible-proxmox`, `ansible-proxmox-apps` | `ansible-workflows@lunar-claude`, `proxmox-infrastructure@lunar-claude` |
+| `ansible-splunk` | `ansible-workflows@lunar-claude` |
+| `cribl`, `cc-edge-*`, `cc-stream-*` | `cribl-pack-validator@vct-cribl-pack-validator-skills` |
+| Obsidian-vault repos | `obsidian@obsidian-skills`, `obsidian-visual-skills@axton-obsidian-visual-skills`, `visual-explainer@visual-explainer-marketplace` |
+| Browser-automation repos | `browser-use@browser-use-skills` |
+
+Add to a repo:
+
+```json
+{
+  "enabledPlugins": {
+    "terraform-module-builder@claude-code-plugins-plus": true,
+    "infrastructure-as-code-generator@claude-code-plugins-plus": true
+  }
+}
+```
+
+Commit to `.claude/settings.json` (not `.claude/settings.local.json` — the `.local` variant
+is gitignored and won't propagate to teammates or worktrees).
+
+## Budget headroom
+
+`modules/claude/options.nix` sets `skillListingBudgetFraction = 0.03` (3%) — well above
+the 1% upstream default. This gives ~6k tokens for skill listings, comfortable headroom
+for the universal plugin set without dropping descriptions even if a few project plugins
+are also enabled per-repo.
+
+If `/doctor` ever reports drops again:
+
+1. Check whether new universal-tier plugins were added (Tier 1–4) — prefer pruning over
+   raising the budget.
+2. If pruning is not viable, raise `skillListingBudgetFraction` in
+   `modules/claude/options.nix` (each 0.01 ≈ 2k tokens).
+
+## Verification
+
+After changing user-level config in nix-ai:
+
+1. `nix flake check` — option regression test verifies the budget setting is present.
+2. `darwin-rebuild switch` to deploy.
+3. Fresh Claude Code session in `~/git/nix-ai/main`:
+   - `/doctor` → no "skill descriptions dropped" line.
+   - `/context` → Skills line ≤ 6k tokens.
+
+After adding per-repo `.claude/settings.json` in a consumer repo:
+
+1. Fresh session inside the repo worktree.
+2. `/skills` → confirm the per-repo plugins are listed.
+3. `/skills` in an unrelated repo → confirm those plugins are *not* listed.
+
+## Related
+
+- `modules/claude/plugins/05-specialty.nix` — globally disabled project-specific plugins
+- `modules/claude/options.nix` — `skillListingBudgetFraction` option
+- `modules/claude/settings.nix` — settings.json generator
+- `.claude/rules/plugin-cache-architecture.md` — read/write boundaries for plugin cache

--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -50,6 +50,7 @@ in
         "permissions"
         "sandbox"
         "schemaUrl"
+        "skillListingBudgetFraction"
       ];
       actualSettingsOptions = builtins.attrNames cfg.settings;
       missingSettingsOptions = builtins.filter (
@@ -128,6 +129,11 @@ in
           name = "cleanupPeriodDays";
           actual = cfg.settings.cleanupPeriodDays;
           expected = 30;
+        }
+        {
+          name = "skillListingBudgetFraction";
+          actual = cfg.settings.skillListingBudgetFraction;
+          expected = 0.03;
         }
         {
           name = "autoUpdatesChannel";

--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -133,7 +133,7 @@ in
         {
           name = "skillListingBudgetFraction";
           actual = cfg.settings.skillListingBudgetFraction;
-          expected = 0.03;
+          expected = 0.02;
         }
         {
           name = "autoUpdatesChannel";

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -335,6 +335,21 @@ in
         '';
       };
 
+      # Skill listing budget
+      skillListingBudgetFraction = lib.mkOption {
+        type = lib.types.float;
+        default = 0.03;
+        description = ''
+          Fraction of the context window reserved for skill descriptions in
+          every session. Claude Code's upstream default is 0.01 (1%), which
+          drops descriptions when many plugins are enabled.
+
+          0.03 (3%) ≈ 6k tokens of a 200k context — comfortable headroom for
+          ~250 skills without dropping descriptions. Raise further only if
+          /doctor still reports "skill descriptions dropped".
+        '';
+      };
+
       # Permissions
       permissions = {
         allow = lib.mkOption {

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -338,15 +338,15 @@ in
       # Skill listing budget
       skillListingBudgetFraction = lib.mkOption {
         type = lib.types.float;
-        default = 0.03;
+        default = 0.02;
         description = ''
           Fraction of the context window reserved for skill descriptions in
           every session. Claude Code's upstream default is 0.01 (1%), which
           drops descriptions when many plugins are enabled.
 
-          Default 0.03 (3%) gives comfortable headroom for the universal
-          plugin set without dropping descriptions. Raise further only if
-          /doctor still reports "skill descriptions dropped".
+          Default 0.02 (2%) doubles the upstream allocation — enough headroom
+          for the universal plugin set without dropping descriptions. Raise
+          further only if /doctor still reports "skill descriptions dropped".
         '';
       };
 

--- a/modules/claude/options.nix
+++ b/modules/claude/options.nix
@@ -344,8 +344,8 @@ in
           every session. Claude Code's upstream default is 0.01 (1%), which
           drops descriptions when many plugins are enabled.
 
-          0.03 (3%) ≈ 6k tokens of a 200k context — comfortable headroom for
-          ~250 skills without dropping descriptions. Raise further only if
+          Default 0.03 (3%) gives comfortable headroom for the universal
+          plugin set without dropping descriptions. Raise further only if
           /doctor still reports "skill descriptions dropped".
         '';
       };

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -31,17 +31,12 @@ _:
     # ========================================================================
     # lunar-claude — basher83/lunar-claude (Proxmox + Ansible)
     # ========================================================================
-    # DISABLED globally — re-enable in ansible-* and terraform-proxmox repos
-    # via per-repo .claude/settings.json overrides. See
-    # docs/architecture/plugin-scoping.md.
     "proxmox-infrastructure@lunar-claude" = false;
     "ansible-workflows@lunar-claude" = false;
 
     # ========================================================================
     # claude-code-plugins-plus — jeremylongshore/claude-code-plugins-plus
     # ========================================================================
-    # DISABLED globally — re-enable in terraform-* repos via per-repo
-    # .claude/settings.json overrides. See docs/architecture/plugin-scoping.md.
     "infrastructure-as-code-generator@claude-code-plugins-plus" = false;
     "terraform-module-builder@claude-code-plugins-plus" = false;
 

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -1,13 +1,11 @@
 # Tier 5 — Niche, specialty, and synthetic marketplaces (superseded by all higher tiers).
-# Tier 5 — Niche / specialty
 #
 # Duplicate Resolution Rule:
 #   Plugins in this file are SUPERSEDED by ALL higher tiers (1, 2, 3, 4).
 #
 # Per-repo overrides:
-#   Project-specific plugins disabled here can be re-enabled in consumer repos
-#   via committed `.claude/settings.json`. Claude Code deep-merges project-scoped
-#   settings into the global config. See docs/architecture/plugin-scoping.md.
+#   Disabled globally but can be re-enabled in consumer repos via
+#   `.claude/settings.json`. See docs/architecture/plugin-scoping.md.
 #
 # Marketplaces in this tier (sorted by relevance to user's stack, not stars —
 # stars are unreliable for niche-classification because some upstreams like

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -4,6 +4,11 @@
 # Duplicate Resolution Rule:
 #   Plugins in this file are SUPERSEDED by ALL higher tiers (1, 2, 3, 4).
 #
+# Per-repo overrides:
+#   Project-specific plugins disabled here can be re-enabled in consumer repos
+#   via committed `.claude/settings.json`. Claude Code deep-merges project-scoped
+#   settings into the global config. See docs/architecture/plugin-scoping.md.
+#
 # Marketplaces in this tier (sorted by relevance to user's stack, not stars —
 # stars are unreliable for niche-classification because some upstreams like
 # browser-use and fabric are very popular but the wrapped-skill marketplaces
@@ -28,17 +33,19 @@ _:
     # ========================================================================
     # lunar-claude — basher83/lunar-claude (Proxmox + Ansible)
     # ========================================================================
-    # Useful for the user's Proxmox + Ansible stack. Re-enable in non-infra
-    # repos only if their per-repo .claude/settings.json doesn't override.
-    "proxmox-infrastructure@lunar-claude" = true;
-    "ansible-workflows@lunar-claude" = true;
+    # DISABLED globally — re-enable in ansible-* and terraform-proxmox repos
+    # via per-repo .claude/settings.json overrides. See
+    # docs/architecture/plugin-scoping.md.
+    "proxmox-infrastructure@lunar-claude" = false;
+    "ansible-workflows@lunar-claude" = false;
 
     # ========================================================================
     # claude-code-plugins-plus — jeremylongshore/claude-code-plugins-plus
     # ========================================================================
-    # Used in terraform-* repos. Re-enable per-repo where applicable.
-    "infrastructure-as-code-generator@claude-code-plugins-plus" = true;
-    "terraform-module-builder@claude-code-plugins-plus" = true;
+    # DISABLED globally — re-enable in terraform-* repos via per-repo
+    # .claude/settings.json overrides. See docs/architecture/plugin-scoping.md.
+    "infrastructure-as-code-generator@claude-code-plugins-plus" = false;
+    "terraform-module-builder@claude-code-plugins-plus" = false;
 
     # ========================================================================
     # bitwarden-marketplace — bitwarden/ai-plugins

--- a/modules/claude/settings.nix
+++ b/modules/claude/settings.nix
@@ -78,7 +78,7 @@ let
   # Build the settings object
   settings = {
     "$schema" = cfg.settings.schemaUrl;
-    inherit (cfg.settings) alwaysThinkingEnabled cleanupPeriodDays;
+    inherit (cfg.settings) alwaysThinkingEnabled cleanupPeriodDays skillListingBudgetFraction;
     inherit (cfg)
       autoUpdatesChannel
       teammateMode


### PR DESCRIPTION
## Summary

- `/doctor` reported `237 skill descriptions dropped` because 45+ globally-enabled plugins generated more skill descriptions than fit in Claude Code's default 1% `skillListingBudgetFraction`.
- Disable infrastructure-only plugins globally; require per-repo `.claude/settings.json` to re-enable them in consumer worktrees (Claude Code deep-merges project settings).
- Add `programs.claude.settings.skillListingBudgetFraction` option (default `0.02`) so user-level config keeps headroom without depending on Claude Code's overly conservative upstream default.

## Changes

| File | Change |
| --- | --- |
| `modules/claude/plugins/05-specialty.nix` | Flip `proxmox-infrastructure`, `ansible-workflows`, `terraform-module-builder`, `infrastructure-as-code-generator` from `true` to `false`; comments updated to point to the new doc |
| `modules/claude/options.nix` | New `settings.skillListingBudgetFraction` option (default `0.02`) |
| `modules/claude/settings.nix` | Emit the new field into `settings.json` |
| `lib/checks/claude.nix` | Add the new option to expected-options regression and a default-value check |
| `docs/architecture/plugin-scoping.md` | New doc — user-level vs per-repo plugin partition, mapping table |
| `docs/architecture/README.md` | Index entry for the new doc |

## Why this is a two-PR split

This PR covers the user-level changes (`nix-ai`). The per-repo Phase 3 work is one
small commit per consumer repo and is tracked below as a checklist:

### Phase 3 follow-up — committed `.claude/settings.json` per consumer repo

- [ ] `terraform-proxmox` — `terraform-module-builder@…`, `infrastructure-as-code-generator@…`, `proxmox-infrastructure@lunar-claude`
- [ ] `terraform-aws` — `terraform-module-builder@…`, `infrastructure-as-code-generator@…`
- [ ] `terraform-aws-bedrock` — same as terraform-aws
- [ ] `terraform-aws-static-website` — same as terraform-aws
- [ ] `terraform-runs-on` — same as terraform-aws
- [ ] `ansible-proxmox` — `ansible-workflows@lunar-claude`, `proxmox-infrastructure@lunar-claude`
- [ ] `ansible-proxmox-apps` — same as ansible-proxmox
- [ ] `ansible-splunk` — `ansible-workflows@lunar-claude`

(`cribl-pack-validator`, `obsidian-*`, `browser-use` were already disabled globally and
need per-repo enablement only when their consumer repos exist; not blocking for this PR.)

## Out of scope (separate issues to file)

- Plugin errors in `/doctor` (skill-guards manifest missing, stale cache, cribl synthetic marketplace path) — mid-session cache mutation is forbidden per `.claude/rules/plugin-cache-architecture.md`.
- Three concurrent Claude Code versions running — no `claude-code` flake input pin; separate cleanup.
- Tier 4 community plugin audit — conservative cleanup chosen for this PR.

## Test plan

- [x] `nix fmt` — 0 files changed
- [x] `nix flake check` — all flake checks pass (including `options-regression` and `defaults-regression` which now require `skillListingBudgetFraction`)
- [ ] After merge: `darwin-rebuild switch --flake $HOME/git/nix-darwin/main --override-input nix-ai $HOME/git/nix-ai/fix/skill-listing-budget-overflow`
- [ ] In a fresh Claude Code session in `~/git/nix-ai/main`:
  - [ ] `/doctor` — no "skill descriptions dropped" line (or 0)
  - [ ] `/context` — Skills line within the configured budget
  - [ ] `/skills` — `proxmox-infrastructure`, `ansible-workflows`, `terraform-module-builder`, `infrastructure-as-code-generator` not listed
- [ ] Per-repo Phase 3 verification (per consumer repo): `/skills` confirms the disabled plugin reappears inside the worktree.