### PR TITLE
docs(plugin-scoping): include tf-splunk-aws in terraform mapping row

### DIFF
--- a/docs/architecture/plugin-scoping.md
+++ b/docs/architecture/plugin-scoping.md
@@ -47,7 +47,7 @@ and re-enabled per-repo. Mapping:
 | Repo | Plugins to enable in `<repo>/.claude/settings.json` |
 | --- | --- |
 | `terraform-proxmox` | `terraform-module-builder@claude-code-plugins-plus`, `infrastructure-as-code-generator@claude-code-plugins-plus`, `proxmox-infrastructure@lunar-claude` |
-| `terraform-aws`, `terraform-aws-bedrock`, `terraform-aws-static-website`, `terraform-runs-on` | `terraform-module-builder@claude-code-plugins-plus`, `infrastructure-as-code-generator@claude-code-plugins-plus` |
+| `terraform-aws`, `terraform-aws-bedrock`, `terraform-aws-static-website`, `terraform-runs-on`, `tf-splunk-aws` | `terraform-module-builder@claude-code-plugins-plus`, `infrastructure-as-code-generator@claude-code-plugins-plus` |
 | `ansible-proxmox`, `ansible-proxmox-apps` | `ansible-workflows@lunar-claude`, `proxmox-infrastructure@lunar-claude` |
 | `ansible-splunk` | `ansible-workflows@lunar-claude` |
 | `cribl`, `cc-edge-*`, `cc-stream-*` | `cribl-pack-validator@vct-cribl-pack-validator-skills` |


### PR DESCRIPTION
## Summary

`tf-splunk-aws` was missing from the per-repo override mapping table introduced in #721. Same plugin set as the rest of the AWS terraform repos (`terraform-module-builder@claude-code-plugins-plus`, `infrastructure-as-code-generator@claude-code-plugins-plus`).

Discovered while creating the Phase 3 per-repo `.claude/settings.json` follow-up PRs (e.g. [tf-splunk-aws#164](https://github.com/JacobPEvans/tf-splunk-aws/pull/164)).

## Test plan

- [x] `nix flake check` passes — pure doc change