### PR TITLE
feat(flake): export overlays.default for downstream consumers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -315,6 +315,17 @@
         }
       );
 
+      # Default overlay — injects every flake-exported package into pkgs.
+      # Consumers register this via:
+      #   nixpkgs.overlays = [ nix-ai.overlays.default ];
+      # Required when importing this flake's homeManagerModules, since those
+      # modules reference pkgs.<name> (e.g. modules/cecli/packages.nix uses
+      # pkgs.cecli). Any package added to `packages` above is automatically
+      # available — consumers do not need to enumerate package names.
+      # The `prev ? system` guard makes the overlay safe to call with the
+      # empty attrsets the flake schema validator uses (`overlay {} {}`).
+      overlays.default = _final: prev: if prev ? system then self.packages.${prev.system} or { } else { };
+
       # Formatter
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
     };


### PR DESCRIPTION
## Summary

Add `overlays.default` that re-exports every package from `self.packages.<system>` into `pkgs`. Required for any consumer that imports this flake's `homeManagerModules` — modules like `modules/cecli/packages.nix` reference `pkgs.cecli`, which only resolves when consumers register an overlay that injects the package set into nixpkgs.

## Why

After 1.63.0 introduced the cecli home-manager module, downstream consumers (nix-darwin) immediately broke:

\`\`\`
error: attribute 'cecli' missing
at modules/cecli/packages.nix:23:7
\`\`\`

Without an exported overlay, every consumer would have to enumerate package names by hand:

\`\`\`nix
nixpkgs.overlays = [
  (final: prev: {
    cecli = nix-ai.packages.${prev.system}.cecli;
    fabric-ai = nix-ai.packages.${prev.system}.fabric-ai;
    pal-mcp-server = nix-ai.packages.${prev.system}.pal-mcp-server;
    gh-aw = nix-ai.packages.${prev.system}.gh-aw;
  })
];
\`\`\`

That is a maintenance trap — every new package this flake adds becomes a downstream wiring change. With `overlays.default`, consumers register one overlay and inherit every current and future package automatically:

\`\`\`nix
nixpkgs.overlays = [ nix-ai.overlays.default ];
\`\`\`

## Implementation notes

- The `prev ? system` guard keeps the overlay safe to call with empty attrsets, which the Nix flake schema validator does (`overlay {} {}`). Without it, schema introspection (and `nix flake show`) errored.
- `_final` (underscore-prefixed) silences `deadnix` for the unused argument.
- `or { }` defends against unsupported systems (consumers on systems where this flake exports no packages get an empty injection rather than an eval error).

## Test plan

- [x] `nix flake check` — all checks (formatting, statix, deadnix, shellcheck, module-eval, package builds) pass on aarch64-darwin
- [x] `nix flake show` lists `overlays.default: Nixpkgs overlay` alongside `packages`
- [x] Verified consumer-side breakage reproduces without overlay registration (downstream repo with `--override-input nix-ai path:...` still errors on `pkgs.cecli` until the consumer adds `nix-ai.overlays.default` to its `nixpkgs.overlays`)
- [ ] CI passes