### PR TITLE
fix(flake): replace prev.system with prev.stdenv.hostPlatform.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -322,9 +322,16 @@
       # modules reference pkgs.<name> (e.g. modules/cecli/packages.nix uses
       # pkgs.cecli). Any package added to `packages` above is automatically
       # available — consumers do not need to enumerate package names.
-      # The `prev ? system` guard makes the overlay safe to call with the
-      # empty attrsets the flake schema validator uses (`overlay {} {}`).
-      overlays.default = _final: prev: if prev ? system then self.packages.${prev.system} or { } else { };
+      #
+      # Use prev.stdenv.hostPlatform.system (not prev.system). The bare
+      # `system` attribute is a deprecated alias in nixpkgs whose
+      # warnAlias machinery triggers infinite recursion when evaluated
+      # inside an overlay during home-manager's _module.args.pkgs path.
+      # The hostPlatform check guards against the empty attrsets the
+      # flake schema validator passes (`overlay {} {}`).
+      overlays.default =
+        _final: prev:
+        if prev ? stdenv then self.packages.${prev.stdenv.hostPlatform.system} or { } else { };
 
       # Formatter
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);

--- a/flake.nix
+++ b/flake.nix
@@ -327,7 +327,7 @@
       # `system` attribute is a deprecated alias in nixpkgs whose
       # warnAlias machinery triggers infinite recursion when evaluated
       # inside an overlay during home-manager's _module.args.pkgs path.
-      # The hostPlatform check guards against the empty attrsets the
+      # The stdenv check guards against the empty attrsets the
       # flake schema validator passes (`overlay {} {}`).
       overlays.default =
         _final: prev:


### PR DESCRIPTION
## Summary

Fixes infinite recursion in the default overlay when evaluated inside home-manager's `_module.args.pkgs` path.

The overlay previously used `prev.system`, which is a deprecated alias in nixpkgs. When evaluated through certain paths (specifically `_module.args.pkgs` and assertions), the warnAlias machinery recurses infinitely.

## Changes

- Replaced `prev.system` with `prev.stdenv.hostPlatform.system` in flake.nix line 330
- Updated the guard from `prev ? system` to `prev ? stdenv` (still defends against the empty attrsets the flake schema validator passes)
- Updated inline comment to reflect that the guard uses `stdenv` check, not `hostPlatform`

## Test plan

- [x] `nix flake check` passes (formatting, statix, deadnix, shellcheck)
- [x] Reproduced infinite recursion with `prev.system` version, verified fixed on this version using `nix flake check --override-input nix-ai path:.` from a downstream nix-darwin worktree that registers `nix-ai.overlays.default`
- [ ] CI passes