### PR TITLE
fix(claude,cecli): eliminate Python env conflicts in home-manager buildEnv

### DIFF
--- a/modules/cecli/packages.nix
+++ b/modules/cecli/packages.nix
@@ -1,11 +1,10 @@
 #
 # cecli Module — Package Install
 #
-# cecli is built from PyPI as a real Nix derivation in
-# modules/cecli/package.nix and exposed via the flake's
-# `packages.<system>.cecli` output. This module just adds it to the
-# user's home.packages — no activation scripts, no uvx shim, no
-# `installVia` choice (only one source today).
+# Builds cecli directly from package.nix via pkgs.callPackage — same
+# pattern as modules/mcp/module.nix (pal-mcp). This avoids requiring
+# consumers to register an overlay (nix-ai.overlays.default), which
+# causes infinite recursion in nix-darwin when useGlobalPkgs = true.
 #
 {
   pkgs,
@@ -16,11 +15,12 @@
 
 let
   cfg = config.programs.cecli;
+  cecliPkg = pkgs.callPackage ./package.nix { };
 in
 {
   config = lib.mkIf cfg.enable {
     home.packages = [
-      pkgs.cecli
+      cecliPkg
     ];
   };
 }

--- a/modules/claude/default.nix
+++ b/modules/claude/default.nix
@@ -26,11 +26,17 @@ let
 
   # Bundle get-api-key.py + bws_helper.py into a single Nix store directory
   # so Path(__file__).parent in get-api-key.py resolves bws_helper correctly.
-  apiKeyHelperSrc = pkgs.runCommand "claude-api-key-helper-src" { } ''
-    mkdir -p $out
-    cp ${./get-api-key.py} $out/get-api-key.py
-    cp ${./bws_helper.py} $out/bws_helper.py
-  '';
+  # linkFarm creates a directory of symlinks — more idiomatic than runCommand cp.
+  apiKeyHelperSrc = pkgs.linkFarm "claude-api-key-helper-src" [
+    {
+      name = "get-api-key.py";
+      path = ./get-api-key.py;
+    }
+    {
+      name = "bws_helper.py";
+      path = ./bws_helper.py;
+    }
+  ];
 
   # Wrap get-api-key.py as a self-contained shell app.
   # runtimeInputs injects python314+keyring into PATH only when the wrapper

--- a/modules/claude/default.nix
+++ b/modules/claude/default.nix
@@ -23,6 +23,29 @@
 
 let
   cfg = config.programs.claude;
+
+  # Bundle get-api-key.py + bws_helper.py into a single Nix store directory
+  # so Path(__file__).parent in get-api-key.py resolves bws_helper correctly.
+  apiKeyHelperSrc = pkgs.runCommand "claude-api-key-helper-src" { } ''
+    mkdir -p $out
+    cp ${./get-api-key.py} $out/get-api-key.py
+    cp ${./bws_helper.py} $out/bws_helper.py
+  '';
+
+  # Wrap get-api-key.py as a self-contained shell app.
+  # runtimeInputs injects python314+keyring into PATH only when the wrapper
+  # runs — this avoids adding a python3.withPackages env to home.packages,
+  # which conflicts with nix-home's python3-3.14-env in buildEnv.
+  apiKeyHelperBin = pkgs.writeShellApplication {
+    name = "claude-api-key-helper";
+    runtimeInputs = [
+      (pkgs.python314.withPackages (ps: [ ps.keyring ]))
+      pkgs.bws
+    ];
+    text = ''
+      exec python3 ${apiKeyHelperSrc}/get-api-key.py "$@"
+    '';
+  };
 in
 {
   imports = [
@@ -58,18 +81,12 @@ in
         '';
       }
       // lib.optionalAttrs cfg.apiKeyHelper.enable {
-        # API Key Helper script for headless authentication
-        # Configuration now comes from ~/.config/bws/.env (not Nix options)
+        # API Key Helper: symlink the wrapper binary to scriptPath so
+        # settings.json can reference it at its stable home-relative location.
+        # The wrapper has python314+keyring+bws in its closure via runtimeInputs
+        # (not in home.packages) to avoid Python env conflicts in buildEnv.
         "${cfg.apiKeyHelper.scriptPath}" = {
-          source = ./get-api-key.py; # Python script using bws_helper
-          executable = true;
-        };
-
-        # Shared BWS helper used by get-api-key.py to fetch CLAUDE_OAUTH_TOKEN
-        # from ~/.config/bws/.env (Bitwarden Secrets Manager backend).
-        # Deployed alongside get-api-key.py so Path(__file__).parent finds it.
-        "${builtins.dirOf cfg.apiKeyHelper.scriptPath}/bws_helper.py" = {
-          source = ./bws_helper.py;
+          source = "${apiKeyHelperBin}/bin/claude-api-key-helper";
           executable = true;
         };
 
@@ -79,10 +96,7 @@ in
         };
       };
 
-      packages = lib.optionals cfg.apiKeyHelper.enable [
-        (pkgs.python3.withPackages (ps: [ ps.keyring ]))
-        pkgs.bws
-      ];
+      packages = [ ];
 
       # Activation scripts for directory and config setup
       # NOTE: "local" marketplace setup removed - Claude Code doesn't use it by default.


### PR DESCRIPTION
## Summary

- **cecli `packages.nix`**: Replace `pkgs.cecli` (requires `nix-ai.overlays.default` registered in `nixpkgs.overlays`) with `pkgs.callPackage ./package.nix {}`. The overlay approach causes infinite recursion in nix-darwin consumers (`useGlobalPkgs = true`) because `prev.system` triggers the nixpkgs-25.11 deprecated-alias check during overlay evaluation. Pattern matches `modules/mcp/module.nix` (pal-mcp).
- **Claude `default.nix`**: Replace `pkgs.python3.withPackages [keyring]` in `home.packages` with a `writeShellApplication` wrapper (`apiKeyHelperBin`) that carries `python314 + keyring + bws` via `runtimeInputs`. Install the wrapper via `home.file` symlink. This keeps the Python env in the wrapper's closure rather than `buildEnv`, eliminating the `python3-3.13-env` vs `python3-3.14-env` conflict that surfaces when nix-home's markitdown/mammoth Python 3.14 env is already in `home.packages`.

## Root cause

Both bugs were latent and surfaced together when attempting to bump the nix-darwin `flake.lock` to pick up the ccstatusline migration (PR #690). The lock update pulled in PRs #719 (cecli) and #697 (keyring helper), which introduced the two conflicts.

## Test plan

- `nix flake check` passes (all static + regression checks green)
- `darwin-rebuild switch --override-input nix-ai <this-branch>` succeeds end-to-end
- ccstatusline renders correctly in a fresh Claude Code session
- `~/.local/bin/claude-api-key-helper` works (runs the bws_helper wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)