### PR TITLE
chore(claude): audit May 2026 config — stable channel, 180d cleanup, refresh model refs

### DIFF
--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -128,7 +128,7 @@ in
         {
           name = "cleanupPeriodDays";
           actual = cfg.settings.cleanupPeriodDays;
-          expected = 30;
+          expected = 180;
         }
         {
           name = "skillListingBudgetFraction";
@@ -138,7 +138,7 @@ in
         {
           name = "autoUpdatesChannel";
           actual = cfg.autoUpdatesChannel;
-          expected = "latest";
+          expected = "stable";
         }
         {
           name = "teammateMode";

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -133,7 +133,7 @@ in
   # Override per-session via /model effort slider or "ultrathink" keyword.
   effortLevel = "high";
 
-  autoUpdatesChannel = "stable";
+  autoUpdatesChannel = "stable"; # override (upstream default: "latest")
   # showTurnDuration — using upstream default: false (options.nix)
 
   # Enable Remote Control for all sessions (Feb 2026 feature).
@@ -218,7 +218,7 @@ in
     # Extended thinking enabled with token budget controlled via env vars
     alwaysThinkingEnabled = true;
 
-    cleanupPeriodDays = 180;
+    cleanupPeriodDays = 180; # override (upstream default: 30)
 
     env = import ./claude/settings-env.nix;
 

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -133,7 +133,7 @@ in
   # Override per-session via /model effort slider or "ultrathink" keyword.
   effortLevel = "high";
 
-  # autoUpdatesChannel — using upstream default: "latest" (options.nix)
+  autoUpdatesChannel = "stable";
   # showTurnDuration — using upstream default: false (options.nix)
 
   # Enable Remote Control for all sessions (Feb 2026 feature).
@@ -218,7 +218,7 @@ in
     # Extended thinking enabled with token budget controlled via env vars
     alwaysThinkingEnabled = true;
 
-    # cleanupPeriodDays — using upstream default: 30 (options.nix)
+    cleanupPeriodDays = 180;
 
     env = import ./claude/settings-env.nix;
 

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -12,6 +12,7 @@
   # CLAUDE_CODE_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"; # Cost control for subagents
 
   # Explicit model versions (May 2026) - pin to known working versions if customization needed
+  # Note: Opus/Sonnet 4.x use dateless IDs; Haiku 4.5 retains a date suffix per the API versioning scheme.
   # ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-7";
   # ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-6";
   # ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -11,9 +11,9 @@
   # ANTHROPIC_MODEL = "sonnet"; # Uncomment to override default model via env var
   # CLAUDE_CODE_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"; # Cost control for subagents
 
-  # Explicit model versions (Jan 2026) - pin to known working versions if customization needed
-  # ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-5-20251101";
-  # ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-5-20250929";
+  # Explicit model versions (May 2026) - pin to known working versions if customization needed
+  # ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-7";
+  # ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-6";
   # ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5-20251001";
 
   # MCP timeout settings (5 minutes) - required for PAL MCP


### PR DESCRIPTION
## Summary

Switch `autoUpdatesChannel` from `latest` to `stable` for predictable releases, extend `cleanupPeriodDays` from 30 to 180 days (projects ~11 GB at current session rate), refresh example model IDs to May 2026 generation (Opus 4.7 / Sonnet 4.6), and update CI assertions accordingly.

## Changes

- `autoUpdatesChannel`: `"latest"` → `"stable"` with inline comment showing upstream default
- `cleanupPeriodDays`: 30 → 180 (fine until NAS storage is ready; projects ~11 GB at current session rate)
- Example model IDs in `settings-env.nix`: Jan 2026 generation (Opus 4.5/Sonnet 4.5) → May 2026 generation (Opus 4.7/Sonnet 4.6); added note that Haiku 4.5 intentionally retains dated naming
- CI assertions in `lib/checks/claude.nix`: updated to match new values

## Test Plan

- [x] `nix flake check` — all 38 checks pass
- [ ] `darwin-rebuild switch` + fresh Claude Code session to verify `autoUpdatesChannel` and `cleanupPeriodDays` apply
- [ ] Manual cleanup: remove stale store-hash permission and normalize `//Users/` paths in `settings.local.json` (untracked)