### PR TITLE
fix(ci): opt out of --all-systems for nix-validate

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -96,6 +96,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.nix == 'true' && needs.changes.outputs.is-deps-only != 'true'
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    with:
+      # wrap-claude-command-*, gemini-policy, fabric-patterns-marketplace,
+      # maestro-cli, pal-mcp-server and the check-* derivations are
+      # platform-specific runCommand builds. --all-systems would try to
+      # build them on linux and fail with "platform mismatch". Evaluate
+      # the current system only.
+      all_systems: false
 
   markdown-lint:
     name: Markdown Lint


### PR DESCRIPTION
## Summary
- Pass \`all_systems: false\` to \`_nix-validate.yml\` in \`ci-gate.yml\`
- Restores pre-#294 behavior where nix flake check evaluates the current system only

## Why
nix-ai's check suite (\`wrap-claude-command-*\`, \`gemini-policy.toml\`, \`fabric-patterns-marketplace\`, \`maestro-cli\`, \`pal-mcp-server\`, plus the \`check-*\` regression derivations) are \`pkgs.runCommand\` builds that need darwin binaries. With \`--all-systems\` (introduced in JacobPEvans/.github#294), \`nix flake check\` attempted those builds on the linux runner and failed:

\`\`\`
error: Cannot build '<hash>-wrap-claude-command-X.drv'.
       Reason: platform mismatch
       Required system: 'aarch64-darwin'
       Current system: 'x86_64-linux'
\`\`\`

JacobPEvans/.github#300 made \`--all-systems\` opt-in via an \`all_systems\` workflow input (default true). This PR opts out for this repo.

## Test plan
- [ ] CI Gate / Nix Validate passes
- [ ] After merge, re-trigger CI on the open renovate PRs (#740, #743, #744, #746, #747, #748, #749) — all should turn green

Assisted-by: Claude <noreply@anthropic.com>