### PR TITLE
fix(mlx): pin mlx==0.31.1 + mlx-lm==0.31.2 to restore inference

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -73,8 +73,18 @@
   parakeetMlx = "0.5.1";
   # renovate: datasource=pypi depName=mlx-vlm
   mlxVlm = "0.5.0";
+  # Pinned to 0.31.1 — mlx 0.31.2 changed cross-thread stream registration
+  # semantics, making generation_stream (created at mlx_lm module import in the
+  # main thread) invisible to vllm-mlx's scheduler thread, causing every
+  # inference call to crash with "There is no Stream(gpu, N) in current thread."
+  # See nix-ai#751. Re-evaluate when vllm-mlx is updated to initialize
+  # generation_stream per-thread or MLX restores cross-thread stream visibility.
+  # renovate: datasource=pypi depName=mlx
+  mlx = "0.31.1";
+  # Pinned to 0.31.2 to stay compatible with mlx 0.31.1 (mlx_lm 0.31.3 was
+  # released alongside mlx 0.31.2 and requires it). See nix-ai#751.
   # renovate: datasource=pypi depName=mlx-lm
-  mlxLm = "0.31.3";
+  mlxLm = "0.31.2";
   # renovate: datasource=pypi depName=lm-eval
   lmEval = "0.4.11";
 

--- a/mlx-server/pyproject.toml
+++ b/mlx-server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Apple MLX local inference server environment"
 requires-python = ">=3.14"
 dependencies = [
-  "mlx>=0.31.1",
-  "mlx-lm>=0.31.1",
+  "mlx>=0.31.1,<0.31.2",
+  "mlx-lm>=0.31.1,<0.31.3",
   "huggingface-hub>=0.30.2",
 ]

--- a/mlx-server/uv.lock
+++ b/mlx-server/uv.lock
@@ -226,22 +226,22 @@ wheels = [
 
 [[package]]
 name = "mlx"
-version = "0.31.2"
+version = "0.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
-    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/a4/e822202dd2e4e7d08671f2ecf7b6500af74f5bad5ceb27086b1aa6902f3a/mlx-0.31.2-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:e81798c610f95a09c642c89214ba5c23b72ce18ce4728184aceabe7eddca33d7", size = 630473, upload-time = "2026-04-22T03:14:58.985Z" },
-    { url = "https://files.pythonhosted.org/packages/40/6f/da48d2d7a76e644d35438ef6f33c68755fdd382e2c546fd1804ccba01d04/mlx-0.31.2-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:69fbc94bf53607a75af9eb3e22c354738a6fe4e25aa4e2b20934b009a4bba1f3", size = 685459, upload-time = "2026-04-22T03:15:00.45Z" },
+    { url = "https://files.pythonhosted.org/packages/99/65/208f511acd5fb1ed0b08f047bd6229583845cc6f4b5aa6547a3219332dbb/mlx-0.31.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bba9d471ba20e050676292b1089a355c8042d3fc9462e4c1738a9735d7d40cfa", size = 576300, upload-time = "2026-03-12T02:16:24.545Z" },
+    { url = "https://files.pythonhosted.org/packages/98/58/2d925cb3fa3cd28d279ed6f44508ab7fbbf7359b17359914aa3652a7d734/mlx-0.31.1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:d90b0529b22553eb1353b113b7233aa391ca55e24b1ba69024c732fcc21c5c49", size = 576303, upload-time = "2026-03-12T02:16:26.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/17/abec0bd0f9347dae13e60b33325cb199312798842901953495e19f3bb3c8/mlx-0.31.1-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:69bc88b41ddd61b44cd6a4d417790f9971ba3fdf58d824934cea95a95b9b4031", size = 576275, upload-time = "2026-03-12T02:16:27.57Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/91/85c73f7cc3a661416d05315623458c719eda7de958b05f4e10ba40c52d07/mlx-0.31.1-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:b973506fd49ba39df6dc4ff655b77bd35ea193cee878e71d6ee3d1a951d2b3a6", size = 628701, upload-time = "2026-03-12T02:16:28.949Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e9/d87638e00a44dcf346fe838caaf1e2dae96a88d5779edbd66ce27d4bbdcc/mlx-0.31.1-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:3987282a1e63252bdd7c636138812c67316c3f7c7a7acad08e76c8843648a056", size = 668959, upload-time = "2026-03-12T02:16:30.41Z" },
 ]
 
 [[package]]
 name = "mlx-lm"
-version = "0.31.3"
+version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -252,19 +252,19 @@ dependencies = [
     { name = "sentencepiece" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/d7/66ac623c87f9ca834e49f8c79ff3be69179a6b5f23fc7b257fcd4fbb15bd/mlx_lm-0.31.2.tar.gz", hash = "sha256:2681b7652546d36128f43d6cc7698ec43529a1845a27350394d1843be63c652b", size = 301181, upload-time = "2026-04-07T21:36:51.229Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/67/63b032a4f11d1a634f26cedf4c5e0e33ea027bf189b1a10e1cac2653db92/mlx_lm-0.31.2-py3-none-any.whl", hash = "sha256:a90a7905031b2580b4923f92e0fb156ca287f452bb1a9e41a60dcbc971532d46", size = 407972, upload-time = "2026-04-07T21:36:49.859Z" },
 ]
 
 [[package]]
 name = "mlx-metal"
-version = "0.31.2"
+version = "0.31.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
-    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/39/66/2313497fdbc7fbadf8e026c09366e3f049f9114e65ca4edc23cdb8699186/mlx_metal-0.31.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:70741174131dbf7fdd479cb730e06e08c358eac3bf7905d9e884e7960cfdd5b8", size = 38624074, upload-time = "2026-03-12T02:15:48.036Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/34/4c3c6890ce6095b2ab2ba2f5f15c9a7ba17208d47f8cacb572885a2dc0eb/mlx_metal-0.31.1-py3-none-macosx_15_0_arm64.whl", hash = "sha256:6c56bd8cd27743e635f5a90a22535af7c31bd22b4b126d46b6da2da52d72e413", size = 38618950, upload-time = "2026-03-12T02:15:51.908Z" },
+    { url = "https://files.pythonhosted.org/packages/51/bc/987cb99e3aafb296aa11ce5133838a10eae8447edd53168d0804d4fb3a14/mlx_metal-0.31.1-py3-none-macosx_26_0_arm64.whl", hash = "sha256:e7324b7c56b519ae67c025d3ced07e5d35bc3a9f19d4c45fe4927f385148c59e", size = 49256543, upload-time = "2026-03-12T02:15:54.851Z" },
 ]
 
 [[package]]
@@ -280,8 +280,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.30.2" },
-    { name = "mlx", specifier = ">=0.31.1" },
-    { name = "mlx-lm", specifier = ">=0.31.1" },
+    { name = "mlx", specifier = ">=0.31.1,<0.31.2" },
+    { name = "mlx-lm", specifier = ">=0.31.1,<0.31.3" },
 ]
 
 [[package]]

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -47,8 +47,17 @@ let
   # Central vllm-mlx wrapper — single source of truth for the pinned version.
   # The LaunchAgent needs a Nix store path (not a PATH lookup), so the
   # derivation lives here. Also added to home.packages for CLI access.
+  #
+  # mlx==0.31.1 + mlx-lm==0.31.2 are pinned together because mlx 0.31.2 changed
+  # cross-thread stream registration semantics: generation_stream (created at
+  # mlx_lm module import in the main thread) is no longer visible to vllm-mlx's
+  # scheduler thread, causing "There is no Stream(gpu, N) in current thread" on
+  # every inference call. mlx_lm 0.31.3 was released alongside mlx 0.31.2, so
+  # both are rolled back together. See nix-ai#751.
+  mlxPin = "mlx==${versions.mlx}";
+  mlxLmPin = "mlx-lm==${versions.mlxLm}";
   vllmMlxPkg = pkgs.writeShellScriptBin "vllm-mlx" ''
-    exec ${pkgs.uv}/bin/uvx --from "vllm-mlx==${vllmMlxVersion}" vllm-mlx "$@"
+    exec ${pkgs.uv}/bin/uvx --from "vllm-mlx==${vllmMlxVersion}" --with "${mlxPin}" --with "${mlxLmPin}" vllm-mlx "$@"
   '';
 
   # llama-swap proxy package — sits on the API port, manages vllm-mlx child processes.


### PR DESCRIPTION
## Summary

- mlx 0.31.2 changed cross-thread stream registration semantics, breaking vllm-mlx's multi-threaded scheduler
- Every inference call crashed with `RuntimeError: There is no Stream(gpu, N) in current thread`
- The working combination was mlx 0.31.1 + mlx-lm 0.31.2 (all PyPI environments before April 23)
- Pin both via `--with` in the uvx wrapper; cap both in mlx-server/pyproject.toml

Also incorporates Renovate's mlx-vlm 0.5.0 bump (merged from main during rebase).

## Root cause

mlx_lm creates `generation_stream = mx.new_stream(mx.default_device())` at module import time (main thread). vllm-mlx's scheduler calls `batch_generator.next()` from a background scheduler thread. With mlx 0.31.2, cross-thread stream visibility was removed, so the scheduler thread cannot find the stream created in the main thread.

Verified by comparing uv archive history: all archives from before April 23 used mlx 0.31.1 + mlx-lm 0.31.2 (working). Environments built from April 23 onward use mlx 0.31.2 + mlx-lm 0.31.3 (broken).

Closes #751.

## Test plan

- [x] Smoke test: `curl localhost:11434/v1/chat/completions` returns `completion_tokens: 8` (was 0)
- [x] Log shows zero `Stream(gpu, N)` errors for new requests
- [x] `/running` endpoint reports Qwen3.6-35B-A3B-mxfp4 as the loaded model
- [ ] `darwin-rebuild switch` applies the new vllmMlxPkg store path

🤖 Generated with [Claude Code](https://claude.com/claude-code)