### PR TITLE
docs(claude): document manual upgrade paths

### DIFF
--- a/modules/claude/README.md
+++ b/modules/claude/README.md
@@ -40,15 +40,21 @@ brew upgrade --cask claude-code
 
 To force a fresh Anthropic-installer pull for `~/.local/bin/claude` (useful when
 `claude update` says it's already current but a new release exists), delete the
-symlink and re-run the installer:
+symlink and re-run the module-provided installer wrapper:
 
 ```bash
-rm ~/.local/bin/claude
-curl -fsSL https://claude.ai/install.sh | bash
+rm -f ~/.local/bin/claude
+claude-latest-install
 ```
 
-`~/.local/bin/claude` wins on PATH over `/opt/homebrew/bin/claude`, so the
-Anthropic-installer binary is what Claude Code sessions actually run.
+The `claude-latest-install` command is the managed wrapper from
+[`modules/claude-latest.nix`](../claude-latest.nix) (on PATH after a rebuild). It uses
+declared `runtimeInputs` and is the same script the LaunchAgent calls — it just
+has its idempotency check bypassed by removing the symlink first.
+
+Use `which claude` to confirm which binary `claude` resolves to. The `claude-latest`
+shell alias (from [`ai-aliases.zsh`](../ai-aliases.zsh)) always points directly to
+`~/.local/bin/claude` regardless of PATH order.
 
 ## Component Map
 

--- a/modules/claude/README.md
+++ b/modules/claude/README.md
@@ -11,7 +11,7 @@ Two Claude Code binaries live side-by-side on this system:
 
 | Binary | Path | Channel | Managed by |
 | ------ | ---- | ------- | ---------- |
-| `claude` | `/opt/homebrew/bin/claude` | Stable (Homebrew) | nix-darwin `homebrew.brews` |
+| `claude` | `/opt/homebrew/bin/claude` | Stable (Homebrew Cask) | nix-darwin `homebrew.casks` |
 | `claude-latest` | `~/.local/bin/claude` | Bleeding edge (Anthropic installer) | [`modules/claude-latest.nix`](../claude-latest.nix) |
 
 `claude-latest` is bootstrapped once by a user-level LaunchAgent
@@ -23,6 +23,32 @@ first install. Run `claude-latest-install` by hand to force a reinstall.
 Shell aliases (`claude-latest`, `claude-d`, `claude-latest-d`, `d-claude`,
 `tf-claude`) live in [`../ai-aliases.zsh`](../ai-aliases.zsh), wired into
 `programs.zsh.initContent` by [`../ai-shell.nix`](../ai-shell.nix).
+
+### Upgrading to a specific release
+
+Both channels are self-managing: Homebrew's auto-updater bumps the cask and
+`claude update` advances the Anthropic install on the `autoUpdatesChannel`
+configured in `modules/claude-config.nix` (currently `"stable"`). Stable lags
+the `"latest"` channel by roughly one week.
+
+To pull a release that is available on Homebrew but hasn't arrived on stable yet,
+upgrade the Homebrew cask manually:
+
+```bash
+brew upgrade --cask claude-code
+```
+
+To force a fresh Anthropic-installer pull for `~/.local/bin/claude` (useful when
+`claude update` says it's already current but a new release exists), delete the
+symlink and re-run the installer:
+
+```bash
+rm ~/.local/bin/claude
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+`~/.local/bin/claude` wins on PATH over `/opt/homebrew/bin/claude`, so the
+Anthropic-installer binary is what Claude Code sessions actually run.
 
 ## Component Map
 


### PR DESCRIPTION
## Summary

This PR documents manual Claude Code upgrade paths and fixes a configuration label error in the Claude module README. It addresses the gap where Homebrew's stable channel lags behind available releases by ~1 week, leaving users without an automatic update path when they want to adopt new features immediately.

## Changes

- **Fixed configuration label**: Updated Parallel Installs table to correctly show `homebrew.casks` (binary lives in Caskroom/) instead of `homebrew.brews`
- **Added upgrade section**: New "Upgrading to a specific release" sub-section with two paths:
  - `brew upgrade --cask claude-code` — when Homebrew has a release the stable channel hasn't yet promoted
  - `claude-latest-install` wrapper — forces installation via Anthropic installer when the channel check blocks an update
- **Improved clarity**: Replaced assertive PATH claims with `which claude` confirmation and clarified the `claude-latest` alias as the unambiguous stable override

## Test Plan

- [x] All 38 nix flake checks pass
- [x] CI checks pass
- [x] All review threads resolved
- [x] Documentation renders correctly in GitHub UI