### PR TITLE
refactor(mlx): lower cache reservation and normalize idle ttl

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -74,7 +74,12 @@ in
         {
           name = "mlx.cacheMemoryMb";
           actual = mlxCfg.cacheMemoryMb;
-          expected = 32768;
+          expected = 8192;
+        }
+        {
+          name = "mlx.proxy.idleTtl";
+          actual = mlxCfg.proxy.idleTtl;
+          expected = 3600;
         }
         {
           name = "mlx.prefillBatchSize";

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -126,8 +126,11 @@ let
   # Group roles by physical model. One backend serves many role aliases.
   rolesByPhysical = lib.groupBy (role: roleModels.${role}) (lib.attrNames roleModels);
 
-  # One entry per unique physical model. The entry owning the "default"
-  # alias is preloaded; others inherit the proxy idle TTL.
+  # One entry per unique physical model. Every model — including the entry
+  # owning the "default" alias — inherits the uniform proxy idle TTL.
+  # The default model is still preloaded on startup via hooks.on_startup.preload
+  # below, so the first request never pays a cold-start cost; after one hour
+  # of idle it unloads and the next request reloads it (~15-30 s).
   #
   # useModelName makes llama-swap rewrite the OpenAI-compatible request body's
   # `model` field to the physical model id before forwarding to vllm-mlx.
@@ -139,7 +142,7 @@ let
   # works end-to-end through the local proxy without needing Bifrost in front.
   registryModels = lib.mapAttrs (physical: roles: {
     cmd = mkVllmCmd physical;
-    ttl = if builtins.elem "default" roles then 0 else cfg.proxy.idleTtl;
+    ttl = cfg.proxy.idleTtl;
     env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
     checkEndpoint = "/v1/models";
     aliases = roles;

--- a/modules/mlx/options-cache.nix
+++ b/modules/mlx/options-cache.nix
@@ -2,14 +2,24 @@
 # MLX Module — KV cache and prefill options
 #
 # vllm-mlx 0.2.9 PERFORMANCE TUNING.
-# Benchmarked 2026-03-19 on M4 Max 128GB with Qwen3.5-122B-A10B-4bit (~65 GB).
-# Memory budgets reference the 122B MoE model (10B active params, ~20 GB).
-# Baseline: 55-74 tok/s generation, no parallel request benefit (bandwidth-bound).
+# Sizing target: M4 Max 128 GB. Effective wired ceiling 118 GB (from
+# nix-darwin's apple-silicon-tunables module via iogpu.wired_limit_mb=118000).
 #
 # vllm-mlx 0.2.9 adds Paged KV Cache + prefix sharing on top of the
-# memory-aware cache that auto-sizes based on available RAM. Combined with
-# iogpu.wired_limit_mb=118000 (set by nix-darwin's apple-silicon-tunables
-# module) this lets us push the cache budget higher without thrashing.
+# memory-aware cache that auto-sizes based on available RAM.
+#
+# Cache-size rationale (cacheMemoryMb default = 8192):
+#   The KV cache working set is bounded by maxNumSeqs * maxTokens * 2 (K and V)
+#   times the per-layer state. For the Qwen3.x MoE models in this registry, 4
+#   active sequences at 8192 tokens fit comfortably in 6-8 GB. The default of
+#   8192 MB covers that plus prefix-cache headroom. Larger reservations just
+#   wire memory that is never used.
+#
+# History note (2026-05-13): the previous default of 32768 MB combined with
+# hot-swap activity drove the host into 24 GB of swap and ~1 tok/s decode on
+# the flagship model. Lowering to 8192 restores expected throughput. Raise on
+# a per-host basis if a workload genuinely benefits from larger cache; do not
+# raise the module default.
 #
 { lib, ... }:
 {
@@ -23,8 +33,8 @@
     # Ref: https://github.com/ml-explore/mlx-lm/issues/883
     cacheMemoryMb = lib.mkOption {
       type = lib.types.nullOr lib.types.ints.positive;
-      default = 32768;
-      description = "Cache memory limit in MB. Null = auto-detect. Default 32GB amortises prefix-cache reuse on multi-turn workloads.";
+      default = 8192;
+      description = "KV cache reservation in MB (vllm-mlx --cache-memory-mb). Null = server auto-detect. Default 8 GB right-sized for maxNumSeqs=4 and maxTokens=8192; raise per-host if a workload needs more.";
     };
 
     # enablePrefixCaching — Enable prefix sharing across requests (--enable-prefix-cache).

--- a/modules/mlx/options-cache.nix
+++ b/modules/mlx/options-cache.nix
@@ -25,11 +25,10 @@
 {
   options.programs.mlx = {
     # cacheMemoryMb — Override the memory-aware cache size (--cache-memory-mb).
-    # Default: 32768 (32GB). Larger cache amortises prefix-cache reuse on
-    # multi-turn agentic workloads. With a 65GB model + 32GB cache the
-    # footprint sits at ~97GB, fitting within the 118GB wired ceiling set by
-    # nix-darwin's apple-silicon-tunables module. Lower to 16384 if reverting.
-    # Set to null to restore server auto-detect (~20% RAM = ~25.6GB).
+    # Default: 8192 (8 GB). Right-sized for maxNumSeqs=4 at maxTokens=8192 with
+    # prefix-cache headroom; see the file-header rationale (lines 11-22) for
+    # why the previous 32768 (32 GB) default was lowered.
+    # Set to null to restore server auto-detect (~20% RAM = ~25.6 GB on 128 GB).
     # Ref: https://github.com/ml-explore/mlx-lm/issues/883
     cacheMemoryMb = lib.mkOption {
       type = lib.types.nullOr lib.types.ints.positive;

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -53,8 +53,8 @@
       };
       idleTtl = lib.mkOption {
         type = lib.types.ints.unsigned;
-        default = 1800;
-        description = "Default idle TTL in seconds for non-default models. 0 = never auto-unload. Default 30 min.";
+        default = 3600;
+        description = "Idle TTL in seconds applied uniformly to every model in the registry (including the default-aliased one). 0 = never auto-unload (escape hatch). Default 3600 s (1 hour) gives a long warm window without permanently wiring a model's weights.";
       };
       logLevel = lib.mkOption {
         type = lib.types.enum [

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -42,7 +42,7 @@
         }
       );
       default = { };
-      description = "Additional models available for on-demand switching via llama-swap proxy. The defaultModel is always available with TTL 0.";
+      description = "Additional models available for on-demand switching via llama-swap proxy. All models (including the default-aliased one) share the uniform proxy.idleTtl unless overridden per-model.";
     };
 
     proxy = {


### PR DESCRIPTION
## Summary

- `programs.mlx.cacheMemoryMb` default 32768 → **8192** (8 GB)
- `programs.mlx.proxy.idleTtl` default 1800 → **3600** (1 hour)
- Drop the `ttl = 0` (never-unload) special case on the default-aliased registry entry — all models follow `cfg.proxy.idleTtl` uniformly
- `lib/checks/mlx.nix`: regression test updated to assert the new defaults

## Why

On a 128 GB M4 Max running the current registry the previous 32 GB KV-cache reservation, combined with hot-swap activity and a default-model that never unloaded, was wiring well over 100 GB of memory. The OS pushed weights to swap and decode dropped to roughly 1 tok/s on the flagship model. Right-sizing the reservation and giving every model the same idle-TTL discipline removes the structural pressure without touching anything else in the stack.

### Cache-size math

Default model: Qwen3.6-35B-A3B-mxfp4 (3B active, mxfp4 weights ~22 GB).
KV working set is bounded by `maxNumSeqs (4) × maxTokens (8192) × 2 (K+V) × per-layer-state`. For the Qwen3.x A3B/A10B models that's 4–8 GB in practice. 8192 MB covers the working set plus prefix-cache headroom; raising the default just wires unused memory.

### TTL

The default-aliased model is still preloaded on startup via `hooks.on_startup.preload = ["default"]`, so the first request remains warm. After one hour of idle the model unloads (cleanly freeing wired memory) and the next call reloads it in ~15–30 s. Idle-then-reload was already the behavior for every non-default model in the registry — this just removes the asymmetry.

## What is not changed

- vllm-mlx, mlx-lm, mlx, llama-swap versions
- The default model itself (still Qwen3.6-35B-A3B-mxfp4)
- Any options other than the two defaults named above
- Workflow files (the 2 pre-existing zizmor `secrets-inherit` mediums in `.github/workflows/ai-merge-gate.yml` and `ci-gate.yml` are unrelated and were not touched)

## Test plan

- [x] `nix flake check` — all checks pass including `mlx-defaults-regression`
- [ ] On a host: `home-manager switch` then `launchctl kickstart -k gui/$UID/dev.vllm-mlx.server`
- [ ] Verify rendered config: `jq '.models[].ttl, .models[].cmd' ~/.config/mlx/llama-swap.json | head`
- [ ] Verify host memory pressure clears: `vm_stat | awk '/Pages wired|Pages free/'` and `sysctl vm.swapusage`
- [ ] Verify decode throughput on Qwen3.6-35B-A3B-mxfp4 returns to the expected 30–60 tok/s range