### PR TITLE
fix(flake): scope checks to x86_64-linux; restore --all-systems default

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -96,13 +96,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.nix == 'true' && needs.changes.outputs.is-deps-only != 'true'
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
-    with:
-      # wrap-claude-command-*, gemini-policy, fabric-patterns-marketplace,
-      # maestro-cli, pal-mcp-server and the check-* derivations are
-      # platform-specific runCommand builds. --all-systems would try to
-      # build them on linux and fail with "platform mismatch". Evaluate
-      # the current system only.
-      all_systems: false
 
   markdown-lint:
     name: Markdown Lint
@@ -123,7 +116,6 @@ jobs:
     uses: JacobPEvans/.github/.github/workflows/_python-security.yml@main
     with:
       python-dirs: 'mlx-server orchestrator'
-    secrets: inherit
 
   osv-scan:
     name: OSV Scan

--- a/flake.nix
+++ b/flake.nix
@@ -283,23 +283,31 @@
         aiCommon = import ./modules/common;
       };
 
-      # Quality checks (formatting, linting, dead code, shellcheck, module-eval)
-      checks = forAllSystems (
-        system:
+      # Quality checks (formatting, linting, dead code, shellcheck, module-eval).
+      #
+      # Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds
+      # from a single linux runner. All checks in lib/checks.nix are source-only
+      # or evaluation-wrapped — running once on the CI system is sufficient.
+      # Cross-platform breakage is still caught by `--all-systems` evaluating
+      # `packages.<system>`, `formatter.<system>`, and `overlays.default` on
+      # every declared system.
+      checks =
         let
+          system = "x86_64-linux";
           pkgs = nixpkgs.legacyPackages.${system};
         in
-        import ./lib/checks.nix {
-          inherit
-            pkgs
-            home-manager
-            pal-mcp-server
-            fabric-src
-            ;
-          src = ./.;
-          aiModule = self.homeManagerModules.default;
-        }
-      );
+        {
+          ${system} = import ./lib/checks.nix {
+            inherit
+              pkgs
+              home-manager
+              pal-mcp-server
+              fabric-src
+              ;
+            src = ./.;
+            aiModule = self.homeManagerModules.default;
+          };
+        };
 
       # Expose custom packages for nix-update automation
       packages = forAllSystems (


### PR DESCRIPTION
## Summary

Companion to [nix-home#241](https://github.com/JacobPEvans/nix-home/pull/241) and [nix-darwin#1101](https://github.com/JacobPEvans/nix-darwin/pull/1101). This repo had been opting out of `--all-systems` via `all_systems: false` in `ci-gate.yml` to dodge "platform mismatch" errors on the linux runner. The opt-out loses the cross-platform evaluation that `--all-systems` was added for.

## Changes

- **`flake.nix`**: scope `checks` to `x86_64-linux` only. The checks in `lib/checks.nix` are source-only or evaluation-wrapped — running once on the CI system is sufficient. Other systems intentionally have no `checks` entries.
- **`.github/workflows/ci-gate.yml`**: remove `all_systems: false` from the `nix-validate` call so the `_nix-validate.yml` default (`true`) takes effect.
- **`.github/workflows/ci-gate.yml`**: drop `secrets: inherit` from the `python-security` job — `_python-security.yml` declares no secrets, so the inherit is dead code; zizmor (correctly) flags it as an unnecessary blast-radius expansion.

Cross-system breakage is still caught: `packages.<system>`, `formatter.<system>`, and `overlays.default` remain `forAllSystems` and are evaluated by `--all-systems` for every declared system.

## Verification

Local `nix flake check --all-systems --print-build-logs --show-trace --keep-going` confirms:

- `packages.aarch64-darwin.{gh-aw,pal-mcp-server,fabric-ai,cecli}` ✅
- `packages.x86_64-linux.{gh-aw,pal-mcp-server,fabric-ai,cecli}` ✅
- `formatter.{aarch64-darwin,x86_64-linux}` ✅
- `overlays.default` ✅
- Only `checks.x86_64-linux.*` are declared
- The local "Cannot build x86_64-linux drv on aarch64-darwin" errors are expected on my machine and will not appear on the CI runner

## Test plan

- [ ] CI on this PR: `Nix Validate / Validate` passes with `--all-systems` enabled (no platform-mismatch errors)
- [ ] zizmor pre-commit hook passes (was previously failing on the now-removed `secrets: inherit`)
- [ ] No regression in other gate checks

## Companion PRs

- [JacobPEvans/.github#313](https://github.com/JacobPEvans/.github/pull/313) — `all_systems` passthrough in `_ci-gate.yml`
- [JacobPEvans/nix-home#241](https://github.com/JacobPEvans/nix-home/pull/241) — same flake-level fix
- [JacobPEvans/nix-darwin#1101](https://github.com/JacobPEvans/nix-darwin/pull/1101) — same flake-level fix