### PR TITLE
fix(cecli): correct hashes and automate nix-update on Renovate pushes

### DIFF
--- a/.github/scripts/commit-hash-fixes.sh
+++ b/.github/scripts/commit-hash-fixes.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add modules/cecli/package.nix
+git diff --cached --quiet && exit 0
+git commit -m "fix(deps): update fetchPypi hashes for cecli and mcp"
+git push

--- a/.github/workflows/fix-renovate-hashes.yml
+++ b/.github/workflows/fix-renovate-hashes.yml
@@ -1,0 +1,48 @@
+# Fixes fetchPypi hash fields after Renovate bumps version strings.
+#
+# Renovate's custom regex manager updates version strings in .nix files but
+# cannot update adjacent hash = "sha256-..." fields. This workflow fires on
+# every push to a Renovate branch, re-runs nix-update for the affected
+# packages, and commits corrected hashes back before CI runs.
+#
+# Packages covered: cecli, mcp (via cecli passthru)
+# Add new packages here and to the packages output in flake.nix when needed.
+name: Fix Renovate hash updates
+
+on:
+  push:
+    branches:
+      - "chore/renovate/**"
+
+jobs:
+  fix-hashes:
+    name: Update fetchPypi hashes
+    runs-on: ubuntu-latest
+    environment: automation
+    permissions:
+      contents: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.ref }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Update mcp hash
+        run: nix run nixpkgs#nix-update -- --flake mcp --version="$(nix eval --raw .#mcp.version)"
+
+      - name: Update cecli hash
+        run: nix run nixpkgs#nix-update -- --flake cecli --version="$(nix eval --raw .#cecli.version)"
+
+      - name: Commit hash fixes
+        run: .github/scripts/commit-hash-fixes.sh

--- a/flake.nix
+++ b/flake.nix
@@ -320,6 +320,7 @@
           pal-mcp-server = pkgs.callPackage ./modules/mcp/pal-package.nix { inherit pal-mcp-server; };
           fabric-ai = pkgs.callPackage ./modules/fabric/package.nix { inherit fabric-src; };
           cecli = pkgs.callPackage ./modules/cecli/package.nix { };
+          inherit ((pkgs.callPackage ./modules/cecli/package.nix { }).passthru) mcp;
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -314,13 +314,14 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          cecliPkg = pkgs.callPackage ./modules/cecli/package.nix { };
         in
         {
           gh-aw = pkgs.callPackage ./modules/gh-extensions/gh-aw.nix { };
           pal-mcp-server = pkgs.callPackage ./modules/mcp/pal-package.nix { inherit pal-mcp-server; };
           fabric-ai = pkgs.callPackage ./modules/fabric/package.nix { inherit fabric-src; };
-          cecli = pkgs.callPackage ./modules/cecli/package.nix { };
-          inherit ((pkgs.callPackage ./modules/cecli/package.nix { }).passthru) mcp;
+          cecli = cecliPkg;
+          inherit (cecliPkg.passthru) mcp;
         }
       );
 

--- a/modules/cecli/package.nix
+++ b/modules/cecli/package.nix
@@ -76,7 +76,7 @@ let
     src = fetchPypi {
       pname = "mcp";
       version = mcpVersion;
-      hash = "sha256-rqrRNGZM5W8nIdGr8wBmah6DSFY/TTuv82HDtlJEjvw=";
+      hash = "sha256-D0fhgg+Pj5QUZrOXSesdGDmgTK3corxg6dRuipmRSSQ=";
     };
     build-system = with python3Packages; [
       hatchling
@@ -115,7 +115,7 @@ python3Packages.buildPythonApplication {
   src = fetchPypi {
     pname = "cecli_dev";
     inherit version;
-    hash = "sha256-kDJ+DfCFz+CJxEjWWeISodAcFdUGSl6wElOZH8rYmVE=";
+    hash = "sha256-27LzYHD2DQYd8TTv+MAOazz4UTUF9GAt9iSLzA4/HOs=";
   };
 
   # nixpkgs-25.11 ships older versions of several deps than cecli's
@@ -200,6 +200,9 @@ python3Packages.buildPythonApplication {
   # test of the install layout.
   doCheck = false;
   pythonImportsCheck = [ "cecli" ];
+
+  # Expose mcp as passthru so nix-update can manage its hash via --flake mcp
+  passthru.mcp = mcp;
 
   meta = with lib; {
     description = "AI pair-programming CLI (maintained fork of Aider)";


### PR DESCRIPTION
## Summary

- Corrects two broken fetchPypi hashes after Renovate bumped versions without updating the adjacent `hash = "sha256-..."` fields
- Exposes `mcp` as a flake package via `cecli.passthru` so nix-update can manage its hash
- Adds `fix-renovate-hashes.yml`: fires on every `chore/renovate/**` push, runs `nix-update` for `mcp` then `cecli`, and commits corrected hashes back to the branch before CI runs

## Immediate hash fixes

| Package | Old (wrong) | New (correct) |
|---------|------------|--------------|
| `cecli_dev` 0.99.11 | `sha256-kDJ+...` | `sha256-27Lz...` |
| `mcp` 1.27.1 | `sha256-rqrR...` | `sha256-D0fh...` |

Both verified by local `nix build .#cecli`.

## Root cause

Renovate's custom regex manager matches only version strings (`version = "1.2.3"`). The `hash = "sha256-..."` fields on separate lines are never touched. The new workflow closes this gap by running `nix-update --version=$(nix eval --raw .#pkg.version)` (pin to the version Renovate set, fix only the hash) on every Renovate branch push.

## Test plan

- [ ] CI passes on this PR (cecli builds on x86_64-linux)
- [ ] After merge: verify `fix-renovate-hashes.yml` fires on next Renovate PR push to `chore/renovate/**`
- [ ] nix-darwin picks up fixed nix-ai input and `darwin-rebuild switch` succeeds