### PR TITLE
fix(fabric): update vendorHash for nixpkgs-25.11 Go toolchain

### DIFF
--- a/modules/fabric/package.nix
+++ b/modules/fabric/package.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
   src = fabric-src;
 
   # Discover via: nix build .#fabric-ai 2>&1 | grep 'got:'
-  vendorHash = "sha256-G1N/cPPReI5jrZ9orrWEAV/cRPrGbUZyhht+8iMDRb0=";
+  vendorHash = "sha256-oSHrn2Oad6XuIFjrqeC4NGC/rasCu+49xADY15YNSbc=";
 
   # Build only the main fabric binary from cmd/fabric. Skip cmd/code2context,
   # cmd/generate_changelog, cmd/to_pdf — we only need the primary CLI.


### PR DESCRIPTION
## Summary

- Updates `fabric-ai-1.4.452` vendorHash from `sha256-G1N/cPP...` to `sha256-oSHrn2O...`
- Hash mismatch detected during `darwin-rebuild switch` after nixpkgs was bumped in nix-darwin
- Root cause: nixpkgs-25.11's Go toolchain update changed go-modules hash computation

## How the correct hash was found

```
nix build .#darwinConfigurations.jevans-mbp.system --keep-going 2>&1 | grep "got:"
# got:    sha256-oSHrn2Oad6XuIFjrqeC4NGC/rasCu+49xADY15YNSbc=
```

## Test plan

- [ ] CI passes (Nix Validate builds fabric-ai with new hash)
- [ ] darwin-rebuild switch succeeds with this nix-ai version pinned in nix-darwin

Assisted-by: Claude <noreply@anthropic.com>