### PR TITLE
feat(ci): migrate Linux CI to self-hosted RunsOn runners

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -41,7 +41,9 @@ jobs:
   # ==========================================================================
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    # Self-hosted RunsOn runner (terraform-runs-on). docs/migration-guide.md
+    # in JacobPEvans/terraform-runs-on documents the label format and rollback.
+    runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
     permissions:
       contents: read
       pull-requests: read
@@ -96,18 +98,26 @@ jobs:
     needs: changes
     if: needs.changes.outputs.nix == 'true' && needs.changes.outputs.is-deps-only != 'true'
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    with:
+      # `nix flake check --all-systems` needs disk/RAM for darwin source
+      # substitution; m7+c7 family with s3-cache fits.
+      runner_label: "runs-on=${{ github.run_id }}/cpu=4/ram=16/family=m7+c7/extras=s3-cache"
 
   markdown-lint:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
     uses: JacobPEvans/.github/.github/workflows/_markdown-lint.yml@main
+    with:
+      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
 
   file-size:
     name: File Size
     needs: changes
     if: needs.changes.outputs.nix == 'true' || needs.changes.outputs.markdown == 'true'
     uses: JacobPEvans/.github/.github/workflows/_file-size.yml@main
+    with:
+      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
 
   python-security:
     name: Python Security
@@ -116,12 +126,15 @@ jobs:
     uses: JacobPEvans/.github/.github/workflows/_python-security.yml@main
     with:
       python-dirs: 'mlx-server orchestrator'
+      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
 
   osv-scan:
     name: OSV Scan
     needs: changes
     if: always()
     uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@main
+    with:
+      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
 
   # ==========================================================================
   # MERGE GATE - The ONLY required check in branch protection
@@ -130,7 +143,7 @@ jobs:
     name: Merge Gate
     needs: [changes, nix-validate, markdown-lint, file-size, python-security, osv-scan]
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
+    runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
     steps:
       - name: Check all results
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -39,11 +39,17 @@ jobs:
   # ==========================================================================
   # CHANGE DETECTION
   # ==========================================================================
+  # Fork-PR security guard:
+  # nix-ai is a PUBLIC repository, so `pull_request` from fork branches
+  # would otherwise execute fork-author-controlled code on our self-hosted
+  # RunsOn runners (and the underlying AWS account). The `runs-on:` expression
+  # routes same-repo PRs to RunsOn and falls back to `ubuntu-latest`
+  # (github-hosted, ephemeral, sandboxed) for fork PRs. Reusable workflow
+  # calls below carry the same expression through `runner_label`.
+  # Pattern reference: runs-on.com/configuration/job-labels (Fork PRs).
   changes:
     name: Detect Changes
-    # Self-hosted RunsOn runner (terraform-runs-on). docs/migration-guide.md
-    # in JacobPEvans/terraform-runs-on documents the label format and rollback.
-    runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
     permissions:
       contents: read
       pull-requests: read
@@ -101,7 +107,8 @@ jobs:
     with:
       # `nix flake check --all-systems` needs disk/RAM for darwin source
       # substitution; m7+c7 family with s3-cache fits.
-      runner_label: "runs-on=${{ github.run_id }}/cpu=4/ram=16/family=m7+c7/extras=s3-cache"
+      # Fork PRs fall back to ubuntu-latest (see header comment on `changes`).
+      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/cpu=4/ram=16/family=m7+c7/extras=s3-cache', github.run_id) || 'ubuntu-latest' }}
 
   markdown-lint:
     name: Markdown Lint
@@ -109,7 +116,7 @@ jobs:
     if: needs.changes.outputs.markdown == 'true'
     uses: JacobPEvans/.github/.github/workflows/_markdown-lint.yml@main
     with:
-      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
+      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   file-size:
     name: File Size
@@ -117,7 +124,7 @@ jobs:
     if: needs.changes.outputs.nix == 'true' || needs.changes.outputs.markdown == 'true'
     uses: JacobPEvans/.github/.github/workflows/_file-size.yml@main
     with:
-      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
+      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   python-security:
     name: Python Security
@@ -126,7 +133,7 @@ jobs:
     uses: JacobPEvans/.github/.github/workflows/_python-security.yml@main
     with:
       python-dirs: 'mlx-server orchestrator'
-      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
+      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   osv-scan:
     name: OSV Scan
@@ -134,7 +141,7 @@ jobs:
     if: always()
     uses: JacobPEvans/.github/.github/workflows/_osv-scan.yml@main
     with:
-      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
+      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   # ==========================================================================
   # MERGE GATE - The ONLY required check in branch protection
@@ -143,7 +150,7 @@ jobs:
     name: Merge Gate
     needs: [changes, nix-validate, markdown-lint, file-size, python-security, osv-scan]
     if: ${{ !cancelled() }}
-    runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
+    runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
     steps:
       - name: Check all results
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -16,7 +16,8 @@ on:
 jobs:
   update:
     name: Update custom packages
-    runs-on: ubuntu-latest
+    # Self-hosted RunsOn runner — see terraform-runs-on/docs/migration-guide.md
+    runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
     environment: automation
     permissions:
       contents: write

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -20,7 +20,8 @@ permissions:
 jobs:
   dispatch:
     if: github.event_name == 'issues' && github.event.label.name == 'ai:ready'
-    runs-on: ubuntu-latest
+    # Self-hosted RunsOn runner — see terraform-runs-on/docs/migration-guide.md
+    runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
     permissions:
       actions: write
       issues: write


### PR DESCRIPTION
## Summary

- Migrate Linux PR-triggered CI workflows from `ubuntu-latest` to self-hosted RunsOn runners deployed by `JacobPEvans/terraform-runs-on`. Mirrors the migration applied in nix-darwin (#1104).
- Migrated jobs:
  - `ci-gate.yml`: `Detect Changes`, `Merge Gate`
  - `ci-gate.yml` reusable calls: `_nix-validate` (with `cpu=4/ram=16/family=m7+c7/extras=s3-cache`), `_markdown-lint`, `_file-size`, `_python-security`, `_osv-scan`
  - `deps-update-flake.yml`: `Update custom packages`
  - `issue-auto-resolve.yml`: `dispatch`
- Not migrated: lock files (gh-aw regenerated), disabled-schedule agentic workflows (`pull_request` trigger absent — no fork-PR exposure).
- **Fork-PR security guard** (commit 4a8f525): nix-ai is a PUBLIC repository. The `runs-on:` expression routes same-repo PRs to RunsOn and falls back to `ubuntu-latest` (github-hosted, sandboxed) for fork PRs. Mirrors the identical fix applied to nix-darwin (commit 355bda7).

  ```yaml
  runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
  ```

## Test plan

- [x] Confirmed JacobPEvans/.github#319 has merged.
- [ ] Confirm the RunsOn GitHub App has this repo in its allowlist.
- [ ] Push a trivial change to trigger CI Gate, expand the `Set up runner` group on each migrated job, verify `RUNS_ON_VERSION=v3.x.x` is printed.
- [ ] Verify the RunsOn dashboard shows runs from this repo.

Refs: https://github.com/JacobPEvans/terraform-runs-on/blob/main/docs/migration-guide.md (PR #60)