### PR TITLE
fix(mlx): enforce loop-prevention penalties via llama-swap setParams

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -150,7 +150,7 @@ let
   # apply universally to every caller, every prompt, every model — including
   # callers that explicitly send greedy-decoding parameters (setParams
   # overrides client values per llama-swap's documented semantics).
-  defaultFilters = cfg.proxy.defaultFilters;
+  inherit (cfg.proxy) defaultFilters;
 
   registryModels = lib.mapAttrs (
     physical: roles:

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -106,6 +106,10 @@ let
           "--max-tokens"
           (toString cfg.maxTokens)
         ]
+        ++ lib.optionals (cfg.maxRequestTokens != null) [
+          "--max-request-tokens"
+          (toString cfg.maxRequestTokens)
+        ]
         ++ lib.optionals cfg.enableAutoToolChoice [ "--enable-auto-tool-choice" ]
         ++ lib.optionals (cfg.enableAutoToolChoice && cfg.toolCallParser != null) [
           "--tool-call-parser"
@@ -140,19 +144,42 @@ let
   #   "The model `default` does not exist."
   # even though llama-swap routed the request correctly. With it, the alias
   # works end-to-end through the local proxy without needing Bifrost in front.
-  registryModels = lib.mapAttrs (physical: roles: {
-    cmd = mkVllmCmd physical;
-    ttl = cfg.proxy.idleTtl;
-    env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
-    checkEndpoint = "/v1/models";
-    aliases = roles;
-    useModelName = physical;
-    inherit (cfg.proxy) concurrencyLimit;
-  }) rolesByPhysical;
+  # Default llama-swap filters applied to every model in the registry.
+  # See modules/mlx/options-filters.nix for the schema and reasoning.
+  # Filters run at the proxy layer BEFORE the request hits vllm-mlx, so they
+  # apply universally to every caller, every prompt, every model — including
+  # callers that explicitly send greedy-decoding parameters (setParams
+  # overrides client values per llama-swap's documented semantics).
+  defaultFilters = cfg.proxy.defaultFilters;
+
+  registryModels = lib.mapAttrs (
+    physical: roles:
+    {
+      cmd = mkVllmCmd physical;
+      ttl = cfg.proxy.idleTtl;
+      env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
+      checkEndpoint = "/v1/models";
+      aliases = roles;
+      useModelName = physical;
+      inherit (cfg.proxy) concurrencyLimit;
+    }
+    // lib.optionalAttrs (defaultFilters != { }) {
+      filters = defaultFilters;
+    }
+  ) rolesByPhysical;
 
   # Additional ad-hoc models from cfg.models (existing extension point).
+  # Per-model filters merge on top of the global default so an individual
+  # model can tighten one key without dropping siblings — e.g. setting
+  # cfg.models.foo.filters.setParams.top_p preserves the global
+  # frequency_penalty / presence_penalty defaults. Uses lib.recursiveUpdate
+  # so nested attrsets (setParams, future filter groups) merge key-by-key
+  # rather than wholesale-replacing each other.
   additionalModels = lib.mapAttrs (
     name: modelCfg:
+    let
+      mergedFilters = lib.recursiveUpdate defaultFilters (modelCfg.filters or { });
+    in
     {
       cmd =
         mkVllmCmd name
@@ -166,6 +193,9 @@ let
     }
     // lib.optionalAttrs (modelCfg.aliases != [ ]) {
       inherit (modelCfg) aliases;
+    }
+    // lib.optionalAttrs (mergedFilters != { }) {
+      filters = mergedFilters;
     }
   ) cfg.models;
 
@@ -203,6 +233,7 @@ in
     ./options-server.nix
     ./options-cache.nix
     ./options-batching.nix
+    ./options-filters.nix
     ./options-parsers.nix
     ./options-runtime.nix
     ./packages.nix

--- a/modules/mlx/options-batching.nix
+++ b/modules/mlx/options-batching.nix
@@ -60,5 +60,24 @@
       default = null;
       description = "Default max tokens when client omits max_tokens. Null = vllm-mlx server default: 32768.";
     };
+
+    # maxRequestTokens — Hard cap on max_tokens accepted from API clients
+    # (--max-request-tokens). Server default: 32768.
+    #
+    # Unlike maxTokens, which only fills in a default when the client OMITS
+    # max_tokens, this option ENFORCES a ceiling on whatever value the client
+    # requests. If a client asks for max_tokens=100000, vllm-mlx clamps it to
+    # this value and returns finish_reason: "length" once the cap is hit.
+    #
+    # Left null by default — keeps the 32768 server ceiling intact so
+    # legitimate expensive generations remain possible. Set to a positive
+    # integer only when you specifically need to cap client-requested
+    # generation length (e.g. cost control on a shared environment, or
+    # bounding wasted compute on a pathologically misconfigured caller).
+    maxRequestTokens = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      description = "Hard cap on max_tokens accepted from clients. Null = vllm-mlx server default: 32768.";
+    };
   };
 }

--- a/modules/mlx/options-filters.nix
+++ b/modules/mlx/options-filters.nix
@@ -1,0 +1,69 @@
+#
+# MLX Module — llama-swap request filter options
+#
+# Per-model filters applied at the llama-swap proxy layer. Filters run BEFORE
+# the request reaches vllm-mlx, so they apply universally — to every caller,
+# every prompt, every model with the filter configured. Cannot be bypassed
+# by client request bodies.
+#
+# Two filter types are supported by llama-swap:
+#
+#   setParams   — dict of parameters to SET/OVERRIDE in the request.
+#                 Enforcement, not default-filling. If the client sends
+#                 frequency_penalty=0 and setParams.frequency_penalty=0.3,
+#                 the request that reaches vllm-mlx has 0.3.
+#
+#   stripParams — comma-separated list of parameters to REMOVE from the
+#                 request before forwarding. Useful to fully delegate a
+#                 parameter to the vllm-mlx / model default.
+#
+# Reference: https://github.com/mostlygeek/llama-swap/blob/main/docs/configuration.md
+#
+# Why the default value enables modest frequency_penalty/presence_penalty:
+#
+# Token-repetition loops on local MLX models are most commonly caused by
+# callers using greedy decoding (temperature=0) on long inputs (e.g.
+# transcript summarization). The OpenAI-API standard counter-measures are
+# frequency_penalty (additive penalty proportional to a token's occurrence
+# count) and presence_penalty (additive penalty for any previously-seen
+# token). Both flow cleanly through vllm-mlx → mlx-lm. A modest value of
+# 0.3 (in the 0.0-2.0 range) disrupts the high-probability token cycles
+# that produce loops without measurably degrading quality on normal
+# prompts. Higher values trade quality for safety; lower values approach
+# the unprotected baseline. 0.3 is the community-recognized "loop-
+# prevention baseline" for OpenAI-compatible serving stacks.
+#
+# Documented at:
+#   - https://github.com/mostlygeek/llama-swap/blob/main/docs/configuration.md
+#   - https://github.com/mostlygeek/llama-swap/blob/main/config.example.yaml
+#
+{ lib, ... }:
+{
+  options.programs.mlx.proxy.defaultFilters = lib.mkOption {
+    type = lib.types.attrs;
+    default = {
+      setParams = {
+        frequency_penalty = 0.3;
+        presence_penalty = 0.3;
+      };
+    };
+    description = ''
+      llama-swap filters merged into every model in the generated config.
+      The default enables modest OpenAI-spec frequency/presence penalties to
+      prevent token-repetition loops on every request, including from clients
+      that explicitly send greedy-decoding parameters (the filter overrides
+      them). Set to {} to disable entirely; per-model overrides are supported
+      via programs.mlx.models.<name>.filters.
+    '';
+    example = lib.literalExpression ''
+      {
+        setParams = {
+          frequency_penalty = 0.5;
+          presence_penalty = 0.3;
+          top_p = 0.95;
+        };
+        stripParams = "temperature";
+      }
+    '';
+  };
+}

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -38,6 +38,16 @@
               default = [ ];
               description = "Alternative model names that route to this model";
             };
+            filters = lib.mkOption {
+              type = lib.types.attrs;
+              default = { };
+              description = ''
+                Per-model llama-swap filters. Merged on top of
+                programs.mlx.proxy.defaultFilters, so this model entry can
+                tighten, loosen, or fully replace the global filter.
+                See modules/mlx/options-filters.nix for the schema.
+              '';
+            };
           };
         }
       );


### PR DESCRIPTION
## Summary

Prevent MLX token-repetition loops at the proxy layer using llama-swap's documented `filters.setParams` enforcement. Applies to every caller, every prompt, every registered model — no caller can bypass it. Pure llama-swap configuration; no custom middleware, no upstream patches.

## Why

On 2026-05-18 the local MLX commitment-scanner hit a token-repetition loop on a Quest meeting transcript and had to be killed manually. The downstream skill stalled until the request was force-terminated.

Investigation:

- `vllm-mlx` 0.2.9 does **not** expose `--no_repeat_ngram_size` or a `--default-repetition-penalty` flag (verified against `vllm-mlx serve --help`). The Apple-MLX-backed server is a separate implementation from upstream vLLM and exposes no structural n-gram blocking knob.
- The community-standard fix for this exact failure mode in a stack with a proxy in front of the inference server is llama-swap's built-in **per-model request filters**:
  - `filters.setParams` — "a dictionary of parameters to **set/override in requests**" (enforcement, not default-filling)
  - `filters.stripParams` — comma-separated parameters to drop from requests
- These run before requests reach vllm-mlx and apply universally.

## Changes

| File | Change |
| --- | --- |
| `modules/mlx/options-filters.nix` (new) | `programs.mlx.proxy.defaultFilters` option. Default: `{ setParams = { frequency_penalty = 0.3; presence_penalty = 0.3; }; }` |
| `modules/mlx/options-batching.nix` | Adds `programs.mlx.maxRequestTokens` (scaffolding only — defaults to `null` to preserve the 32k server ceiling for legitimate expensive calls) |
| `modules/mlx/options-runtime.nix` | Adds `filters` submodule field to `programs.mlx.models.<name>` for per-model overrides that **recursive-merge** on top of `defaultFilters` |
| `modules/mlx/default.nix` | Imports `options-filters.nix`; wires `--max-request-tokens` into `mkVllmCmd`; injects `filters` attr into every `registryModels` and `additionalModels` entry; preserves the new `concurrencyLimit` field from #796 |

Why `frequency_penalty = 0.3` + `presence_penalty = 0.3`:

- Both are OpenAI-API canonical parameters (`0.0`–`2.0` range, `0.0` = off)
- `0.3` is the community-recognized "loop-prevention baseline" — strong enough to disrupt high-probability token cycles, light enough not to measurably degrade quality on normal prompts
- Additive penalties (vs. multiplicative `repetition_penalty`) preserve relative token probabilities better

Per-model overrides use `lib.recursiveUpdate` so `cfg.models.foo.filters.setParams.top_p = 0.95` keeps the global `frequency_penalty`/`presence_penalty` defaults rather than silently dropping them (caught and fixed in review).

## Sources

- [llama-swap configuration docs](https://github.com/mostlygeek/llama-swap/blob/main/docs/configuration.md) — `filters.setParams` / `filters.stripParams` reference
- [llama-swap config.example.yaml](https://github.com/mostlygeek/llama-swap/blob/main/config.example.yaml) — verbatim filter examples

## Test plan

- [x] `nix flake check` passes
- [x] `programs.mlx.proxy.defaultFilters` evaluates to `{"setParams":{"frequency_penalty":0.3,"presence_penalty":0.3}}` in isolation
- [x] `programs.mlx.maxRequestTokens` defaults to `null` (preserves 32k server ceiling)
- [x] Per-model `filters` recursive-merges with global defaults — verified: `lib.recursiveUpdate {setParams={frequency_penalty=0.3; presence_penalty=0.3;};} {setParams={top_p=0.95;};}` yields `{setParams={frequency_penalty=0.3; presence_penalty=0.3; top_p=0.95;};}` (preserves siblings)
- [x] Copilot review thread resolved (recursiveUpdate fix applied)
- [ ] After `darwin-rebuild switch`, verify `cat ~/.config/mlx/llama-swap.json | jq '.models | to_entries[0].value.filters'` shows the filter on every model entry
- [ ] Smoke test: send a request with `temperature: 0` + a repetition-prone prompt and confirm the response is bounded / diverse rather than degenerate
- [ ] Re-run the original failure path (commitment-scan against the Quest 5/18 transcript via the AI gateway) and confirm it completes within normal time bounds

## Known unrelated CI blocker

`Nix Validate / Validate` is failing on this PR due to a **pre-existing failure on `main`** (verified — same failure on `main` at sha `bd95646`): `pal-mcp-server` build fails because setuptools-scm 9.x now requires a `[tool.setuptools_scm]` section in `pyproject.toml` that the upstream Python package doesn't ship. The fix is one line in `modules/mcp/pal-package.nix` (drop `setuptools-scm` from `build-system` — `SETUPTOOLS_SCM_PRETEND_VERSION` already provides the version), but that's out of scope for this PR. Tracking separately.

## Out of scope

- Truly bulletproof n-gram-level prevention would require upstream vllm-mlx feature work or a Bifrost streaming detector. Token-penalty-based prevention is statistical, not structural — but combined with the now-available `maxRequestTokens` knob, the worst case shrinks to a bounded request rather than a hung pipeline.
- Per-model tuning: any model that still loops after this can be tightened in its own `cfg.models.<name>.filters.setParams.frequency_penalty` without touching the global default.
- The pal-mcp-server CI failure (separate concern, exists on main).