### PR TITLE
fix(cecli): refresh cecli_dev 0.99.12 source hash after upstream republish

### DIFF
--- a/modules/cecli/package.nix
+++ b/modules/cecli/package.nix
@@ -115,7 +115,7 @@ python3Packages.buildPythonApplication {
   src = fetchPypi {
     pname = "cecli_dev";
     inherit version;
-    hash = "sha256-27LzYHD2DQYd8TTv+MAOazz4UTUF9GAt9iSLzA4/HOs=";
+    hash = "sha256-d1PZ2qco87+yQJPfzTxEygH1TLjXN+bwgrwaqTu8tls=";
   };
 
   # nixpkgs-25.11 ships older versions of several deps than cecli's


### PR DESCRIPTION
## Summary

PyPI re-published `cecli_dev` 0.99.12 with different tarball content. The fixed-output `fetchPypi` derivation in `modules/cecli/package.nix` started failing with hash mismatch on every consumer (caught by nix-darwin#1115 macOS Build CI):

```
specified: sha256-27LzYHD2DQYd8TTv+MAOazz4UTUF9GAt9iSLzA4/HOs=
     got: sha256-d1PZ2qco87+yQJPfzTxEygH1TLjXN+bwgrwaqTu8tls=
```

Adopt the new hash. No version change, no behavior change — just rematch the fixed-output derivation to what PyPI is actually serving today.

## Why this happens

Renovate's nix manager bumps version strings but cannot update adjacent `hash = "sha256-..."` fields. There is a `Fix Renovate hash updates` workflow for that, but it only fires on `chore/renovate/**` branches — not for upstream-side republishes of the same version. So this is the manual escape hatch for an in-place tarball swap.

## Test plan

- [x] `nix flake check` will validate the new hash by re-running the cecli derivation
- [ ] After merge, nix-darwin#1115 picks up the new nix-ai SHA and macOS Build succeeds