### PR TITLE
fix(automation): restore Mon+Thu lockFileMaintenance, fix renovate branch listener, drop dead palMcpServer pin

### DIFF
--- a/.github/workflows/fix-renovate-hashes.yml
+++ b/.github/workflows/fix-renovate-hashes.yml
@@ -12,7 +12,7 @@ name: Fix Renovate hash updates
 on:
   push:
     branches:
-      - "chore/renovate/**"
+      - "renovate/**"
 
 jobs:
   fix-hashes:

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -59,8 +59,10 @@
   # MCP servers (pypi)
   # renovate: datasource=pypi depName=mcp-server-time
   mcpServerTime = "2026.1.26";
-  # renovate: datasource=pypi depName=pal-mcp-server
-  palMcpServer = "9.8.2";
+  # pal-mcp-server lives on GitHub (not PyPI). Version is derived from the
+  # flake input's pyproject.toml at build time in modules/mcp/pal-package.nix
+  # so the version label and the source rev stay locked together — see
+  # nix-ai#801 for the duplicate-source-of-truth issue this replaces.
   # renovate: datasource=pypi depName=fabric-mcp
   fabricMcp = "1.2.1";
   # renovate: datasource=pypi depName=google-workspace-mcp

--- a/modules/mcp/pal-package.nix
+++ b/modules/mcp/pal-package.nix
@@ -19,8 +19,9 @@ let
   # `# renovate: datasource=pypi depName=pal-mcp-server` annotation — pal-mcp-server
   # is not published on PyPI, so Renovate's lookup permanently failed and the
   # constant rotted out of sync with the input. See nix-ai#801.
-  version =
-    (builtins.fromTOML (builtins.readFile "${pal-mcp-server}/pyproject.toml")).project.version;
+  inherit ((builtins.fromTOML (builtins.readFile "${pal-mcp-server}/pyproject.toml")).project)
+    version
+    ;
 in
 python3Packages.buildPythonApplication {
   pname = "pal-mcp-server";

--- a/modules/mcp/pal-package.nix
+++ b/modules/mcp/pal-package.nix
@@ -19,7 +19,8 @@ let
   # `# renovate: datasource=pypi depName=pal-mcp-server` annotation — pal-mcp-server
   # is not published on PyPI, so Renovate's lookup permanently failed and the
   # constant rotted out of sync with the input. See nix-ai#801.
-  version = (builtins.fromTOML (builtins.readFile "${pal-mcp-server}/pyproject.toml")).project.version;
+  version =
+    (builtins.fromTOML (builtins.readFile "${pal-mcp-server}/pyproject.toml")).project.version;
 in
 python3Packages.buildPythonApplication {
   pname = "pal-mcp-server";

--- a/modules/mcp/pal-package.nix
+++ b/modules/mcp/pal-package.nix
@@ -13,7 +13,13 @@
 { python3Packages, pal-mcp-server }:
 
 let
-  version = (import ../../lib/versions.nix).palMcpServer;
+  # Read the version directly from the flake input's pyproject.toml so the
+  # version label and the source rev never drift. This replaces a separate
+  # `palMcpServer = "..."` constant in lib/versions.nix that had a broken
+  # `# renovate: datasource=pypi depName=pal-mcp-server` annotation — pal-mcp-server
+  # is not published on PyPI, so Renovate's lookup permanently failed and the
+  # constant rotted out of sync with the input. See nix-ai#801.
+  version = (builtins.fromTOML (builtins.readFile "${pal-mcp-server}/pyproject.toml")).project.version;
 in
 python3Packages.buildPythonApplication {
   pname = "pal-mcp-server";

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,10 +7,6 @@
   "nix": {
     "enabled": true,
   },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 7am on Monday"],
-  },
   "packageRules": [
     {
       "description": "Group MLX Python packages into a single PR",


### PR DESCRIPTION
## Summary

Three independent automation fixes that together explain the 51-version llama-swap drift in #801. Each commit is self-contained.

- **drop lockFileMaintenance schedule override** — local `"before 7am on Monday"` was narrower than org preset's `Mon+Thu`. Renovate missed the Mon 2026-05-18 cutoff (run landed at 07:53 Chicago), so 4 queued items got punted a full week.
- **listen on `renovate/**`** — Renovate's actual default prefix is `renovate/`, not `chore/renovate/`. The hash-fix workflow has had zero runs since being created.
- **derive pal-mcp-server version from flake input** — `palMcpServer = "9.8.2"` had a Renovate annotation that permanently failed PyPI lookup (BeehiveInnovations/pal-mcp-server isn't on PyPI). Reading `project.version` from the flake input's pyproject.toml locks the label to the source rev.
- **style: format pal-package.nix per treefmt** — the multi-line `fromTOML / readFile` chain exceeds nixfmt's column budget.

## CI status

**Nix Validate**: was failing on the formatting check after the initial 3 commits — fixed by the `style:` commit.

**OSV Scan**: failing on a brand-new GHSA published 14:34 UTC today (`CVE-2026-45409` / `GHSA-65pc-fj4g-8rjx`, idna 3.14 → 3.15). The vuln is in `mlx-server/uv.lock` and `orchestrator/uv.lock`, both pre-existing on main — **not introduced by this PR**.

Dashboard #94 nudged: 4 Renovate PRs (#803/#804/#805/#806) created from the awaiting-schedule queue. But:

- #804 fixes idna in `mlx-server/uv.lock` only; OSV still sees the unfixed copy in `orchestrator/uv.lock`.
- #805 fixes idna in `orchestrator/uv.lock` only; OSV still sees the unfixed copy in `mlx-server/uv.lock`.
- Result: **mutual block** — each PR's OSV scan reports the vuln from the OTHER PR's untouched file.

The org preset has `vulnerabilityAlerts.automerge: true` with `osvVulnerabilityAlerts: true`, so Renovate SHOULD detect CVE-2026-45409 and create a unified security PR that fixes both uv.lock files. As of writing, the dashboard still says "Renovate has not found any CVEs on osv.dev" — vuln-scan hasn't propagated yet.

## What this does NOT do

- No version pin bumps (mlx 0.31.1, mlx-lm 0.31.2, browser-use 0.12.6 all stay).
- No `# renovate:` annotation added for `llama-swap` — it correctly flows from nixpkgs once the schedule fires.
- No manual idna bump — per #801's directive, the deadlock is for Renovate's vuln-scan + auto-merge to resolve.

## Test plan

- [x] `nix flake check` passes locally
- [x] `nix eval --raw .#pal-mcp-server.version` still returns `9.8.2`
- [x] `renovate-config-validator renovate.json5` reports success
- [x] `nix fmt` produces no changes
- [ ] After Renovate vuln-scan or admin force-merge of #804+#805: rebase this PR; OSV passes
- [ ] After merge: confirm `chore(deps): lock file maintenance` PR appears on Thu 2026-05-21
- [ ] After merge: confirm `Fix Renovate hash updates` workflow runs on the next `renovate/...` branch
- [ ] After merge: confirm pal-mcp-server warning disappears from dashboard #94

Refs: #801
