### PR TITLE
feat(mlx): pull llama-swap from nixpkgs-unstable (surgical overlay)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,6 +326,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "obsidian-skills": {
       "flake": false,
       "locked": {
@@ -396,6 +412,7 @@
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "lunar-claude": "lunar-claude",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "obsidian-skills": "obsidian-skills",
         "openai-codex": "openai-codex",
         "pal-mcp-server": "pal-mcp-server",

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    # Second nixpkgs only for llama-swap: 25.11-darwin froze it at v165 on
+    # 2025-09-22 with no backports. See nix-ai#801.
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     home-manager = {
       url = "github:nix-community/home-manager/release-25.11";
@@ -135,6 +138,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       home-manager,
       claude-code-plugins,
       claude-cookbooks,
@@ -204,6 +208,7 @@
           claude-cookbooks
           pal-mcp-server
           fabric-src
+          nixpkgs-unstable
           ;
       };
 

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -5,6 +5,7 @@
   claude-cookbooks,
   pal-mcp-server,
   fabric-src,
+  nixpkgs-unstable,
 }:
 {
   default = {
@@ -17,6 +18,7 @@
         claude-cookbooks
         pal-mcp-server
         fabric-src
+        nixpkgs-unstable
         ;
     };
   };

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  nixpkgs-unstable,
   ...
 }:
 #
@@ -61,7 +62,9 @@ let
   '';
 
   # llama-swap proxy package — sits on the API port, manages vllm-mlx child processes.
-  llamaSwapPkg = pkgs.llama-swap;
+  # Sourced from nixpkgs-unstable: 25.11-darwin froze it at v165 on 2025-09-22
+  # with no backports while unstable kept moving (currently v211). See nix-ai#801.
+  llamaSwapPkg = nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system}.llama-swap;
 
   apiUrl = "http://${cfg.host}:${toString cfg.port}/v1";
   launchAgentLabel = "dev.vllm-mlx.server";


### PR DESCRIPTION
## Summary

Pull `llama-swap` from `nixpkgs-unstable` while keeping the main `nixpkgs` input on `nixpkgs-25.11-darwin`. Closes #801.

## Why

`nixpkgs-25.11-darwin` froze `llama-swap` at v165 on 2025-09-22 with no backports:

| Date | Bump | Channel |
|---|---|---|
| 2025-09-22 | 156 → 165 | both (last touch on 25.11-darwin) |
| 2026-03-22 | 183 → 199 | unstable only |
| 2026-04-20 | 199 → 204 | unstable only |
| 2026-05-04 | 204 → 211 | unstable only |

The WaitGroup race documented in #801 reproduces against v165. Waiting for 25.11-darwin to backport is unbounded — 8 months of upstream releases haven't crossed.

## Approach (surgical overlay, not full channel switch)

A previous attempt at this PR swapped the entire `nixpkgs` input to unstable. That worked for llama-swap but home-manager `master` introduced stricter module type checks that surfaced a pre-existing `programs.codex.skills` definition conflict, and the broader unstable→25.11-darwin lift kept tripping evaluator differences in lib/checks/*. Reverted to a narrower approach:

- Add `nixpkgs-unstable` as a second flake input.
- Pass it through `homeManagerModules.default._module.args` to `modules/mlx/default.nix`.
- Resolve **only** `llamaSwapPkg` from it: `nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system}.llama-swap`.
- Everything else stays on 25.11-darwin: cecli's transitive Python deps, fabric, home-manager, the intentional `mlx 0.31.1` / `mlx-lm 0.31.2` PyPI pins from #751 / #762.

Renovate will track both `nixpkgs` and `nixpkgs-unstable` lock entries on the Mon+Thu cadence we just restored.

## Test plan

- [x] `nix flake check` passes locally on aarch64-darwin
- [x] `nix fmt` clean, `statix` clean
- [x] `nix eval` against the new `nixpkgs-unstable` input returns `llama-swap.version = "211"`
- [x] `flake.nix` 11889 bytes (under the 12KB file-size budget)
- [ ] CI Nix Validate passes on x86_64-linux
- [ ] After merge: `darwin-rebuild switch` deploys llama-swap v211; #801 race ceases to reproduce

## Trade-offs accepted

- Two `nixpkgs` lock entries to manage. Renovate handles both.
- A consumer that imports this flake's `homeManagerModule` and overrides `nixpkgs-unstable.follows` would force their unstable choice on our llama-swap. Documented in the module's CLAUDE.md if relevant.

Refs: #801
