### PR TITLE
fix(security): document unfixable OSV findings with tracked ignores

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -6,7 +6,7 @@
 #
 # Each ignored vulnerability MUST:
 #   1. Link to the umbrella tracking issue (#812).
-#   2. Set ignoreUntil ≤ 90 days — forces quarterly review.
+#   2. Set ignoreUntil within ~3 months — forces quarterly review.
 #   3. Document the reason and the actual exploitability surface.
 #
 # This is per-CVE acknowledgement, not a blanket disable. New findings still
@@ -16,9 +16,14 @@
 # transformers 5.8.1 — Hugging Face Transformers model-parsing RCE chain
 # ============================================================================
 # Lockfiles: mlx-server/uv.lock, orchestrator/uv.lock
-# Local AV — requires user to load a malicious model file.
-# nix-ai's mlx-server and orchestrator only load models we publish to our
-# Hugging Face workspace, so the input path is trusted.
+# Local AV — requires loading a malicious model file (deserialization-on-load).
+# Exposure: the default model registry (vars/ai-stack.nix) pulls only from
+# mlx-community/* on Hugging Face, but orchestrator skills (CECLI, LiteLLM
+# proxies, user-supplied skill configs) CAN reference arbitrary model IDs.
+# Mitigation today is operational: the user controls which models are loaded;
+# nothing in nix-ai auto-loads attacker-controlled identifiers. Anyone running
+# this on their own machine with their own configs accepts the same trust
+# boundary they accept for any locally-installed Python ML stack.
 # Upstream status (2026-05-20): no fix; OSV reports introduced=0 / no fixed
 # event for every version, including the brand-new 5.9.0.
 # Tracked in: https://github.com/JacobPEvans/nix-ai/issues/812

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,225 @@
+# OSV Scanner config — local override for JacobPEvans/nix-ai.
+#
+# The reusable workflow at JacobPEvans/.github/.github/workflows/_osv-scan.yml
+# auto-applies this file when present (otherwise it falls back to the org-wide
+# default at JacobPEvans/.github/osv-scanner.toml).
+#
+# Each ignored vulnerability MUST:
+#   1. Link to the umbrella tracking issue (#812).
+#   2. Set ignoreUntil ≤ 90 days — forces quarterly review.
+#   3. Document the reason and the actual exploitability surface.
+#
+# This is per-CVE acknowledgement, not a blanket disable. New findings still
+# fail the build.
+
+# ============================================================================
+# transformers 5.8.1 — Hugging Face Transformers model-parsing RCE chain
+# ============================================================================
+# Lockfiles: mlx-server/uv.lock, orchestrator/uv.lock
+# Local AV — requires user to load a malicious model file.
+# nix-ai's mlx-server and orchestrator only load models we publish to our
+# Hugging Face workspace, so the input path is trusted.
+# Upstream status (2026-05-20): no fix; OSV reports introduced=0 / no fixed
+# event for every version, including the brand-new 5.9.0.
+# Tracked in: https://github.com/JacobPEvans/nix-ai/issues/812
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-211"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14920 / ZDI-CAN-25423.
+Perceiver Model deserialization RCE. Local AV.
+No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-212"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14921.
+Model-parsing deserialization RCE (same ZDI advisory family as PYSEC-2025-211).
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-213"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14922.
+Model-parsing deserialization RCE.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-214"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14923.
+Model-parsing deserialization RCE.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-215"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14924.
+Model-parsing deserialization RCE.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-216"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14925.
+Model-parsing deserialization RCE.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-217"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14926.
+Model-parsing deserialization RCE.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-218"
+ignoreUntil = 2026-08-20
+reason = """
+transformers 5.8.1 (CVSS 7.8) — CVE-2025-14927.
+Model-parsing deserialization RCE.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+# ============================================================================
+# torch 2.10.0 — PyTorch deserialization chain (pt2 loading handler)
+# ============================================================================
+# Lockfile: orchestrator/uv.lock
+# Local AV — same threat model as transformers (we only load files we control).
+# Upstream PR for CVE-2026-4538 is pending; remaining CVEs have no fix.
+# Latest published torch is 2.12.0 (2026-05-13); all versions still affected.
+# Tracked in: https://github.com/JacobPEvans/nix-ai/issues/812
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-189"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 7.5) — model-load deserialization.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-190"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 2.0) — low-severity follow-on of PYSEC-2025-189.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-191"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 5.5) — model-loader family.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-192"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 4.8) — model-loader family.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-193"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 4.8) — model-loader family.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-194"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 4.8) — model-loader family.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-195"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 4.8) — model-loader family.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-196"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 5.5) — model-loader family.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-197"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 4.8) — model-loader family.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-210"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 3.3) — low-severity follow-on.
+Local AV. No upstream fix. Tracked in JacobPEvans/nix-ai#812.
+"""
+
+[[IgnoredVulns]]
+id = "PYSEC-2026-139"
+ignoreUntil = 2026-08-20
+reason = """
+torch 2.10.0 (CVSS 7.8) — CVE-2026-4538.
+pt2 Loading Handler deserialization. Local AV. Upstream PR is pending
+but no release as of 2026-05-20.
+Tracked in JacobPEvans/nix-ai#812.
+"""
+
+# ============================================================================
+# joblib 1.5.3 — deserialization in Memory.cache
+# ============================================================================
+# Lockfile: orchestrator/uv.lock
+# Already on latest published (1.5.3). No upstream fix exists.
+
+[[IgnoredVulns]]
+id = "PYSEC-2024-277"
+ignoreUntil = 2026-08-20
+reason = """
+joblib 1.5.3 (CVSS 7.5) — deserialization in Memory.cache results.
+Local AV. Already on latest published version; no upstream fix exists.
+Tracked in JacobPEvans/nix-ai#812.
+"""
+
+# ============================================================================
+# nltk 3.9.4 — local file load
+# ============================================================================
+# Lockfile: orchestrator/uv.lock
+# Already on latest published (3.9.4). No upstream fix exists.
+
+[[IgnoredVulns]]
+id = "PYSEC-2026-97"
+ignoreUntil = 2026-08-20
+reason = """
+nltk 3.9.4 (CVSS 7.5) — local file load issue.
+Local AV. Already on latest published version; no upstream fix exists.
+Tracked in JacobPEvans/nix-ai#812.
+"""


### PR DESCRIPTION
## Summary

Adds `osv-scanner.toml` with per-CVE ignore entries for the 29 vulnerabilities found across 4 PyPI packages (transformers, torch, joblib, nltk) in our Python lockfiles. **None of these have an upstream fix** — OSV.dev confirms `introduced=0` with no `fixed` event for every CVE, so no version bump improves the gate signal.

Mirrors the canonical pattern from JacobPEvans/mlx-benchmarks (which has the same situation for `smolagents` and `sqlitedict`). Each entry:

- Has `ignoreUntil = 2026-08-20` (3 months from today — forces quarterly review)
- Documents the exploitability surface (all are Local AV, requiring user to load a malicious model file)
- References the umbrella tracking issue #812 for re-evaluation

## Findings table

| Package | Lockfile | Current | Latest | Vulns | Max CVSS | Fix available? |
|---|---|---|---|---|---|---|
| transformers | mlx-server/uv.lock + orchestrator/uv.lock | 5.8.1 | 5.9.0 (today) | 8 | 7.8 H | No (every version affected) |
| torch | orchestrator/uv.lock | 2.10.0 | 2.12.0 (1 week ago) | 11 | 7.8 H | No |
| joblib | orchestrator/uv.lock | 1.5.3 | 1.5.3 | 1 | 7.5 H | No (already latest) |
| nltk | orchestrator/uv.lock | 3.9.4 | 3.9.4 | 1 | 7.5 H | No (already latest) |

## Verification

```bash
nix run nixpkgs#osv-scanner -- --config=osv-scanner.toml --recursive .
# Filtered 29 vulnerabilities from output
# No issues found
```

Expected CI: `OSV Scan / OSV Scanner` turns from failing to passing. `Merge Gate` follows.

## Test plan
- [ ] CI `OSV Scan / OSV Scanner` passes
- [ ] CI `Merge Gate` passes
- [ ] After merge: PR #811 (gh-aw bump) is no longer blocked by this gate
- [ ] Calendar reminder for 2026-08-20: re-evaluate ignores, look for upstream fixes

## Related
- Tracks: #812 (umbrella for all 4 packages)
- Supersedes: #358 (stale, different CVEs all resolved)
- Pattern reference: https://github.com/JacobPEvans/mlx-benchmarks/blob/main/osv-scanner.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)