### PR TITLE
feat(mcp): add apple-events server for Reminders and Calendar

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -55,6 +55,8 @@
   mcpPuppeteer = "2025.5.12";
   # renovate: datasource=npm depName=@modelcontextprotocol/server-slack
   mcpSlack = "2025.4.25";
+  # renovate: datasource=npm depName=mcp-server-apple-events
+  mcpAppleEvents = "1.4.0";
 
   # MCP servers (pypi)
   # renovate: datasource=pypi depName=mcp-server-time

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -30,8 +30,8 @@ let
   mcpGoogleMapsVersion = versions.mcpGoogleMaps;
   mcpPuppeteerVersion = versions.mcpPuppeteer;
   mcpSlackVersion = versions.mcpSlack;
-  mcpServerTimeVersion = versions.mcpServerTime;
   mcpAppleEventsVersion = versions.mcpAppleEvents;
+  mcpServerTimeVersion = versions.mcpServerTime;
   hfMcpServerVersion = versions.hfMcpServer;
   fabricMcpVersion = versions.fabricMcp;
   gwsMcpVersion = versions.gwsMcp;

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -31,6 +31,7 @@ let
   mcpPuppeteerVersion = versions.mcpPuppeteer;
   mcpSlackVersion = versions.mcpSlack;
   mcpServerTimeVersion = versions.mcpServerTime;
+  mcpAppleEventsVersion = versions.mcpAppleEvents;
   hfMcpServerVersion = versions.hfMcpServer;
   fabricMcpVersion = versions.fabricMcp;
   gwsMcpVersion = versions.gwsMcp;
@@ -145,6 +146,13 @@ in
     command = "codex";
     args = [ "mcp-server" ];
   };
+
+  # ================================================================
+  # Apple Events - native macOS Reminders + Calendar via EventKit
+  # ================================================================
+  # Source: https://github.com/FradSer/mcp-server-apple-events
+  # First call triggers macOS TCC prompts for Reminders + Calendar.
+  apple-events = bunx [ "mcp-server-apple-events@${mcpAppleEventsVersion}" ];
 
   # ================================================================
   # Database (disabled by default)


### PR DESCRIPTION
## Summary

- Adds [`mcp-server-apple-events`](https://github.com/FradSer/mcp-server-apple-events) (npm `mcp-server-apple-events@1.4.0`) to the shared MCP catalog
- Single catalog entry auto-wires the server into Claude, Codex, and Gemini via `programs.aiMcp.servers`
- No secrets or env vars; macOS surfaces a one-time TCC prompt for Reminders + Calendar on first call

## Why this server

The most popular **actively-maintained** option that covers both Reminders and Calendar in one server: 116 stars, 16 releases, last push 2026-05-20, MIT-licensed TypeScript using native EventKit.

| Repo | Stars | Status | Reason rejected |
| --- | --- | --- | --- |
| `supermemoryai/apple-mcp` | 3095 | **Archived** 2025-08 | Top forks stalled too. |
| `dbmcco/apple-reminders-mcp` | 22 | Active | Reminders only. |
| `EgorKurito/apple-calendar-mcp` | 4 | Active | Calendar only. |
| `snarris/apple-eventkit-mcp` | 3 | Active | Tiny audience, no releases. |

## Changes

- `lib/versions.nix` — adds Renovate-tracked pin `mcpAppleEvents = "1.4.0"`
- `modules/mcp/catalog.nix` — adds `apple-events = bunx [ "mcp-server-apple-events@${mcpAppleEventsVersion}" ]` with let-binding grouped alongside other npm pins per review feedback

## Test plan

- [x] `nix fmt` — 0 files changed
- [x] `nix flake check` — passes; pre-existing `--all-systems` darwin/linux cross-arch warnings unrelated
- [x] `nix eval ./modules/mcp/catalog.nix#apple-events` → `{"command":"bunx","args":["mcp-server-apple-events@1.4.0"]}`
- [x] Module evaluation: `homeManagerModules.default` returns ok
- [ ] After merge: `darwin-rebuild switch`, restart Claude/Codex/Gemini, confirm `apple-events` appears in `claude mcp list`
- [ ] After merge: smoke-test "list my apple reminders" and "what's on my calendar tomorrow" — grant TCC prompts on first call

Assisted-by: Claude <noreply@anthropic.com>