### PR TITLE
feat(agent-skills): add karpathy-skills + auto-discover all marketplaces

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -294,6 +294,22 @@
         "type": "github"
       }
     },
+    "karpathy-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776679504,
+        "narHash": "sha256-4z/wRdYH7UXRzF8RJU0sw8xbpx0BW/7CBv5sVEC2knY=",
+        "owner": "forrestchang",
+        "repo": "andrej-karpathy-skills",
+        "rev": "2c606141936f1eeef17fa3043a72095b4765b9c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "forrestchang",
+        "repo": "andrej-karpathy-skills",
+        "type": "github"
+      }
+    },
     "lunar-claude": {
       "flake": false,
       "locked": {
@@ -394,6 +410,7 @@
         "home-manager": "home-manager",
         "huggingface-skills": "huggingface-skills",
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
+        "karpathy-skills": "karpathy-skills",
         "lunar-claude": "lunar-claude",
         "nixpkgs": "nixpkgs",
         "obsidian-skills": "obsidian-skills",

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,12 @@
       flake = false;
     };
 
+    # Behavioral / Workflow guidelines derived from Andrej Karpathy's observations
+    karpathy-skills = {
+      url = "github:forrestchang/andrej-karpathy-skills";
+      flake = false;
+    };
+
     # Skill-only repos (no marketplace structure — wrapped via synthetic derivation)
     browser-use-skills = {
       url = "github:browser-use/browser-use";
@@ -153,6 +159,7 @@
       visual-explainer-marketplace,
       wakatime,
       huggingface-skills,
+      karpathy-skills,
       browser-use-skills,
       vct-cribl-pack-validator-skills,
       pal-mcp-server,
@@ -173,6 +180,7 @@
           bitwarden-marketplace
           browser-use-skills
           huggingface-skills
+          karpathy-skills
           vct-cribl-pack-validator-skills
           cc-dev-tools
           cc-marketplace

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -145,8 +145,13 @@ let
   # that namespace their plugins under those subdirs — a common convention among
   # Claude marketplaces, expressed here generically without naming any specific input.
   # lib.optionals is used instead of if/then/else to keep this pure-Nix (not shell).
+  # rootDir lookup short-circuits when input is not a directory and verifies each
+  # subpath is itself a directory before recursing — readDir on a regular file throws.
   walkAllPatterns =
     input:
+    let
+      rootDir = if builtins.pathExists input then builtins.readDir input else { };
+    in
     discoverFlatSkills input
     ++ discoverDotClaudeSkills input
     ++ discoverSkills input
@@ -154,7 +159,7 @@ let
       lib.concatMap
         (
           sub:
-          lib.optionals (builtins.pathExists "${input}/${sub}") (
+          lib.optionals ((rootDir.${sub} or "") == "directory") (
             discoverSkills "${input}/${sub}" ++ discoverClaudeCommands "${input}/${sub}"
           )
         )

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -139,18 +139,36 @@ let
       source = "${skillsPath}/${name}/SKILL.md";
     }) (lib.filterAttrs (name: _: builtins.pathExists "${skillsPath}/${name}/SKILL.md") skillDirs);
 
-  # Skills from JacobPEvans/claude-code-plugins (tool-agnostic markdown)
-  # Plus VisiCore cribl-pack-validator (bare .claude/skills/ layout)
-  # Plus Hugging Face Hub skills (flat skills/<n>/SKILL.md layout)
-  # Plus official Claude plugin skills and translated commands
-  sharedSkills =
-    discoverSkills marketplaceInputs.jacobpevans-cc-plugins
-    ++ discoverDotClaudeSkills marketplaceInputs.vct-cribl-pack-validator-skills
-    ++ discoverFlatSkills marketplaceInputs.huggingface-skills
-    ++ discoverSkills "${marketplaceInputs.claude-plugins-official}/plugins"
-    ++ discoverSkills "${marketplaceInputs.claude-plugins-official}/external_plugins"
-    ++ discoverClaudeCommands "${marketplaceInputs.claude-plugins-official}/plugins"
-    ++ discoverClaudeCommands "${marketplaceInputs.claude-plugins-official}/external_plugins";
+  # Applies all known SKILL.md discovery patterns to one input path.
+  # Each pattern short-circuits (via pathExists) when the layout is absent.
+  # The one-level subpath walk ("plugins", "external_plugins") handles inputs
+  # that namespace their plugins under those subdirs — a common convention among
+  # Claude marketplaces, expressed here generically without naming any specific input.
+  # lib.optionals is used instead of if/then/else to keep this pure-Nix (not shell).
+  walkAllPatterns =
+    input:
+    discoverFlatSkills input
+    ++ discoverDotClaudeSkills input
+    ++ discoverSkills input
+    ++
+      lib.concatMap
+        (
+          sub:
+          lib.optionals (builtins.pathExists "${input}/${sub}") (
+            discoverSkills "${input}/${sub}" ++ discoverClaudeCommands "${input}/${sub}"
+          )
+        )
+        [
+          "plugins"
+          "external_plugins"
+        ];
+
+  # Auto-discovers skills from every input this module receives, by trying all
+  # known SKILL.md layouts. No marketplace names are hardcoded here — the module
+  # is decoupled from Claude's registry and operates on a generic set of input
+  # paths supplied by the consumer flake. When this module is split into its own
+  # flake, the consumer decides which inputs to pass; the walker stays unchanged.
+  sharedSkills = lib.concatMap walkAllPatterns (lib.attrValues marketplaceInputs);
 in
 {
   imports = [

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -14,6 +14,7 @@
 #   - cc-dev-tools (Lucklyric/cc-dev-tools, 29★)            — community Codex/Gemini wrappers
 #   - fabric-patterns (danielmiessler/fabric, 41428★ upstream, synthetic)
 #   - huggingface-skills (huggingface/skills, 10371★)       — HF Hub ops
+#   - karpathy-skills (forrestchang/andrej-karpathy-skills, 113639★) — behavioral guidelines
 #   - obsidian-skills (kepano/obsidian-skills, 28277★)
 #   - axton-obsidian-visual-skills (axtonliu/..., 2651★)
 #   - visual-explainer-marketplace (nicobailon/..., 7816★)
@@ -83,6 +84,15 @@ _:
     # Kept for hf CLI Hub operations (download/upload models, manage repos) —
     # user actively does HF model ops in nix-ai (MLX work).
     "hf-cli@huggingface-skills" = true;
+
+    # ========================================================================
+    # karpathy-skills — forrestchang/andrej-karpathy-skills (113639★)
+    # ========================================================================
+    # Single skill: karpathy-guidelines. Behavioral rules for LLM coding:
+    # Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution.
+    # Complements Tier 1 code-review; focuses on pre-coding discipline rather than review.
+    # Also flows to ~/.agents/skills/ automatically via agent-skills auto-discovery.
+    "andrej-karpathy-skills@karpathy-skills" = true;
 
     # ========================================================================
     # obsidian-skills + axton-obsidian-visual-skills + visual-explainer

--- a/modules/claude/plugins/marketplaces.nix
+++ b/modules/claude/plugins/marketplaces.nix
@@ -118,6 +118,16 @@ let
       };
     };
 
+    # --- Behavioral / Workflow ---
+    # Behavioral guidelines for reducing common LLM coding mistakes (Think Before
+    # Coding, Simplicity First, Surgical Changes, Goal-Driven Execution).
+    "karpathy-skills" = {
+      source = {
+        type = "github";
+        url = "forrestchang/andrej-karpathy-skills";
+      };
+    };
+
     # --- Community ---
     "cc-marketplace" = {
       source = {


### PR DESCRIPTION
Restoring abandoned 17-day-old local branch.

## Commits
```
44866a7 feat(agent-skills): add karpathy-skills + auto-discover all marketplaces
```

## Summary
Adds forrestchang/andrej-karpathy-skills (113k stars) to both the Claude marketplace and the tool-agnostic agent-skills tree.

- Claude: andrej-karpathy-skills@karpathy-skills enabled in Tier 5 (behavioral/workflow).
- Agent-skills: refactored from hardcoded 5-marketplace list to auto-discovery via walkAllPatterns.

Opened as draft for review. Re-baseline against main before promoting.

Assisted-by: Claude <noreply@anthropic.com>