### PR TITLE
fix(ci-gate): sync pip-audit ignore-vulns with osv-scanner.toml

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -133,6 +133,9 @@ jobs:
     uses: JacobPEvans/.github/.github/workflows/_python-security.yml@main
     with:
       python-dirs: 'mlx-server orchestrator'
+      # PYSEC-2026-139: torch 2.10.0 deserialization (no upstream fix yet,
+      # local-only attack vector). Remove once PyTorch releases a fix.
+      ignore-vulns: 'PYSEC-2026-139'
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   osv-scan:

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -133,9 +133,20 @@ jobs:
     uses: JacobPEvans/.github/.github/workflows/_python-security.yml@main
     with:
       python-dirs: 'mlx-server orchestrator'
-      # PYSEC-2026-139: torch 2.10.0 deserialization (no upstream fix yet,
-      # local-only attack vector). Remove once PyTorch releases a fix.
-      ignore-vulns: 'PYSEC-2026-139'
+      # MUST mirror osv-scanner.toml `[[IgnoredVulns]]`. Each ID is documented
+      # there (rationale, tracking issue #812, `ignoreUntil` review date).
+      # New advisories must be added to BOTH files in lockstep.
+      #   PYSEC-2025-211..218 — transformers 5.8.1 deserialization chain.
+      #   PYSEC-2025-189..197, 210, PYSEC-2026-139 — torch 2.10.0 chain.
+      #   PYSEC-2024-277 — joblib 1.5.3 Memory.cache deserialization.
+      #   PYSEC-2026-97  — nltk 3.9.4 local file load.
+      ignore-vulns: >-
+        PYSEC-2024-277 PYSEC-2025-189 PYSEC-2025-190 PYSEC-2025-191
+        PYSEC-2025-192 PYSEC-2025-193 PYSEC-2025-194 PYSEC-2025-195
+        PYSEC-2025-196 PYSEC-2025-197 PYSEC-2025-210 PYSEC-2025-211
+        PYSEC-2025-212 PYSEC-2025-213 PYSEC-2025-214 PYSEC-2025-215
+        PYSEC-2025-216 PYSEC-2025-217 PYSEC-2025-218 PYSEC-2026-97
+        PYSEC-2026-139
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   osv-scan:


### PR DESCRIPTION
## Summary

Mirror all 21 `[[IgnoredVulns]]` entries from `osv-scanner.toml` into pip-audit's `ignore-vulns:` parameter so the two scanners share a single source of truth. Previously only `PYSEC-2026-139` was synced, so pip-audit re-blocked Renovate lock PRs whenever it surfaced the transformers / torch / joblib / nltk chains.

Currently blocking #820 and #818.

## Changes

Extend `ignore-vulns` to the full set documented in `osv-scanner.toml`:

- `PYSEC-2025-211..218` — transformers 5.8.1 deserialization chain
- `PYSEC-2025-189..197, 210, PYSEC-2026-139` — torch 2.10.0 chain
- `PYSEC-2024-277` — joblib 1.5.3 Memory.cache deserialization
- `PYSEC-2026-97` — nltk 3.9.4 local file load

Comment block in the workflow file ties the two files together — future advisories must be added to BOTH in lockstep.

## Test plan

- [x] Diff is comment + folded scalar (no logic change)
- [ ] CI passes on this PR (workflow change takes effect for the PR itself, so green pip-audit confirms wiring)
- [ ] After merge, retrigger #820 and #818 — both should clear the security gate

## Cleanup

Drop each ID from BOTH files once upstream ships a fix. Review quarterly via the `ignoreUntil` dates in `osv-scanner.toml`.

Related: #812, #818, #820