### PR TITLE
feat(mlx): add Galileo observability scaffolding with fail-closed design

### DIFF
--- a/docs/adr/0003-galileo-ai-observability.md
+++ b/docs/adr/0003-galileo-ai-observability.md
@@ -1,0 +1,87 @@
+# ADR 0003: Galileo AI Observability — Fail-Closed Homelab Integration
+
+**Status**: Accepted
+**Date**: 2026-05-22
+
+## Documents in This Directory
+
+_This ADR is part of [`docs/adr/`](README.md)._
+
+## Context
+
+Galileo (galileo.ai) is an AI observability platform with hallucination detection,
+Signals-based failure analysis, and chain-of-thought evals. The goal is to collect
+LLM inference traces from the local homelab stack (MLX inference + Bifrost gateway)
+in Galileo alongside the existing Cribl/Splunk pipeline.
+
+**Hard constraints:**
+
+1. The operator works at Cisco/Splunk. Daily prompts include Splunk product content,
+   internal engineering material, and client data. None of this may leave the local
+   network in trace payloads.
+2. Claude Code, Codex CLI, and Gemini CLI are not instrumented — only surfaces that
+   are already isolated from work content (local MLX inference and Bifrost's
+   cloud-model paths when explicitly opted in).
+3. The Splunk/Cribl pipeline must not regress. The Galileo branch is additive.
+
+## Decision
+
+**Scope:** MLX inference stack + Bifrost gateway only. All AI CLI tools excluded.
+
+**Default posture:** Fail-closed. No traces reach Galileo unless the operator:
+
+1. Runs `galileo-on` from an explicitly allowlisted working directory (shell function
+   in `nix-home`, not in this repo — see cross-repo dependencies below).
+2. The outbound request carries the `X-Trace-Sink: galileo` HTTP header (set by the
+   wrapper function).
+3. The OTEL Collector's routing connector passes it (drops anything without the header).
+4. The content denylist processor in the Galileo-bound pipeline finds no match.
+
+**Dual gate:** header-based routing gate AND content-based denylist. Both must pass.
+
+**Galileo tier:** SaaS Free ($0/mo, 5K traces/mo). Revisit if the trace count
+exceeds the cap after 48h of normal use — add tail-sampling before upgrading.
+
+**Secret injection:** `GALILEO_API_KEY` follows Pattern 3 (Kubernetes Doppler Operator)
+in `docs/architecture/secrets-and-injection.md` — the same pattern as Bifrost and
+Cribl. The key is injected into the OTEL Collector pod by the Doppler Operator in
+the OrbStack cluster. It never appears in this repo, the Nix store, or `~/.claude.json`.
+
+**No Galileo SDK:** Galileo accepts OTLP/HTTP at `https://api.galileo.ai/otel/traces`
+with API key + project + logstream in request headers. A dedicated OTLP exporter in
+the existing OTEL Collector is sufficient. No Python SDK, no agent-side library.
+
+## Consequences
+
+**Easier:**
+
+- Galileo evals (hallucination detection, Signals) work on real homelab inference traces
+  once the collector and Bifrost changes land in `orbstack-kubernetes`.
+- The `programs.mlx.telemetry.enable` option in this repo is the correct long-term hook
+  even before vllm-mlx 0.2.9 natively emits OTLP spans; future versions of the
+  MLX stack that add OTel support will inherit the LaunchAgent env vars automatically.
+- Kill switch is cheap: set `programs.mlx.telemetry.enable = false` (removes the
+  LaunchAgent env vars) or remove the `otlphttp/galileo` exporter from the collector
+  pipeline in `orbstack-kubernetes`. Either stops all Galileo traffic within seconds.
+
+**Harder:**
+
+- `galileo-on` requires a deliberate opt-in per shell session. Passive tracing of
+  ad-hoc inference is not supported by design.
+- VisiCore instrumentation (company) is deferred. When it lands, use a separate
+  Galileo log stream (`visicore-prod`) and apply stricter redaction there.
+
+## Cross-Repo Dependencies
+
+This ADR spans three repos. The nix-ai changes (this file, telemetry option) are
+self-contained. The remaining work:
+
+| Repo | Change | Status |
+|------|--------|--------|
+| `nix-ai` | `programs.mlx.telemetry.enable` option + LaunchAgent env | Done (this PR) |
+| `orbstack-kubernetes` | OTEL Collector: `otlphttp/galileo` exporter, routing connector, content denylist processor | Pending |
+| `orbstack-kubernetes` | Bifrost: OTel exporter + header→span-attr mapping for `X-Trace-Sink` | Pending |
+| `nix-home` | `galileo-on` zsh function + `gcurl` wrapper + `~/.config/galileo/allowlist.toml` | Pending |
+| `orbstack-kubernetes` | Doppler Operator: `GALILEO_API_KEY` in `ai-ci-automation/prd` | Pending (manual Doppler config) |
+
+No Galileo traffic flows to the SaaS until all five rows are complete.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ Each record follows the format: **Context → Decision → Consequences**.
 |---|-------|--------|------|
 | [0001](0001-static-vs-dynamic-model-config.md) | Static vs dynamic model config files for PAL MCP | Accepted | 2026-04-18 |
 | [0002](0002-activation-merge-pattern.md) | Activation-time deep-merge instead of Nix store symlinks | Accepted | 2026-04-18 |
+| [0003](0003-galileo-ai-observability.md) | Galileo AI observability — fail-closed homelab integration | Accepted | 2026-05-22 |
 
 ## Format
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -88,3 +88,11 @@ or enabling a project-specific plugin in a consumer repo.
 
 [`docs/adr/`](../adr/README.md) contains the decisions behind non-obvious design choices.
 If you find yourself wondering "why does it work this way?", the ADR index is the place to look.
+
+## Runbooks
+
+[`docs/runbooks/`](../runbooks/) contains operational guides for non-obvious workflows:
+
+| Runbook | Purpose |
+|---------|---------|
+| [galileo-onboarding.md](../runbooks/galileo-onboarding.md) | Galileo AI observability setup, daily use, denylist management, and kill switches |

--- a/docs/architecture/secrets-and-injection.md
+++ b/docs/architecture/secrets-and-injection.md
@@ -101,6 +101,7 @@ This is the cleanest pattern: zero credential exposure outside the cluster bound
 | GitHub MCP | `GITHUB_PERSONAL_ACCESS_TOKEN` | Keychain → shell env | macOS Keychain |
 | Bifrost | Provider API keys | K8s Doppler Operator | OrbStack cluster |
 | Cribl | Provider credentials | K8s Doppler Operator | OrbStack cluster |
+| OTEL Collector (Galileo exporter) | `GALILEO_API_KEY` | K8s Doppler Operator | OrbStack cluster (`ai-ci-automation/prd`) |
 | WakaTime | `WAKATIME_API_KEY` | Activation-time Doppler fetch | Written to `~/.wakatime.cfg` at `darwin-rebuild switch` |
 
 ## What NOT to Do

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -140,8 +140,32 @@ Enable by overriding `programs.aiMcp.servers.<name>.disabled` and adding the key
 | 9379 | LiteRT-LM classifier (Gemini CLI gemma router, opt-in) | HTTP | `modules/gemini/` |
 | 30080 | Bifrost AI gateway | HTTP | `orbstack-kubernetes` repo |
 | 30030 | Cribl MCP | HTTP | `orbstack-kubernetes` repo |
+| 30317 | OTEL Collector (gRPC receiver) | gRPC | `orbstack-kubernetes` repo |
+| 4317 | Cribl OTEL ingest | gRPC | `orbstack-kubernetes` repo |
 
 Reserved but avoid: **11435** (macOS app conflict, see PR #230).
+
+## Telemetry Pipeline
+
+```mermaid
+graph LR
+    CC["Claude Code\n(metrics + logs)"]
+    MLX["vllm-mlx\n(traces, when telemetry.enable=true)"]
+    OTEL["OTEL Collector\n:30317"]
+    CRIBL["Cribl Stream\n:4317"]
+    SPLUNK["Splunk HEC"]
+    GAL["Galileo SaaS\napi.galileo.ai/otel/traces"]
+
+    CC -->|grpc OTLP| OTEL
+    MLX -->|grpc OTLP| OTEL
+    OTEL -->|grpc OTLP| CRIBL
+    CRIBL --> SPLUNK
+    OTEL -->|"otlphttp (gated: X-Trace-Sink header\n+ content denylist)"| GAL
+```
+
+**Galileo gate:** only spans carrying `X-Trace-Sink: galileo` AND passing the
+content denylist (no Splunk/Cisco/client keywords) are forwarded to Galileo.
+All other spans flow only to Cribl/Splunk. See [ADR 0003](../adr/0003-galileo-ai-observability.md).
 
 ## Fabric's Four Integration Channels
 

--- a/docs/runbooks/galileo-onboarding.md
+++ b/docs/runbooks/galileo-onboarding.md
@@ -1,0 +1,99 @@
+# Galileo AI Observability — Operator Runbook
+
+See [ADR 0003](../adr/0003-galileo-ai-observability.md) for design decisions
+and [system-integration-map](../architecture/system-integration-map.md) for topology.
+
+## Prerequisites (one-time setup)
+
+All five rows in the ADR's cross-repo table must be complete before any traces
+reach Galileo. Check each before assuming the pipeline is live:
+
+1. `programs.mlx.telemetry.enable = true` in your nix-darwin config (this repo).
+2. `orbstack-kubernetes`: OTEL Collector has `otlphttp/galileo` exporter, routing
+   connector, and content denylist processor deployed.
+3. `orbstack-kubernetes`: Bifrost emits OTel spans and maps `X-Trace-Sink` header
+   to `trace.sink` span attribute.
+4. `nix-home`: `galileo-on` zsh function and `gcurl` wrapper are activated.
+5. Doppler (`ai-ci-automation/prd`): `GALILEO_API_KEY` is set, Doppler Operator
+   has synced it to the OTEL Collector pod.
+
+## Daily use
+
+```bash
+# From an allowlisted working directory (e.g. ~/git/nix-ai/main):
+galileo-on          # sets GALILEO_TRACE=1, prints confirmation
+
+# Hit MLX directly with trace header:
+gcurl http://127.0.0.1:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"default","messages":[{"role":"user","content":"hello"}]}'
+
+# Hit Bifrost with trace header (cloud model):
+gcurl http://127.0.0.1:30080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"anthropic/claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}'
+
+# Check Galileo console:
+# app.galileo.ai → project: homelab → log stream: default
+```
+
+Without running `galileo-on` first, `gcurl` sends no `X-Trace-Sink` header and
+the OTEL Collector routing connector drops the span before it reaches Galileo.
+Splunk still receives every span regardless.
+
+## Add a path to the allowlist
+
+Edit `~/.config/galileo/allowlist.toml` (not committed — user-owned):
+
+```toml
+[[paths]]
+path = "~/git/nix-ai"
+
+[[paths]]
+path = "~/git/nix-darwin"
+```
+
+## Add a denylist term
+
+The content denylist lives in `/etc/galileo/denylist.txt` on the OrbStack node,
+injected by Doppler. To add a term:
+
+1. Add the regex pattern to the `GALILEO_CONTENT_DENYLIST` secret in Doppler
+   (`ai-ci-automation/prd`). Format: one pattern per line, POSIX ERE, case-insensitive.
+2. Restart the OTEL Collector pod: `kubectl rollout restart deployment otel-collector -n monitoring`.
+3. Verify the updated denylist is loaded: check collector logs for `denylist loaded N patterns`.
+
+## If a trace lands in Galileo that shouldn't have
+
+1. **Rotate the API key immediately**: Doppler → `ai-ci-automation/prd` → regenerate
+   `GALILEO_API_KEY`. Old key stops working within seconds.
+2. **Delete the trace in Galileo**: `app.galileo.ai` → project → log stream → find
+   the trace → delete (Galileo supports individual trace deletion from the UI).
+3. **Expand the denylist**: add the pattern that should have matched.
+4. **Redeploy**: restart the OTEL Collector pod to pick up the new key and denylist.
+
+## Check trace count vs. Free tier cap
+
+Free tier allows 5,000 traces per month. To check current usage:
+
+- `app.galileo.ai` → project settings → Usage shows the monthly trace count.
+
+If trending to exceed 5K at your current rate, add tail-sampling to the collector:
+
+```yaml
+processors:
+  probabilistic_sampler:
+    hash_seed: 42
+    sampling_percentage: 20   # 20% of MLX-internal traces; keep 100% CLI traces
+```
+
+Apply to the `traces/galileo` sub-pipeline only, not the Cribl/Splunk pipeline.
+
+## Kill switches
+
+| Action | Effect |
+|--------|--------|
+| `programs.mlx.telemetry.enable = false` + rebuild | Removes OTel env vars from vllm-mlx LaunchAgent; MLX stops sending to collector |
+| Remove `otlphttp/galileo` from collector pipeline | Stops all Galileo exports; Splunk unaffected |
+| Delete `GALILEO_API_KEY` in Doppler | Collector authentication fails; no traces accepted by Galileo |
+| Unset `GALILEO_TRACE` in shell | No `X-Trace-Sink` header sent; routing connector drops all spans before Galileo exporter |

--- a/docs/runbooks/galileo-onboarding.md
+++ b/docs/runbooks/galileo-onboarding.md
@@ -31,7 +31,7 @@ gcurl http://127.0.0.1:11434/v1/chat/completions \
 # Hit Bifrost with trace header (cloud model):
 gcurl http://127.0.0.1:30080/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model":"anthropic/claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}'
+  -d '{"model":"${MODEL_ID}","messages":[{"role":"user","content":"hello"}]}'
 
 # Check Galileo console:
 # app.galileo.ai → project: homelab → log stream: default
@@ -78,13 +78,13 @@ Free tier allows 5,000 traces per month. To check current usage:
 
 - `app.galileo.ai` → project settings → Usage shows the monthly trace count.
 
-If trending to exceed 5K at your current rate, add tail-sampling to the collector:
+If trending to exceed 5K at your current rate, add sampling to the collector:
 
 ```yaml
 processors:
   probabilistic_sampler:
     hash_seed: 42
-    sampling_percentage: 20   # 20% of MLX-internal traces; keep 100% CLI traces
+    sampling_percentage: 20   # 20% sampling for all traces in this pipeline
 ```
 
 Apply to the `traces/galileo` sub-pipeline only, not the Cribl/Splunk pipeline.

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -54,6 +54,17 @@ in
         AbandonProcessGroup = false;
         EnvironmentVariables = {
           HF_HOME = cfg.huggingFaceHome;
+        }
+        // lib.optionalAttrs cfg.telemetry.enable {
+          # Standard OTel env vars inherited by llama-swap and its vllm-mlx children.
+          # The OTEL Collector at :30317 fans out to Cribl/Splunk and (optionally)
+          # to Galileo — see docs/adr/0003-galileo-ai-observability.md.
+          # Trace emission from vllm-mlx 0.2.9 is best-effort; the collector's
+          # routing connector is the primary gate, not the agent env.
+          OTEL_SERVICE_NAME = "vllm-mlx";
+          OTEL_EXPORTER_OTLP_ENDPOINT = cfg.telemetry.otlpEndpoint;
+          OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
+          OTEL_RESOURCE_ATTRIBUTES = "service.namespace=mlx,deployment.environment=homelab";
         };
         StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log";
         StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log";

--- a/modules/mlx/options-server.nix
+++ b/modules/mlx/options-server.nix
@@ -37,5 +37,18 @@
       default = "/Volumes/HuggingFace";
       description = "Path to HuggingFace model cache (dedicated APFS volume)";
     };
+
+    telemetry = {
+      enable = lib.mkEnableOption "OpenTelemetry trace export from the MLX inference stack";
+
+      otlpEndpoint = lib.mkOption {
+        type = lib.types.str;
+        default = "http://localhost:30317";
+        description = ''
+          gRPC OTLP endpoint for the OpenTelemetry Collector.
+          Matches the existing Claude Code telemetry pipeline endpoint.
+        '';
+      };
+    };
   };
 }

--- a/modules/mlx/options-server.nix
+++ b/modules/mlx/options-server.nix
@@ -5,6 +5,9 @@
 # default-model passthrough that ties this server to the ai-stack registry.
 #
 { config, lib, ... }:
+let
+  aiStackVars = import ../../vars/ai-stack.nix;
+in
 {
   options.programs.mlx = {
     enable = lib.mkEnableOption "MLX inference server via vllm-mlx";
@@ -43,7 +46,7 @@
 
       otlpEndpoint = lib.mkOption {
         type = lib.types.str;
-        default = "http://localhost:30317";
+        default = "http://localhost:${toString aiStackVars.nodeports.otel_grpc}";
         description = ''
           gRPC OTLP endpoint for the OpenTelemetry Collector.
           Matches the existing Claude Code telemetry pipeline endpoint.


### PR DESCRIPTION
## Summary

Adds `programs.mlx.telemetry.enable` option (default `false`) that gates standard OTel env vars on the vllm-mlx LaunchAgent — env vars propagate to llama-swap and its vllm-mlx child processes, wiring the MLX inference stack into the existing OTEL Collector pipeline at `:30317`.

New ADR 0003 documents the fail-closed Galileo design, dual-gate architecture (header + content denylist), Cisco/Splunk constraints, and cross-repo companion work required before any trace leaves the network.

Telemetry pipeline diagram added to `system-integration-map.md`, `GALILEO_API_KEY` row added to `secrets-and-injection.md` (K8s Doppler Operator pattern), `galileo-onboarding.md` runbook created.

## Changes

### Core
- `modules/mlx/default.nix`: New `telemetry.enable` option gates OTLP env vars on vllm-mlx LaunchAgent
- `vars/ai-stack.nix`: OTLP gRPC port `:30317` defined (refactored from hardcoded port)

### Documentation
- ADR 0003: Fail-closed design principles, header + content denylist gates, integration prerequisites
- `docs/architecture/system-integration-map.md`: Telemetry pipeline topology + port allocation
- `docs/architecture/secrets-and-injection.md`: `GALILEO_API_KEY` Doppler Operator pattern
- `docs/runbooks/galileo-onboarding.md`: Operator workflow for `galileo-on` + companion setup

### Runbook fixes
- Model IDs: versioned placeholders replaced with `${MODEL_ID}` for portability
- Sampling config: `tail-sampling` corrected to `sampling`, misleading probabilistic_sampler comment fixed

## Nothing reaches Galileo yet

Three companion items required before any trace leaves the local network:

1. **`nix-home`** — `galileo-on` zsh function + `gcurl` wrapper + `~/.config/galileo/allowlist.toml`
2. **`orbstack-kubernetes`** — OTEL Collector: `otlphttp/galileo` exporter, routing connector (fail-closed: drops spans without `X-Trace-Sink: galileo` header), content denylist processor (drops Splunk/Cisco/client keywords)
3. **Doppler** — add `GALILEO_API_KEY` to `ai-ci-automation/prd`; Doppler Operator syncs it to the collector pod

## Security design

Default posture is fail-closed. A trace only reaches Galileo if all of the following hold simultaneously:

- Operator ran `galileo-on` from an explicitly allowlisted working directory
- Outbound request carried `X-Trace-Sink: galileo` header (set only by `gcurl`/wrapper when `GALILEO_TRACE=1`)
- OTEL Collector routing connector passed the span (drops anything without the header)
- Content denylist processor found no match (Splunk, Cisco, `.spl`, `.conf`, customer names)

Claude Code, Codex, and Gemini CLIs are not instrumented — their existing Splunk/Cribl pipeline is unchanged.

## Test plan

- `nix flake check` passes (verified locally)
- `nix fmt` clean (verified locally)
- After all companion PRs land: negative test — no `galileo-on`, confirm zero Galileo traces; Splunk receives span normally
- Positive test — `galileo-on` from allowlisted cwd, `gcurl` to MLX, confirm trace in `app.galileo.ai` within 30s

Assisted-by: Claude <noreply@anthropic.com>