### PR TITLE
feat(claude): expose programs.claude.settings.autoMode configuration

### DIFF
--- a/modules/claude/options-settings.nix
+++ b/modules/claude/options-settings.nix
@@ -128,11 +128,11 @@
         type = lib.types.listOf lib.types.str;
         default = [ "$defaults" ];
         description = ''
-          Trusted infrastructure entries. Prose strings, read as natural-
-          language rules. Include `"$defaults"` to inherit the built-in
-          entries (working repo plus configured remotes) and splice your
-          entries before/after. Omit `"$defaults"` to replace the entire
-          built-in list — rarely desired.
+          Trusted infrastructure entries. Prose strings, read as
+          natural-language rules. Include `"$defaults"` to inherit the
+          built-in entries (working repo plus configured remotes) and
+          splice your entries before/after. Omit `"$defaults"` to
+          replace the entire built-in list — rarely desired.
         '';
       };
       allow = lib.mkOption {

--- a/modules/claude/options-settings.nix
+++ b/modules/claude/options-settings.nix
@@ -113,6 +113,57 @@
       };
     };
 
+    # Auto-mode classifier configuration. Lands at top-level `autoMode`
+    # in settings.json (NOT under permissions). See
+    # https://code.claude.com/docs/en/auto-mode-config.
+    #
+    # Setting defaultMode = "auto" enables the classifier; this block
+    # configures what it trusts. Out of the box the classifier trusts
+    # only the working directory and the active repo's remotes, so
+    # populating `environment` is the single highest-leverage tuning
+    # action — it stops the classifier from blocking routine cross-repo,
+    # cross-org, cloud, and homelab operations.
+    autoMode = {
+      environment = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "$defaults" ];
+        description = ''
+          Trusted infrastructure entries. Prose strings, read as natural-
+          language rules. Include `"$defaults"` to inherit the built-in
+          entries (working repo plus configured remotes) and splice your
+          entries before/after. Omit `"$defaults"` to replace the entire
+          built-in list — rarely desired.
+        '';
+      };
+      allow = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "$defaults" ];
+        description = ''
+          Exceptions to `soft_deny` rules. Prose strings. Include
+          `"$defaults"` to inherit built-ins.
+        '';
+      };
+      soft_deny = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "$defaults" ];
+        description = ''
+          Destructive actions blocked unless overridden by explicit user
+          intent or an `allow` entry. Include `"$defaults"` to inherit
+          the built-in soft-block list (force-push, `curl | bash`,
+          production deploys, etc.).
+        '';
+      };
+      hard_deny = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "$defaults" ];
+        description = ''
+          Unconditional blocks. Include `"$defaults"` to inherit the
+          built-in list (data exfiltration patterns, auto-mode bypass
+          attempts, etc.).
+        '';
+      };
+    };
+
     additionalDirectories = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];

--- a/modules/claude/settings.nix
+++ b/modules/claude/settings.nix
@@ -109,6 +109,17 @@ let
   // lib.optionalAttrs (cfg.settings.skillOverrides != { }) {
     inherit (cfg.settings) skillOverrides;
   }
+  // (
+    let
+      # Filter autoMode sub-fields that exactly equal [ "$defaults" ] —
+      # semantically a no-op since the classifier already uses defaults
+      # when a field is unset. Keeps settings.json minimal while still
+      # honoring consumer customizations to any sub-field.
+      isDefaultOnly = v: v == [ "$defaults" ];
+      kept = lib.filterAttrs (_: v: !isDefaultOnly v) cfg.settings.autoMode;
+    in
+    lib.optionalAttrs (kept != { }) { autoMode = kept; }
+  )
   // lib.optionalAttrs (cfg.model != null) { inherit (cfg) model; }
   // lib.optionalAttrs (cfg.remoteControlAtStartup != null) { inherit (cfg) remoteControlAtStartup; }
   // lib.optionalAttrs (envAttrs != { }) { env = envAttrs; }


### PR DESCRIPTION
## Summary

`permissions.defaultMode = "auto"` (already the default here) turns on Anthropic's auto-mode classifier. Out of the box the classifier trusts only the working directory and the active repo's configured remotes; cross-repo, cross-org, cloud, and homelab operations get blocked. The cure is configuring `autoMode.{environment,allow,soft_deny,hard_deny}` at top-level in settings.json. Reference: <https://code.claude.com/docs/en/auto-mode-config>.

Add typed sub-options under `programs.claude.settings.autoMode`:

- `environment` — trusted-infrastructure prose (highest leverage)
- `allow` — exceptions to `soft_deny` rules
- `soft_deny` — destructive actions user intent can clear
- `hard_deny` — unconditional blocks

Each defaults to `[ "$defaults" ]` (inherit built-ins). Consumers extend by adding prose entries; `$defaults` is spliced in at its position.

`modules/claude/settings.nix` filters sub-fields exactly equal to `[ "$defaults" ]` at write time — semantically a no-op since the classifier already uses defaults when a field is unset — so the generated settings.json stays minimal.

## First consumer

[JacobPEvans/nix-darwin#feat/automode-environment](https://github.com/JacobPEvans/nix-darwin/pull/new/feat/automode-environment) populates `programs.claude.settings.autoMode.environment` for the macbook-m4 host with the user's homelab trust context (GitHub orgs, AWS/Proxmox, MLX server, Doppler/Keychain/SOPS/Bitwarden, OTEL→Cribl→Splunk, self-hosted RunsOn runners, etc.).

## Test plan

- [x] `nix flake check` passes
- [x] `nix fmt` no diff
- [ ] Downstream rebuild: `jq '.autoMode.environment' ~/.claude/settings.json` returns populated list; `claude auto-mode config` shows entries; `claude auto-mode critique` AI review surfaces ambiguity

🤖 Generated with [Claude Code](https://claude.com/claude-code)