### PR TITLE
refactor(claude): inline claude-code schema URL in validation hook

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -16,7 +16,6 @@ let
       aiModule
       {
         _module.args.userConfig = {
-          ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
           user.fullName = "JacobPEvans";
         };
         home = {
@@ -36,7 +35,6 @@ let
       aiModule
       {
         _module.args.userConfig = {
-          ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
           user.fullName = "JacobPEvans";
         };
         home = {

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -18,7 +18,6 @@
   claude-cookbooks,
   fabric-src,
   userConfig ? {
-    ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
     user.fullName = "JacobPEvans";
   },
   ...

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -12,7 +12,6 @@
   lib,
   ai-assistant-instructions,
   userConfig ? {
-    ai.claudeSchemaUrl = "https://json.schemastore.org/claude-code-settings.json";
     user.fullName = "JacobPEvans";
   },
   ...
@@ -87,10 +86,13 @@ in
 
       activation = {
         # Claude Code Settings Validation (post-rebuild)
+        # Schema URL inlined here — same constant nix-claude-code embeds in
+        # lib/to-settings-json.nix's "$schema" field, single source of truth
+        # is the file produced by nix-claude-code; this validates against it.
         validateClaudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${./scripts/validate-claude-settings.sh} \
             "${config.home.homeDirectory}/.claude/settings.json" \
-            "${userConfig.ai.claudeSchemaUrl}"
+            "https://json.schemastore.org/claude-code-settings.json"
         '';
 
         cleanupLegacyGeminiMd = lib.hm.dag.entryAfter [ "linkGeneration" ] ''


### PR DESCRIPTION
## Summary

Drops `userConfig.ai.claudeSchemaUrl` as a module input. The
validation activation hook inlines the schemastore URL directly —
it's the same constant nix-claude-code embeds in
`lib/to-settings-json.nix`'s `\"\$schema\"` field, so the validation
script checks the generated `settings.json` against the schema that
produced it.

## Why this is needed

Unblocks deletion of the matching `ai.claudeSchemaUrl` attribute from
`dryvist/nix-darwin`'s `lib/user-config.nix`. The migration plan
called for removing it on both sides, but nix-ai had to drop its
consumer first — without this, deleting the nix-darwin definition
caused `error: attribute 'ai' missing` at flake eval (see
https://github.com/dryvist/nix-darwin/pull/1160 history).

## Changes

- \`modules/default.nix\`: \`validateClaudeSettings\` activation inlines the
  URL; \`userConfig\` default no longer carries \`ai.claudeSchemaUrl\`
- \`modules/claude-config.nix\`: same default cleanup
- \`lib/checks.nix\`: test fixture \`userConfig\` no longer carries it

## Verification

- \`nix flake check\` clean locally (aarch64-darwin)
- \`statix\`, \`deadnix -L --fail\`, \`nix fmt\` all clean

## Follow-up

Once this merges, https://github.com/dryvist/nix-darwin/pull/1160 can
drop the corresponding \`ai = { claudeSchemaUrl = ...; }\` block from
\`lib/user-config.nix\`.

Refs: https://github.com/dryvist/nix-darwin/pull/1160