### PR TITLE
feat(claude-config): move host MCP overrides from nix-darwin

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -198,7 +198,13 @@ in
           };
         };
 
-      enabled = enabledPlugins;
+      enabled = enabledPlugins // {
+        # Host-specific opinion (was nix-darwin hosts/macbook-m4/home.nix):
+        # playwright plugin disabled globally — only useful in specific
+        # projects. playwright@claude-skills (skills-only, no MCP) stays
+        # enabled via 04-community.nix.
+        "playwright@claude-plugins-official" = false;
+      };
       allowRuntimeInstall = true;
     };
 
@@ -261,7 +267,41 @@ in
 
     # MCP Servers - deployed to ~/.claude.json via home.activation.
     # Shared definitions are owned by modules/mcp and rendered per-client here.
-    mcpServers = lib.mapAttrs (_: normalizeClaudeMcpServer) config.programs.aiMcp.servers;
+    # Per-host overrides (disables + splunk) were previously in
+    # nix-darwin/hosts/macbook-m4/home.nix; moved here as part of the
+    # nix-claude-code migration so Claude config lives in nix-ai.
+    mcpServers =
+      let
+        fromCatalog = lib.mapAttrs (_: normalizeClaudeMcpServer) config.programs.aiMcp.servers;
+        # Disable MCP servers that duplicate built-in tools, are demo/test,
+        # or are project-specific. Definitions stay (for type validation);
+        # disabled = true excludes them from ~/.claude.json. Project-specific
+        # servers re-enable per-project via .mcp.json.
+        disabledServers = lib.genAttrs [
+          "everything" # Demo/test — not useful in production
+          "filesystem" # Duplicates built-in Read/Write/Glob/Edit tools
+          "fetch" # Duplicates built-in WebFetch tool
+          "git" # Duplicates built-in git via Bash(git:*)
+          "github" # Duplicates github@claude-plugins-official plugin
+          "cribl" # Project-specific — re-enable per-project
+          "terraform" # Project-specific — re-enable per-project
+          "cloudflare" # Not actively used — disable until needed
+          "exa" # Not actively used — disable until needed
+          "firecrawl" # Not actively used — disable until needed
+          "docker" # Not actively used — disable until needed
+        ] (name: (fromCatalog.${name} or { }) // { disabled = true; });
+      in
+      fromCatalog
+      // disabledServers
+      // {
+        # Splunk MCP via doppler-mcp wrapper (TLS bypass for self-signed cert
+        # is scoped inside splunk-mcp-connect, not here, to avoid leaking
+        # NODE_TLS_REJECT_UNAUTHORIZED to doppler-mcp).
+        splunk = {
+          command = "doppler-mcp";
+          args = [ "splunk-mcp-connect" ];
+        };
+      };
 
     statusline = {
       enable = true;


### PR DESCRIPTION
## Summary

Per the nix-claude-code migration, Claude-specific opinion belongs in
nix-ai (the user-specific layer), not nix-darwin (the macOS-system
layer). Moves the playwright plugin disable + 10 MCP server disables
+ splunk MCP definition that previously lived in
\`nix-darwin/hosts/macbook-m4/home.nix\`.

## Why this is needed

Unblocks https://github.com/dryvist/nix-darwin/pull/1160 from
removing the corresponding block in \`home.nix\`. With it gone,
\`hosts/macbook-m4/home.nix\` drops below the 12KB file-size CI limit
and the migration's "Claude config doesn't live in nix-darwin"
principle is fully satisfied.

## Changes

- \`modules/claude-config.nix\` plugins.enabled: adds
  \`"playwright@claude-plugins-official" = false\` override (tier 2
  defaults to true; \`playwright@claude-skills\` skills-only variant
  stays enabled via 04-community.nix)
- \`modules/claude-config.nix\` mcpServers: composed from catalog + 11
  disabled servers + splunk (was a single \`mapAttrs\` expression;
  now a let-binding that merges three layers)

## Verification

- \`nix flake check\` clean (aarch64-darwin)
- \`statix\`, \`deadnix -L --fail\`, \`nix fmt --fail-on-change\` all clean

Refs: https://github.com/dryvist/nix-darwin/pull/1160