### PR TITLE
fix(claude): rewire claude-latest to bunx @anthropic-ai/claude-code@latest

### DIFF
--- a/modules/ai-aliases.zsh
+++ b/modules/ai-aliases.zsh
@@ -2,9 +2,11 @@
 # Managed by nix-ai's programs.zsh.initContent via modules/ai-shell.nix.
 # Single source of truth for Claude/Doppler AI-tool wrapper aliases.
 
-# Bleeding-edge native install managed by nix-ai's programs.claude-latest module.
-# `claude` (unaliased) resolves via PATH — whatever that points at is intentional.
-alias claude-latest="$HOME/.local/bin/claude"
+# `claude` (unaliased) resolves via PATH to ~/.local/bin/claude — the pinned
+# stable build maintained by Anthropic's claude.ai/install.sh.
+# `claude-latest` bypasses the local install and fetches the npm `latest`
+# dist-tag of @anthropic-ai/claude-code on every invocation.
+alias claude-latest="bunx @anthropic-ai/claude-code@latest"
 
 # --dangerously-skip-permissions variants (aliases chain at command start in zsh).
 alias claude-d="claude --dangerously-skip-permissions"


### PR DESCRIPTION
## Summary

- `claude-latest` was aliased to `$HOME/.local/bin/claude` — the same binary bare `claude` resolves to via PATH, making the alias a no-op
- Replaces the alias with `bunx @anthropic-ai/claude-code@latest` which fetches the npm `latest` dist-tag on demand (currently `2.1.158` vs installed stable `2.1.149`)
- `bunx` is already on PATH via nix-home; no new deps
- `claude-d` and `claude-latest-d` chain correctly without any changes

## Test plan

- [ ] `alias claude-latest` → expect `bunx @anthropic-ai/claude-code@latest`
- [ ] `claude --version` → still shows the installed stable version
- [ ] `claude-latest --version` → shows the npm `latest` tag version (should differ from stable)
- [ ] `claude-latest --help | head -3` → exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)