### PR TITLE
chore(deps): bump nix-claude-code for home.file/activation-merge dedup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -506,11 +506,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1780252245,
-        "narHash": "sha256-o4MJY2zde9IJbiTVN5kV00sSdqGvdKbnMbO1v5O7e68=",
+        "lastModified": 1780254652,
+        "narHash": "sha256-+OThghl1ecV7fVD2NiHEGfopITtQxTl4aXYLCMEHaQc=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "628dd6fac218e65ce32b1adca7eb6605c1510e1a",
+        "rev": "947526673a8fb52ce400bb824f073f532f4fd2f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `nix-claude-code` from `628dd6f` to `9475266` (PR #39 merge). PR #39 removes the conflicting `home.file.".claude/settings.json"` install from `core.nix`, leaving `claudeSettingsMerge` as the sole writer.

## Why

Pre-fix, on the box currently running this lock chain (`dryvist/nix-darwin@1256ba4`), Claude Code refused to load `~/.claude/settings.json` at startup:

> `permissions.defaultMode: Invalid value. Expected one of: acceptEdits, auto, bypassPermissions, default, dontAsk, plan`
> Files with errors are skipped entirely, not just the invalid settings.

Cause: `linkGeneration` was overwriting the activation-merge's correct output with a symlink to a stale, smaller `home.file` source (missing `enabledPlugins`, `permissions.defaultMode: null`). Removing the `home.file` install eliminates the race.

Refs:
- dryvist/nix-claude-code#39
- dryvist/nix-claude-code#37 (made the merge script executable; required for #39 to take effect)

## Test plan

- [ ] CI green
- [ ] Post-merge: `dryvist/nix-darwin` lock bump → `darwin-rebuild switch` → `jq '.permissions.defaultMode' ~/.claude/settings.json` returns `"auto"` and `enabledPlugins` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)