### PR TITLE
chore(deps): bump nixpkgs + home-manager to 26.05-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -371,16 +371,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1779726825,
+        "narHash": "sha256-RUkMrREjKDQrA+dA9+xZviGAxM5W1aVdyOr/bSYpHrE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "b179bde238977f7d4454fc770b1a727eaf55111c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -521,16 +521,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779495359,
-        "narHash": "sha256-KZ/9A3gvlKboDm2Kbv4A6KnfA9wMSfebyoEU91HeBn8=",
+        "lastModified": 1780180721,
+        "narHash": "sha256-bHHvsVgzvOE0SKJn2OB7LDKuiOpdkXS/eVqTiJDNVBI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b76bb8a3c79707f0d0903e486da6d9851654c3c",
+        "rev": "9396caa0b59af6a17cac62008a72255b25e1e9a8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "AI CLI ecosystem for Claude, Gemini, Copilot, and Codex (Nix flake)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     # Second nixpkgs only for llama-swap: 25.11-darwin froze it at v165 on
     # 2025-09-22 with no backports. See nix-ai#801.
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -11,7 +11,7 @@
 # - .github/workflows/nixos-release-check.yml - automated update notifications
 # - .github/workflows/ci-eol-check.yml - end-of-life validation
 {
-  stableVersion = "25.11";
+  stableVersion = "26.05";
 
   # Package version pins — single source of truth for cross-module shared deps.
   # Each pin entry (below) must have a `# renovate:` annotation immediately above

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -181,32 +181,13 @@ in
     ./components.nix
 
     # Legacy option paths (kept for compatibility during migration).
-    (lib.mkRenamedOptionModule
-      [
-        "programs"
-        "codex"
-        "skills"
-        "fromFlakeInputs"
-      ]
-      [
-        "programs"
-        "agentSkills"
-        "fromFlakeInputs"
-      ]
-    )
-    (lib.mkRenamedOptionModule
-      [
-        "programs"
-        "codex"
-        "skills"
-        "local"
-      ]
-      [
-        "programs"
-        "agentSkills"
-        "local"
-      ]
-    )
+    #
+    # The codex aliases that previously lived here were removed: home-manager
+    # 26.05 introduced a native `programs.codex.skills` leaf option (codex-only,
+    # deploys to ~/.codex/skills), so child aliases under that path collided with
+    # it ("type ... does not support nested options"). nix-ai's cross-tool feature
+    # is `programs.agentSkills.*` (deploys to ~/.agents/skills); nothing in this
+    # repo set the legacy codex paths, so dropping them loses no configuration.
     (lib.mkRenamedOptionModule
       [
         "programs"

--- a/modules/mcp/flake.lock
+++ b/modules/mcp/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779495359,
-        "narHash": "sha256-KZ/9A3gvlKboDm2Kbv4A6KnfA9wMSfebyoEU91HeBn8=",
+        "lastModified": 1780180721,
+        "narHash": "sha256-bHHvsVgzvOE0SKJn2OB7LDKuiOpdkXS/eVqTiJDNVBI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b76bb8a3c79707f0d0903e486da6d9851654c3c",
+        "rev": "9396caa0b59af6a17cac62008a72255b25e1e9a8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/modules/mcp/flake.nix
+++ b/modules/mcp/flake.nix
@@ -2,7 +2,7 @@
   description = "MCP runtime + server definitions for AI CLI tools (sub-flake of nix-ai)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
 
     pal-mcp-server = {
       url = "github:BeehiveInnovations/pal-mcp-server";


### PR DESCRIPTION
## Summary

Bumps the NixOS channel from 25.11 to 26.05 across the flake, keeping nixpkgs and home-manager in lockstep, and resolves a home-manager 26.05 breaking change that collided with this repo's legacy skills option aliases.

Both channels now on 26.05:
- `nixpkgs` → `nixpkgs-26.05-darwin` (top-level `flake.nix` + `modules/mcp/flake.nix`)
- `home-manager` → `release-26.05` (release branch must match the nixpkgs channel)
- `lib/versions.nix` `stableVersion` → `26.05` (informational, consumed by `nixos-release-check.yml` / `ci-eol-check.yml`)

## home-manager 26.05 breaking change + migration

home-manager 26.05 introduced a **native `programs.codex.skills` leaf option** (`modules/programs/codex.nix`), typed `either (attrsOf (either lines path)) path`, that manages codex-only skills under `~/.codex/skills`. A leaf of that type "does not support nested options."

This repo's `modules/agent-skills/default.nix` carried legacy `mkRenamedOptionModule` aliases redirecting `programs.codex.skills.{fromFlakeInputs,local}` → `programs.agentSkills.*`. Those aliases declare **child options under the new leaf**, so the module system now throws:

```
error: The option `programs.codex.skills' ... would be a parent of the following
options, but its type ... does not support nested options.
 - option(s) with prefix `programs.codex.skills.fromFlakeInputs' in module `.../modules/agent-skills'
 - option(s) with prefix `programs.codex.skills.local'          in module `.../modules/agent-skills'
```

This failed the `checks.x86_64-linux.module-eval` CI check (and every other home-manager-driven regression check) on the Linux runner. Confirmed introduced by the home-manager bump: the same eval succeeds on `origin/main` (home-manager 25.11).

**Migration chosen — drop the colliding codex aliases.** nix-ai's real feature is `programs.agentSkills.*`, a *cross-tool* skill deployer targeting `~/.agents/skills` — distinct from home-manager's codex-only `programs.codex.skills`. The aliases were pure backward-compat redirects; nothing in this repo (or in `nix-darwin`) sets the legacy `programs.codex.skills.*` paths, so removing them loses no configuration. The `programs.gemini.skills.*` aliases are **kept** — home-manager exposes gemini skills at `programs.gemini-cli.skills`, not `programs.gemini.skills`, so those do not collide (verified empirically). `stateVersion` test fixtures are intentionally left at 25.11 (plain state-compat markers, no channel-coupling guard — lagging is supported).

## Verification

- `nix eval .#checks.x86_64-linux.module-eval.drvPath` → returns a valid `.drv` (previously threw).
- All home-manager-driven regression checks evaluate: `defaults-regression`, `options-regression`, and the `{agent-skills,codex,gemini,mlx,fabric}-defaults-regression` checks.
- `nix flake check` clean (native; cross-system check *builds* are skipped on darwin as designed — CI runs them on Linux).
- pre-commit (nixfmt, statix, deadnix) passes; no hooks bypassed.

## FYI (not addressed here, out of scope)

home-manager 26.05 also renamed `programs.codex.custom-instructions` → `programs.codex.context`. `modules/codex/default.nix:31` still uses the old name; home-manager emits a soft deprecation warning but evaluation succeeds via its own rename alias. Behavior preserved. Worth a follow-up to adopt `programs.codex.context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)