### PR TITLE
feat(ci): event-driven flake input updates

### DIFF
--- a/.github/workflows/dispatch-to-nix-darwin.yml
+++ b/.github/workflows/dispatch-to-nix-darwin.yml
@@ -14,28 +14,6 @@ permissions: {}
 
 jobs:
   dispatch:
-    name: Notify ${{ matrix.repo }}
-    strategy:
-      matrix:
-        repo: ${{ fromJSON(vars.DISPATCH_CONSUMERS) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          repositories: ${{ matrix.repo }}
-
-      - name: Dispatch update-flake-input
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TARGET_REPO: ${{ matrix.repo }}
-        run: |
-          gh api "repos/dryvist/${TARGET_REPO}/dispatches" \
-            -f event_type=update-flake-input \
-            -f 'client_payload[input]=nix-ai'
+    uses: dryvist/.github/.github/workflows/_dispatch-flake-consumers.yml@main
+    # source_input defaults to the calling repo name (nix-ai).
+    secrets: inherit

--- a/.github/workflows/dispatch-to-nix-darwin.yml
+++ b/.github/workflows/dispatch-to-nix-darwin.yml
@@ -1,0 +1,41 @@
+# Dispatch: notify consumers after flake.lock changes on main
+#
+# Target repos are read from the DISPATCH_CONSUMERS repository variable
+# (JSON array, e.g. '["nix-darwin"]'). Add a new consumer there without
+# touching this file.
+name: Dispatch lock update to consumers
+
+on:
+  push:
+    branches: [main]
+    paths: [flake.lock]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    name: Notify ${{ matrix.repo }}
+    strategy:
+      matrix:
+        repo: ${{ fromJSON(vars.DISPATCH_CONSUMERS) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: ${{ matrix.repo }}
+
+      - name: Dispatch update-flake-input
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_REPO: ${{ matrix.repo }}
+        run: |
+          gh api "repos/dryvist/${TARGET_REPO}/dispatches" \
+            -f event_type=update-flake-input \
+            -f 'client_payload[input]=nix-ai'

--- a/.github/workflows/update-flake-input.yml
+++ b/.github/workflows/update-flake-input.yml
@@ -1,0 +1,36 @@
+# Receiver: bump a flake input on repository_dispatch
+#
+# Called by upstream repos (e.g. nix-claude-code) after they publish a
+# release. Delegates to the shared reusable workflow in dryvist/.github.
+# Also available as workflow_dispatch for manual one-off bumps.
+#
+# Chain: nix-claude-code release → dispatch here → update nix-claude-code
+# input → push to main → dispatch-to-nix-darwin.yml fires.
+name: Update flake input
+
+on:
+  repository_dispatch:
+    types: [update-flake-input]
+  workflow_dispatch:
+    inputs:
+      input_name:
+        description: Flake input to update (default: nix-claude-code)
+        type: string
+        default: nix-claude-code
+
+permissions: {}
+
+jobs:
+  update:
+    uses: dryvist/.github/.github/workflows/_update-flake-input.yml@main
+    with:
+      # client_payload.input from repository_dispatch; falls back to
+      # workflow_dispatch input, then to the default.
+      input_name: >-
+        ${{
+          github.event.client_payload.input
+          || inputs.input_name
+          || 'nix-claude-code'
+        }}
+    secrets:
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Adds event-driven flake input update infrastructure for nix-ai
- `update-flake-input.yml` — receives `repository_dispatch` from nix-claude-code; thin caller of `dryvist/.github/_update-flake-input.yml@main`; also supports `workflow_dispatch` for manual bumps
- `dispatch-to-nix-darwin.yml` — thin `workflow_call` caller of `dryvist/.github/_dispatch-flake-consumers.yml@main`; fires on `push` to `main` when `flake.lock` changes; notifies nix-darwin

## Context

Middle hop in the event-driven flake-lock propagation chain:

```
nix-claude-code release → dispatch → nix-ai (this repo)
  → _update-flake-input bumps nix-claude-code input
  → flake.lock push → dispatch → nix-darwin
```

The sender was previously a 41-line duplicate of the nix-claude-code sender. It is now a 3-line caller. The `permission-contents: write` on the App token (previously omitted here) is now enforced centrally in `_dispatch-flake-consumers.yml`.

**Depends on (merge first):** dryvist/.github#21 (`_dispatch-flake-consumers.yml@main`)

Refs: dryvist/.github#21, dryvist/nix-claude-code#44, dryvist/nix-darwin#1174

## Test Plan

1. Verify dryvist/.github#21 is merged
2. On a nix-claude-code release, confirm `update-flake-input.yml` receives the dispatch and opens a `chore/bump-nix-claude-code` PR
3. After that PR auto-merges → confirm `dispatch-to-nix-darwin.yml` fires and nix-darwin receives the cascade dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)