### PR TITLE
fix(claude-code): install via brew, latest channel, no nix binary

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -506,11 +506,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1780254652,
-        "narHash": "sha256-+OThghl1ecV7fVD2NiHEGfopITtQxTl4aXYLCMEHaQc=",
+        "lastModified": 1780422238,
+        "narHash": "sha256-vjpmQgrE/D8XaLf4HC1R6OiojDm2svTbdodd8cX77cU=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "947526673a8fb52ce400bb824f073f532f4fd2f4",
+        "rev": "b107aede8b07a435261b9dbdc2695fc7cc2f8fae",
         "type": "github"
       },
       "original": {

--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -110,7 +110,12 @@ in
         {
           name = "autoUpdatesChannel";
           actual = cfg.autoUpdatesChannel;
-          expected = "stable";
+          expected = "latest";
+        }
+        {
+          name = "autoUpdates";
+          actual = cfg.autoUpdates;
+          expected = true;
         }
         {
           name = "model";

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -122,6 +122,12 @@ in
   programs.claude = {
     enable = true;
 
+    # Binary comes from Homebrew (claude-code@latest cask in nix-darwin);
+    # Nix manages config only. Claude's native updater (latest channel)
+    # overlays the newest build at ~/.local/bin/claude on top of the brew
+    # baseline. See nix-claude-code core.nix: package = null skips home.packages.
+    package = null;
+
     # API Key Helper for headless authentication (cron jobs, CI/CD)
     # Uses Bitwarden Secrets Manager to securely fetch OAuth token
     # Configuration: ~/.config/bws/.env (see bws-env.example)
@@ -136,7 +142,8 @@ in
     # Effort: high — maximize reasoning quality by default.
     effortLevel = "high";
 
-    autoUpdatesChannel = "stable"; # override (upstream default: "latest")
+    autoUpdatesChannel = "latest"; # newest releases (matches upstream default)
+    autoUpdates = true; # keep the native (~/.local) build self-updating on the latest channel
 
     # Enable Remote Control for all sessions (Feb 2026 feature).
     remoteControlAtStartup = true;


### PR DESCRIPTION
## Problem

`which claude` resolved to a stale `~/.local/bin/claude` (2.1.150) that kept reappearing after deletion. Root cause: three competing Claude binaries (native `~/.local`, brew `claude-code@latest`, and the nixpkgs build), with the native one winning on PATH while pinned to the **stable** channel (~week-old releases) — so it lagged brew's `@latest` and `/doctor` complained.

## Change

Consolidate onto a single brew-anchored install on the **latest** channel (no `stable` anywhere), with Claude's native updater allowed to keep `~/.local/bin/claude` current.

- `autoUpdatesChannel`: `stable` → `latest`.
- `package = null`: drop the redundant nixpkgs binary; the `claude-code@latest` cask (nix-darwin) is the baseline. Also clears the documented brew-bundle conflict.
- `autoUpdates = true`: keep the native build self-updating on the latest channel (consumes the new `programs.claude.autoUpdates` option).
- Regression test now asserts `autoUpdatesChannel = "latest"` and `autoUpdates = true`.
- `flake.lock`: bump `nix-claude-code` to the `feat/auto-updates-option` rev that provides the new option.

## Dependency / merge order

**Blocked on dryvist/nix-claude-code#45** (adds `programs.claude.autoUpdates`). The lock currently points at that PR's branch rev so CI evaluates green. After #45 merges, re-lock `nix-claude-code` to `main` (`nix flake update nix-claude-code`) before/at merge.

Refs: dryvist/nix-claude-code#45

## Verification

- `nix flake check` passes self-contained (no `--override-input`), including the new regression assertions.
- `darwin-rebuild switch` (with both worktree overrides) verified live: `~/.claude.json` → `"autoUpdates": true` via the overlay (declarative, no hand-edit); settings.json `autoUpdatesChannel: latest`; `which claude` → `~/.local/bin/claude` 2.1.160; nixpkgs binary at `/etc/profiles/.../claude` gone.

## Note

Per the chosen install mode, `~/.local/bin/claude` intentionally remains (Claude self-updates it on `latest`) — it is no longer stale. nix-darwin needs no change (cask already `claude-code@latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)