### PR TITLE
feat(mlx): periodic watchdog kicks LaunchAgent under memory pressure

### DIFF
--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -71,6 +71,55 @@ in
       };
     };
 
+    # ==========================================================================
+    # Watchdog LaunchAgent — defense in depth against nix-ai#801
+    # ==========================================================================
+    # Periodic check (default every 5 min) that kicks the vllm-mlx LaunchAgent
+    # when any of:
+    #   - A vllm-mlx serve worker has been alive longer than ttlGraceMult ×
+    #     its configured ttl (stuck-past-TTL — the upstream llama-swap
+    #     proxy/process.go:280-289 race fingerprint).
+    #   - vm.swapusage used / total > swapThresholdPct.
+    #   - Any single worker RSS > rssThresholdPct % of physical RAM.
+    # The "kick" is `launchctl kickstart -k <label>` which forces a clean
+    # restart through the existing KeepAlive + 120 s ThrottleInterval — no
+    # graceful-shutdown ladder, no orphaned workers.
+    # See programs.mlx.watchdog.* options for tuning.
+    launchd.agents.vllm-mlx-watchdog = lib.mkIf cfg.watchdog.enable {
+      enable = true;
+      config = {
+        Label = "${launchAgentLabel}.watchdog";
+        ProgramArguments = [
+          (lib.getExe (
+            pkgs.writeShellApplication {
+              name = "mlx-watchdog";
+              runtimeInputs = with pkgs; [
+                coreutils
+                gawk
+                gnused
+                jq
+              ];
+              text = builtins.readFile ./scripts/mlx-watchdog.sh;
+            }
+          ))
+        ];
+        RunAtLoad = false;
+        StartInterval = cfg.watchdog.intervalSeconds;
+        ProcessType = "Background";
+        AbandonProcessGroup = false;
+        EnvironmentVariables = {
+          MLX_LAUNCHD_LABEL = launchAgentLabel;
+          MLX_WATCHDOG_LOG = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/watchdog.log";
+          MLX_WATCHDOG_CONFIG = llamaSwapRuntimeConfigPath;
+          MLX_WATCHDOG_SWAP_PCT = toString cfg.watchdog.swapThresholdPct;
+          MLX_WATCHDOG_RSS_PCT = toString cfg.watchdog.rssThresholdPct;
+          MLX_WATCHDOG_TTL_MULT = toString cfg.watchdog.ttlGraceMult;
+        };
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/watchdog.stdout.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/watchdog.error.log";
+      };
+    };
+
     home = {
       # ==========================================================================
       # Log Rotation (closes #255)
@@ -82,6 +131,8 @@ in
         # logfilename                                                                [owner:group]  mode  count  size  when  flags
         ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log        :              644   3      10240 *     J
         ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log              :              644   3      10240 *     J
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/watchdog.log              :              644   3      1024  *     J
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/watchdog.error.log        :              644   3      1024  *     J
       '';
 
       # ==========================================================================

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -119,5 +119,47 @@
         '';
       };
     };
+
+    watchdog = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Periodic watchdog (LaunchAgent + shell script) that kicks the
+          vllm-mlx LaunchAgent when worker memory pressure crosses
+          thresholds OR a worker sits past its configured TTL by more than
+          `ttlGraceMult` ×. Defensive layer against the upstream
+          mostlygeek/llama-swap lifecycle race at proxy/process.go:280-289
+          (`panic: sync: WaitGroup is reused before previous Wait has
+          returned`) — see nix-ai#801 and the docs-starlight architecture
+          page at `d/hosts/local-llm-stack`.
+
+          Bug has been observed firing 5+ times on the reference host
+          (M4 Max 128 GB). The watchdog acts as defense in depth: even if
+          upstream stays broken, the host self-recovers within the
+          watchdog's polling interval.
+        '';
+      };
+      intervalSeconds = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 300;
+        description = "How often the watchdog runs (LaunchAgent `StartInterval`). Default 5 min — short enough to catch a stuck worker before it dominates compressor + swap, long enough to avoid spawning chatter at idle.";
+      };
+      swapThresholdPct = lib.mkOption {
+        type = lib.types.ints.between 1 99;
+        default = 75;
+        description = "If `vm.swapusage` used / total exceeds this percentage, the watchdog kicks the LaunchAgent. Default 75 — below the 90 % saturation seen in the 2026-05-19 and 2026-06-02 incidents but well above normal operating headroom.";
+      };
+      rssThresholdPct = lib.mkOption {
+        type = lib.types.ints.between 1 99;
+        default = 50;
+        description = "If any single `vllm-mlx serve` worker's RSS exceeds this percentage of physical RAM, the watchdog kicks. Default 50 — on a 128 GB host that means 64 GB single-process; the 2026-06-02 incident peaked at 55 % (71 GB).";
+      };
+      ttlGraceMult = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 2;
+        description = "Multiplier applied to a model's configured `ttl` to set the watchdog's stuck-worker threshold. A worker still resident past `ttl * ttlGraceMult` seconds triggers a kick. Default 2 — catches the `nix-ai#801` race fingerprint without false positives during legitimate long-tail inference.";
+      };
+    };
   };
 }

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -118,6 +118,20 @@ in
           text = builtins.readFile ./scripts/mlx-preflight.sh;
         })
 
+        # mlx-watchdog — periodic kick-LaunchAgent-on-pressure defense
+        # against nix-ai#801 + multi-day uptime memory accumulation.
+        # Wired into launchd via cfg.watchdog.enable (default true).
+        (pkgs.writeShellApplication {
+          name = "mlx-watchdog";
+          runtimeInputs = with pkgs; [
+            coreutils
+            gawk
+            gnused
+            jq
+          ];
+          text = builtins.readFile ./scripts/mlx-watchdog.sh;
+        })
+
         # ======================================================================
         # Benchmark Suite
         # ======================================================================

--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Periodic watchdog — kicks the vllm-mlx LaunchAgent when worker memory pressure
+# or stuck-past-TTL conditions cross thresholds. Defensive layer against the
+# upstream mostlygeek/llama-swap lifecycle race at proxy/process.go:280-289
+# (`panic: sync: WaitGroup is reused before previous Wait has returned`).
+# See nix-ai#801 + docs-starlight/d/hosts/local-llm-stack.
+#
+# Usage: mlx-watchdog (intended to run via LaunchAgent StartInterval).
+#
+# Tunable env vars (all optional, with sane defaults for an M4 Max 128 GB host):
+#   MLX_LAUNCHD_LABEL          launchd label of the LaunchAgent to kick
+#   MLX_WATCHDOG_LOG           log file path
+#   MLX_WATCHDOG_CONFIG        path to llama-swap.json (TTL lookup)
+#   MLX_WATCHDOG_SWAP_PCT      swap usage % threshold (default 75)
+#   MLX_WATCHDOG_RSS_PCT       single-worker RSS % of physical RAM (default 50)
+#   MLX_WATCHDOG_TTL_MULT      etime / configured-ttl multiplier (default 2)
+
+set -euo pipefail
+
+label="${MLX_LAUNCHD_LABEL:?MLX_LAUNCHD_LABEL must be set}"
+log="${MLX_WATCHDOG_LOG:-$HOME/Library/Logs/vllm-mlx/watchdog.log}"
+cfg="${MLX_WATCHDOG_CONFIG:-$HOME/.config/mlx/llama-swap.json}"
+swap_pct_max="${MLX_WATCHDOG_SWAP_PCT:-75}"
+rss_pct_max="${MLX_WATCHDOG_RSS_PCT:-50}"
+ttl_mult="${MLX_WATCHDOG_TTL_MULT:-2}"
+
+mkdir -p "$(dirname "$log")"
+ts() { date +%Y-%m-%dT%H:%M:%S; }
+note() { printf '%s %s\n' "$(ts)" "$*" >> "$log"; }
+
+trigger=""
+
+# Worker enumeration (one line per worker: pid etime model)
+workers=$(
+  ps -axww -o pid,etime,command \
+    | awk '/bin\/python.*bin\/vllm-mlx serve/ {
+        model = "unknown";
+        for (i = 3; i <= NF; i++) {
+          if ($i == "serve" && (i + 1) <= NF) { model = $(i + 1); break }
+        }
+        print $1, $2, model
+      }'
+)
+
+if [ -z "$workers" ]; then
+  note "OK no workers running"
+  exit 0
+fi
+
+# 1. Stuck-past-TTL check — etime greater than ttl_mult * configured ttl.
+while IFS= read -r row; do
+  pid=$(awk '{print $1}' <<< "$row")
+  etime=$(awk '{print $2}' <<< "$row")
+  model=$(awk '{print $3}' <<< "$row")
+  [ -z "$model" ] || [ "$model" = "unknown" ] && continue
+
+  ttl=$(jq -r --arg m "$model" '.models[$m].ttl // 0' "$cfg" 2>/dev/null || echo 0)
+  [ "${ttl:-0}" = "0" ] && continue
+
+  secs=$(awk -v e="$etime" 'BEGIN {
+    n = split(e, a, /[-:]/);
+    if      (n == 4) print (a[1]*86400) + (a[2]*3600) + (a[3]*60) + a[4];
+    else if (n == 3) print (a[1]*3600) + (a[2]*60) + a[3];
+    else if (n == 2) print (a[1]*60) + a[2];
+    else             print 0;
+  }')
+
+  threshold=$(( ttl * ttl_mult ))
+  if [ "$secs" -gt "$threshold" ]; then
+    trigger="STUCK_WORKER pid=$pid model=$model etime=${secs}s ttl=${ttl}s ratio=$(awk -v s="$secs" -v t="$ttl" 'BEGIN{printf "%.1f", s/t}')x"
+    break
+  fi
+done <<< "$workers"
+
+# 2. Swap pressure check.
+if [ -z "$trigger" ]; then
+  read -r swap_total swap_used < <(
+    sysctl -n vm.swapusage | awk '{
+      for (i = 1; i <= NF; i++) {
+        if ($i == "total") { t = $(i + 2); sub(/[A-Za-z]+$/, "", t) }
+        if ($i == "used")  { u = $(i + 2); sub(/[A-Za-z]+$/, "", u) }
+      }
+      print t, u
+    }'
+  )
+  if [ -n "${swap_total:-}" ] && [ -n "${swap_used:-}" ]; then
+    swap_pct=$(awk -v u="$swap_used" -v t="$swap_total" 'BEGIN { printf "%d", (t > 0) ? u * 100 / t : 0 }')
+    if [ "$swap_pct" -gt "$swap_pct_max" ]; then
+      trigger="SWAP_PRESSURE swap_used=${swap_used}MB swap_total=${swap_total}MB pct=${swap_pct}%"
+    fi
+  fi
+fi
+
+# 3. Single-worker RSS > rss_pct_max % of physical RAM.
+if [ -z "$trigger" ]; then
+  phys_mb=$(( $(sysctl -n hw.memsize) / 1048576 ))
+  rss_threshold_mb=$(( phys_mb * rss_pct_max / 100 ))
+  while IFS= read -r tline; do
+    pid=$(awk '{print $1}' <<< "$tline")
+    rss_raw=$(awk '{print $2}' <<< "$tline")
+    rss_mb=$(awk -v r="$rss_raw" 'BEGIN {
+      v = r + 0;
+      if (r ~ /G$/) v *= 1024;
+      else if (r ~ /K$/) v /= 1024;
+      else if (r ~ /T$/) v *= 1048576;
+      printf "%d", v;
+    }')
+    if [ "$rss_mb" -gt "$rss_threshold_mb" ]; then
+      trigger="RSS_PRESSURE pid=$pid rss_mb=$rss_mb threshold_mb=$rss_threshold_mb (${rss_pct_max}% of ${phys_mb}MB)"
+      break
+    fi
+  done < <(top -l 1 -o rsize -n 10 -stats pid,rsize,command \
+             | awk '/bin\/python.*bin\/vllm-mlx serve/ {print $1, $2}')
+fi
+
+if [ -z "$trigger" ]; then
+  note "OK no triggers"
+  exit 0
+fi
+
+note "TRIGGER $trigger"
+note "ACTION launchctl kickstart -k gui/$(id -u)/$label"
+launchctl kickstart -k "gui/$(id -u)/$label" 2>&1 | sed 's/^/  /' >> "$log" || true
+note "DONE"
+exit 1


### PR DESCRIPTION
## Summary

Adds a `mlx-watchdog` LaunchAgent (default StartInterval=300s) that
self-heals the vllm-mlx stack when memory pressure or stuck-past-TTL
conditions cross thresholds. Closes #801 defensively — even if the
upstream `mostlygeek/llama-swap` `sync.WaitGroup` race at
`proxy/process.go:280-289` stays unfixed, the host self-recovers within
the watchdog's polling interval.

## Triggers (any one fires the kick)

| Check | Default threshold | Source |
|---|---|---|
| Stuck-past-TTL worker | `etime > 2 × ttl` (per-model `ttl` from llama-swap.json) | `ps -axww -o pid,etime,command` + `jq` |
| Swap pressure | > 75 % of dynamic pool used | `sysctl -n vm.swapusage` |
| Single-worker RSS | > 50 % of physical RAM | `top -l 1 -o rsize` |

On trigger: `launchctl kickstart -k <label>` — forces a clean restart
through the existing `KeepAlive` + `ThrottleInterval=120s` pipeline.
No graceful-shutdown ladder; no orphaned workers.

## Why this is needed (incident timeline)

The upstream `nix-ai#801` race has fired 5+ times on the reference
host (M4 Max 128 GB) over the past five weeks:

- 2026-05-09 — RC11 Jetsam (32 GB cache + ttl=0; fixed in #764)
- 2026-05-19 — RC14 overnight compound (53 GB swap + 71 GB compressor)
- 2026-06-02 — RC14 stuck-worker variant (worker 4.4× past TTL,
  single-process RSS 55 % of RAM)
- 2026-06-02 — repeat panic captured live during the architecture
  writeup (see dryvist/docs-starlight#22)
- 2026-06-02 — another panic during this PR's smoke test (below)

## Smoke test (live on the reference host)

Ran the script directly with `MLX_LAUNCHD_LABEL=dev.vllm-mlx.server`
against the actual stuck-worker state:

```text
2026-06-02T16:58:55 TRIGGER SWAP_PRESSURE swap_used=19245.12MB swap_total=20480.00MB pct=93%
2026-06-02T16:58:55 ACTION launchctl kickstart -k gui/501/dev.vllm-mlx.server
2026-06-02T16:58:56 DONE
```

Result: KeepAlive respawned the manager cleanly within seconds.
Worker resident dropped from 71 GB → 18 GB on the fresh load.

## New module surface

- `programs.mlx.watchdog.enable` (default `true`)
- `programs.mlx.watchdog.intervalSeconds` (default 300)
- `programs.mlx.watchdog.swapThresholdPct` (default 75)
- `programs.mlx.watchdog.rssThresholdPct` (default 50)
- `programs.mlx.watchdog.ttlGraceMult` (default 2)

All five tunable via standard `programs.mlx.watchdog.*` home-manager
options. Set `enable = false` to opt out entirely.

## Files

- `modules/mlx/scripts/mlx-watchdog.sh` — the script (uses native
  `ps`, `awk`, `jq`, `sysctl`, `top`, `launchctl` only)
- `modules/mlx/packages.nix` — `writeShellApplication` wrapper
- `modules/mlx/launchd.nix` — second LaunchAgent under
  `cfg.watchdog.enable` + newsyslog entries for the watchdog logs
- `modules/mlx/options-runtime.nix` — `watchdog` sub-options

## Test plan

- [x] `nix flake check --no-build` passes
- [x] `nix fmt` clean
- [x] `bash -n` syntax check passes
- [x] Live smoke test fired correctly on swap pressure
- [x] Live kick → KeepAlive respawn → fresh worker load
- [ ] After merge + `darwin-rebuild switch`: `launchctl print
      gui/$(id -u)/dev.vllm-mlx.server.watchdog` shows
      `state = waiting`; `~/Library/Logs/vllm-mlx/watchdog.log`
      accumulates entries every 5 min
- [ ] After 1 day of operation: no panics in `vllm-mlx.error.log` go
      unrecovered; any spike in swap/RSS auto-recovers within 5 min

## What this does NOT do (out of scope)

- **Upstream fix**: this is defense-in-depth, not the root-cause fix.
  The upstream `mostlygeek/llama-swap` race at `proxy/process.go:280-289`
  still needs a real fix (single-line WaitGroup reset per spawn cycle).
- **Per-model `ttl` overrides**: still a single uniform 3600 s. Worth
  a follow-up PR to shorten TTLs for the larger models (122B, 80B).
- **Caller-side rate limiting**: a separate concern for Screenpipe
  pipes that re-hit the same model every ~5 min.

Refs: closes JacobPEvans/nix-ai#801 (defensively),
dryvist/docs-starlight#22, dryvist/nix-mac-performance#21