### PR TITLE
fix(claude): restore ccstatusline statusline theme

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -312,6 +312,10 @@ in
 
     statusline = {
       enable = true;
+      # ccstatusline (sirmalloc/ccstatusline) — the statusline that was active
+      # in nix-ai before the nix-claude-code migration. Pinned explicitly so it
+      # does not fall back to nix-claude-code's powerline default.
+      theme = "ccstatusline";
     };
 
     # Hooks: Event-driven automation for Claude Code.


### PR DESCRIPTION
## What

Pin `programs.claude.statusline.theme = "ccstatusline"`.

## Why

The nix-claude-code migration (#851) and the brew-install fix (#871) left the statusline block as `enable = true` with **no theme**, so it fell back to nix-claude-code's **powerline** default — the busy, multi-line statusline. The single-line statusline that was actually active in nix-ai before the migration was **ccstatusline** (`sirmalloc/ccstatusline`); git confirms `claudeStatuslineCcstatusline.enable = true` at the migration commit (`20fbd45^`), with daniel3303 already dropped.

This restores that exact theme. Config is byte-identical to nix-claude-code's `ccstatusline.json`, so `theme = "ccstatusline"` reproduces it 1:1.

## Verification
- `nix flake check` passes.
- `darwin-rebuild switch` verified live: `~/.claude/settings.json` `statusLine.command` resolves to the ccstatusline script (`bunx ccstatusline@^2`), not powerline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)