### PR TITLE
feat(ai-stack): parameterize default local model id; tighten mlx defaults

### DIFF
--- a/lib/ai-stack-models.nix
+++ b/lib/ai-stack-models.nix
@@ -1,17 +1,37 @@
-# AI Stack — Role Registry (thin reader)
+# AI Stack — Role Registry (parameterized reader)
 #
-# Reads the canonical capability-class → physical model ID map from
-# vars/ai-stack.nix. The var file holds all cross-repo runtime data
-# (models, endpoints, nodeports); this helper just exposes the models
-# block in the shape consumers and the lib.aiStackModels flake output
-# already expect.
+# Returns the canonical capability-class → physical model ID map for the
+# host. The role NAMES come from vars/ai-stack.nix (the stable taxonomy).
+# The role VALUES are populated by the caller via `defaultLocalModelId` —
+# the locally-installed physical model id, never hardcoded in this repo.
 #
-# Do NOT add data here. New model entries go in vars/ai-stack.nix.
+# Do NOT add data here. New role names go in vars/ai-stack.nix.
 #
-# Flake-output usage from external consumers (read-only):
-#   inputs.nix-ai.lib.aiStackModels
+# Flake-output usage from external consumers (read-only). NOTE: this is a
+# function now, not a static attrset. Callers must provide the id:
+#
+#   inputs.nix-ai.lib.aiStackModels {
+#     defaultLocalModelId = <sourced from AI_MODEL_LOCAL_LLM>;
+#   }
+#
+# The id itself is stored in:
+#   - GitHub org variable `dryvist.AI_MODEL_LOCAL_LLM`
+#   - Doppler `gh-workflow-tokens` (configs `prd` + `dryvist`),
+#     secret `AI_MODEL_LOCAL_LLM`
+#   - macOS no-password automation keychain, item `AI_MODEL_LOCAL_LLM`
 #
 # Non-Nix consumers (orbstack-kubernetes, ansible, shell scripts) should
 # read ~/.config/ai-stack/registry.json instead — that file is written
-# from the same var file by home-manager activation.
-(import ../vars/ai-stack.nix).models
+# from the configured `services.aiStack.models` (already populated) by
+# home-manager activation.
+
+{ defaultLocalModelId }:
+let
+  roleNames = builtins.attrNames (import ../vars/ai-stack.nix).models;
+in
+builtins.listToAttrs (
+  map (role: {
+    name = role;
+    value = defaultLocalModelId;
+  }) roleNames
+)

--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -2,9 +2,6 @@
 { pkgs, hmConfig }:
 let
   mlxCfg = hmConfig.config.programs.mlx;
-  # Read the canonical capability-class registry so this regression test
-  # tracks the var file instead of duplicating the model ID.
-  registry = import ../../vars/ai-stack.nix;
 in
 {
   # Verify all expected MLX option paths exist.
@@ -52,9 +49,13 @@ in
           expected = true;
         }
         {
-          name = "mlx.defaultModel";
-          actual = mlxCfg.defaultModel;
-          expected = registry.models.default;
+          # Presence-only check — the actual model id is parameterized via
+          # services.aiStack.defaultLocalModelId and not hardcoded in this
+          # repo. Verifying it's a non-empty string is enough; the consumer
+          # owns the value.
+          name = "mlx.defaultModel-populated";
+          actual = mlxCfg.defaultModel != null && mlxCfg.defaultModel != "";
+          expected = true;
         }
         {
           name = "mlx.port";

--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -27,20 +27,53 @@
 }:
 let
   registryAttrs = import ../../vars/ai-stack.nix;
-  registryJson = pkgs.writeText "ai-stack-registry.json" (builtins.toJSON registryAttrs);
+  # The populated registry replaces the var file's null-sentinel `models`
+  # block with the actual role → id map computed from
+  # services.aiStack.defaultLocalModelId. The JSON written to
+  # ~/.config/ai-stack/registry.json contains the materialized values so
+  # non-Nix consumers (orbstack-kubernetes, ansible, shell scripts) read a
+  # complete registry.
+  populatedRegistry = registryAttrs // {
+    models = config.services.aiStack.models;
+  };
+  registryJson = pkgs.writeText "ai-stack-registry.json" (builtins.toJSON populatedRegistry);
 in
 {
+  options.services.aiStack.defaultLocalModelId = lib.mkOption {
+    type = lib.types.str;
+    example = "mlx-community/<provider-tag>-<model-name>-<quant>";
+    description = ''
+      Local MLX physical model id used as the single resident model for
+      every role in `services.aiStack.models`. Sourced by the consuming
+      configuration (typically `nix-darwin`) from the dryvist
+      `AI_MODEL_LOCAL_LLM` org variable / Doppler secret / macOS
+      no-password automation keychain. **Never hardcoded in this repo.**
+
+      The deliberate posture: one model resident, every alias pointing
+      at it, swap-thrash impossible. To introduce per-role
+      differentiation later, override `services.aiStack.models` directly
+      or change the role-population logic in `modules/ai-stack/default.nix`.
+    '';
+  };
+
   options.services.aiStack.models = lib.mkOption {
     type = lib.types.attrsOf lib.types.str;
-    default = import ../../lib/ai-stack-models.nix;
+    default = import ../../lib/ai-stack-models.nix {
+      inherit (config.services.aiStack) defaultLocalModelId;
+    };
+    defaultText = lib.literalExpression ''
+      import ../../lib/ai-stack-models.nix {
+        inherit (config.services.aiStack) defaultLocalModelId;
+      }
+    '';
     description = ''
-      Role-name → physical mlx-community/* model ID. Each role becomes a
-      first-class llama-swap entry whose cmd runs `vllm-mlx serve <physical>`.
-      Physical names also remain queryable for direct curl / debugging.
+      Role-name → physical model ID map. Each role becomes a first-class
+      llama-swap entry whose cmd runs `vllm-mlx serve <physical>`.
 
-      The default reads from vars/ai-stack.nix. To change the registry,
-      edit that file. Override here only when a consumer needs a private
-      mapping that should not propagate to ~/.config/ai-stack/registry.json.
+      Default: every role resolves to `services.aiStack.defaultLocalModelId`
+      (read via `lib/ai-stack-models.nix`). Override here only when a
+      consumer needs a private mapping that should not propagate to
+      `~/.config/ai-stack/registry.json`.
     '';
   };
 

--- a/modules/mlx/options-batching.nix
+++ b/modules/mlx/options-batching.nix
@@ -76,8 +76,8 @@
     # bounding wasted compute on a pathologically misconfigured caller).
     maxRequestTokens = lib.mkOption {
       type = lib.types.nullOr lib.types.ints.positive;
-      default = null;
-      description = "Hard cap on max_tokens accepted from clients. Null = vllm-mlx server default: 32768.";
+      default = 8192;
+      description = "Hard cap on max_tokens accepted from clients. Null = vllm-mlx server default (32768). Default 8192 — rejects callers that request runaway generation lengths before they wait 5+ minutes for a `disconnect_guard` timeout. Tightened from `null` after the 2026-05-29 → 2026-06-03 pipe-timeout storm where pipes sending 80K-token prompts dominated the queue.";
     };
   };
 }

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -63,8 +63,8 @@
       };
       idleTtl = lib.mkOption {
         type = lib.types.ints.unsigned;
-        default = 3600;
-        description = "Idle TTL in seconds applied uniformly to every model in the registry (including the default-aliased one). 0 = never auto-unload (escape hatch). Default 3600 s (1 hour) gives a long warm window without permanently wiring a model's weights.";
+        default = 1800;
+        description = "Idle TTL in seconds applied uniformly to every model in the registry (including the default-aliased one). 0 = never auto-unload (escape hatch). Default 1800 s (30 min) — a bounded warm window. Tightened from the prior 3600 s default after the recurring `nix-ai#801` stuck-past-TTL family of incidents; shorter windows mean less time exposed when the upstream `llama-swap` race fires during unload.";
       };
       logLevel = lib.mkOption {
         type = lib.types.enum [
@@ -100,22 +100,26 @@
       };
       concurrencyLimit = lib.mkOption {
         type = lib.types.ints.positive;
-        default = 4;
+        default = 2;
         description = ''
           Max in-flight requests llama-swap will forward to vllm-mlx per
           model. Maps directly to the YAML key llama-swap reads
           (`concurrencyLimit`); excess requests get HTTP 429.
 
-          Default 4 matches `maxNumSeqs = 4` so vllm-mlx continuous batching
-          stays fully utilized (1.5x–3x throughput on M4 Max 128 GB per
-          upstream benchmarks) while still bounding runaway callers so they
-          can't pile on faster than vllm-mlx can schedule. The 2026-05-15
-          finish_reason:error incident is tracked separately as a vllm-mlx
-          scheduler bug — a proxy-side cap is the safety valve, not the fix.
+          Default 2 — serializes bursts so a multi-pipe / multi-tool storm
+          can't fan out parallel calls that pile on faster than vllm-mlx
+          can schedule. Tightened from the prior 4 after the 2026-05-29
+          → 2026-06-03 pipe-timeout storm where bursts of concurrent
+          callers saturated the disconnect_guard window. The 2026-05-15
+          finish_reason:error incident remains tracked separately as a
+          vllm-mlx scheduler bug.
 
-          Setting this to 1 silently defeats continuous batching and is
-          almost never what you want; raise it only if vllm-mlx adds more
-          headroom (and bump `maxNumSeqs` in lockstep).
+          The trade-off: a value below `maxNumSeqs` slightly under-utilizes
+          continuous batching (1.5x–3x throughput peak). On this host the
+          stability win dominates. Bump only if you observe sustained
+          queue depth at the proxy without thrash.
+
+          Setting this to 1 silently defeats continuous batching.
         '';
       };
     };

--- a/vars/ai-stack.nix
+++ b/vars/ai-stack.nix
@@ -23,17 +23,30 @@
 #     docs/architecture/per-agent-flakes.md) when the schema changes,
 #     so the JSON shape stays self-explanatory.
 {
-  # Capability-class registry. Stable consumer-facing names mapped to
-  # currently-preferred physical mlx-community/* model IDs. Physical IDs
-  # change when we re-benchmark or upstream ships a better quant.
+  # Capability-class registry. The role NAMES are the stable taxonomy
+  # consumers depend on. The role VALUES are populated at evaluation time
+  # by modules/ai-stack/default.nix from `services.aiStack.defaultLocalModelId`
+  # (sourced by the consuming configuration from the dryvist
+  # `AI_MODEL_LOCAL_LLM` org variable / Doppler secret / macOS no-password
+  # automation keychain — never hardcoded in this repo).
+  #
+  # Every role currently resolves to the same physical model id: the
+  # locally-installed default. That is the deliberate posture — one model
+  # resident, every alias pointing at it, swap-thrash impossible. To
+  # introduce per-role differentiation later, change the population logic
+  # in modules/ai-stack/default.nix.
+  #
+  # Reading these `null` values directly (without going through the
+  # services.aiStack.models option) will surface as obvious nulls in
+  # downstream config — the option layer is the only correct read path.
   models = {
-    default = "mlx-community/Qwen3.6-35B-A3B-mxfp4";
-    quickest = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-    tool-calling = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-    coding = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-    large-context = "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit";
-    most-capable = "mlx-community/Qwen3.5-122B-A10B-4bit";
-    oss = "mlx-community/gpt-oss-120b-4bit";
+    default = null;
+    quickest = null;
+    tool-calling = null;
+    coding = null;
+    large-context = null;
+    most-capable = null;
+    oss = null;
   };
 
   # Well-known local endpoints. Filled in over Phase 2 as drift sites get


### PR DESCRIPTION
## Summary

Collapses the 7-role capability-class model registry to ONE configurable
physical model id, sourced by the consuming configuration (not hardcoded
in this repo). Tightens three mlx defaults that drove the
2026-05-29 → 2026-06-03 pipe-timeout storm and the recurring `nix-ai#801`
stuck-past-TTL family.

## Why

Multi-day-uptime memory pressure on the reference host (M4 Max 128 GB)
was driven by the 16-entry model registry letting any caller swap to
any model on demand. Each swap = 20-60 s cold load + multi-GB wired GPU
page tables. Concurrent callers (Claude Code via PAL/Bifrost, Qwen Code,
Fabric, Raycast, Screenpipe pipes) fanned across **22 distinct model
ids in a single 24-hour window** measured 2026-06-03. Pipes calling the
same model queued behind swap thrash and hit the 300 s
`disconnect_guard`.

This PR collapses the registry to one resident model. Every alias
points at it. Anything else 404s.

## What changes

- `vars/ai-stack.nix`: \`models.<role>\` values become \`null\`. The role
  names remain the stable taxonomy consumers depend on; the values are
  populated at evaluation time by `modules/ai-stack/default.nix`.
- `lib/ai-stack-models.nix`: now a function
  \`{ defaultLocalModelId }: { ... }\` that materializes the
  role → id map. **Breaking change** for any external consumer of
  \`inputs.nix-ai.lib.aiStackModels\` — must pass the arg.
- `modules/ai-stack/default.nix`: declares the new required option
  `services.aiStack.defaultLocalModelId` (no default — throws if unset).
  `services.aiStack.models` default reads from the new lib function.
  The activation that writes \`~/.config/ai-stack/registry.json\`
  continues to ship a populated registry.
- `lib/checks/mlx.nix`: `mlx.defaultModel` check is now a presence check
  (non-null + non-empty) since the value is parameterized, not hardcoded.
- `modules/mlx/options-runtime.nix`:
  - `proxy.idleTtl` default 3600 → 1800 (30 min — bounded warm window)
  - `proxy.concurrencyLimit` default 4 → 2 (serialize bursts)
- `modules/mlx/options-batching.nix`:
  - `maxRequestTokens` default \`null\` → 8192 (reject runaway prompts)

## Where the value lives (not in this repo)

The local model id is stored in three places:

- GitHub org variable \`dryvist.AI_MODEL_LOCAL_LLM\`
- Doppler \`gh-workflow-tokens\` project, configs \`prd\` and \`dryvist\`,
  secret \`AI_MODEL_LOCAL_LLM\`
- macOS no-password automation keychain item \`AI_MODEL_LOCAL_LLM\`

A separate \`nix-darwin\` PR will wire this into
\`services.aiStack.defaultLocalModelId\` at activation time.

## Test plan

- [x] \`nix flake check --no-build\` passes
- [x] \`git grep 'mlx-community/[A-Z]'\` returns zero matches in tracked nix files
- [x] No literal physical model id in this PR (this body included)
- [ ] After merge + consumer wiring + \`darwin-rebuild switch\`:
      \`curl localhost:11434/v1/models | jq '.data | length'\` returns 1
- [ ] After merge: 404 for any non-default model id
- [ ] After merge: \`vm.swapusage\` trends down as fewer models stay resident

## No auto-merge

Sits open for review. Per session-saved memory, I will not call
\`gh pr merge\`.

Refs: dryvist/docs-starlight#22 (architecture writeup),
dryvist/nix-mac-performance#21 (operational tracker),
JacobPEvans/nix-ai#801 (upstream llama-swap race condition)