### PR TITLE
fix(claude): remove statusline entirely

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -310,14 +310,6 @@ in
         };
       };
 
-    statusline = {
-      enable = true;
-      # ccstatusline (sirmalloc/ccstatusline) — the statusline that was active
-      # in nix-ai before the nix-claude-code migration. Pinned explicitly so it
-      # does not fall back to nix-claude-code's powerline default.
-      theme = "ccstatusline";
-    };
-
     # Hooks: Event-driven automation for Claude Code.
     # captureSessionOutput wires postToolUse to the vendored capture script.
     # refreshMarketplaces wires sessionStart to the vendored refresh helper.


### PR DESCRIPTION
## Summary

- Removes the `statusline` block from `claude-config.nix` entirely
- `programs.claude.statusline.enable` defaults to `false` via `mkEnableOption`, so no explicit opt-out is needed
- The ccstatusline UI has been toggling back on across rebuilds; this ends that cycle permanently

After `darwin-rebuild switch`, the statusline should be completely gone from all new Claude Code sessions.

Assisted-by: Claude:claude-sonnet-4-6