### PR TITLE
fix(ci): quote workflow_dispatch description to avoid YAML parse error

### DIFF
--- a/.github/workflows/update-flake-input.yml
+++ b/.github/workflows/update-flake-input.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       input_name:
-        description: Flake input to update (default: nix-claude-code)
+        description: "Flake input to update (default: nix-claude-code)"
         type: string
         default: nix-claude-code
 


### PR DESCRIPTION
## Summary

- The `description` field in `workflow_dispatch.inputs.input_name` contained a
  colon-space inside `(default: nix-claude-code)`, which YAML 1.1 treats as a
  nested mapping value — making the entire file unparseable
- An unparseable workflow file cannot register its `on:` triggers, so inbound
  `repository_dispatch` events silently no-op'd (propagation dead) and every
  `push` produced a zero-job failure
- Fix: wrap the description in double-quotes — one character change, verified
  clean with `actionlint`

## Test plan

- [x] `actionlint` exits 0 on the fixed file
- [ ] After merge: confirm the next `push` to `main` triggers a `release-please`
  run (previously zero-job failure)
- [ ] After next nix-claude-code release: confirm `repository_dispatch` is received
  and the `update-flake-input` job fires

Refs: dryvist/nix-darwin#1188 dryvist/nix-claude-code#47 dryvist/nix-home#284

🤖 Generated with [Claude Code](https://claude.com/claude-code)