### PR TITLE
chore(claude): switch model default from opusplan to default

### DIFF
--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -109,7 +109,7 @@ in
         {
           name = "model";
           actual = cfg.model;
-          expected = "opusplan";
+          expected = "default";
         }
         {
           name = "effortLevel";

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -136,8 +136,9 @@ in
       # scriptPath default: .local/bin/claude-api-key-helper
     };
 
-    # Model: opusplan — Opus for planning, Sonnet for execution (1M context).
-    model = "opusplan";
+    # Model: default — clears any override; reverts to the account tier's
+    # recommended model. Override manually via /model when needed.
+    model = "default";
 
     # Effort: high — maximize reasoning quality by default.
     effortLevel = "high";

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -7,7 +7,7 @@
 # See: https://code.claude.com/docs/en/settings
 # See: https://code.claude.com/docs/en/model-config
 {
-  # Model: opusplan set above. Env var overrides available if needed.
+  # Model: default set above. Env var overrides available if needed.
   # ANTHROPIC_MODEL = "sonnet"; # Uncomment to override default model via env var
   # CLAUDE_CODE_SUBAGENT_MODEL = "claude-haiku-4-5-20251001"; # Cost control for subagents
 


### PR DESCRIPTION
## Summary

- Replaces `model = "opusplan"` with `model = "default"` in `modules/claude-config.nix`
- Updates the defaults-regression assertion in `lib/checks/claude.nix` to expect `"default"`
- Cleans up the `opusplan` reference in the `modules/claude/settings-env.nix` comment

`"default"` clears any model override and reverts to the account tier's recommended model (Opus 4.8 on Max/API tiers). `opusplan` is still available via `/model` when needed. `effortLevel = "high"` is unchanged.

## Test plan

- [x] `nix flake check --no-build` passes locally (Darwin)
- [x] `nix fmt` — 0 files changed
- [x] Zero `opusplan` references remain
- [ ] CI: defaults-regression check asserts `cfg.model == "default"` on x86_64-linux
- [ ] After `darwin-rebuild switch`: fresh `claude` session shows Default model at high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)