### PR TITLE
fix(ci): repair ai-stack & mlx regression checks after #878

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,16 @@ nix-ai exports [home-manager](https://github.com/nix-community/home-manager) mod
 | `homeManagerModules.maestro` | Just Maestro orchestration |
 | `lib.ci.claudeSettingsJson` | Pure JSON for CI validation (no derivations needed) |
 | `lib.ci.codexRules` | Codex rules export for CI validation and downstream consumers |
-| `lib.aiStackModels` | Role-name → physical model ID registry (plain attrset, no module system needed) |
+| `lib.aiStackModels` | Role-name → physical model ID registry builder — a function `{ defaultLocalModelId }` (no module system needed) |
 
 ### Cross-repo consumption — `lib.aiStackModels`
 
-`lib.aiStackModels` is a plain attrset (no home-manager module system required) mapping stable
-capability-class names to physical `mlx-community/*` model IDs. Foreign consumers such as the
-orbstack-kubernetes Bifrost gateway can import it directly so `model: "default"` resolves
-prefix-free without duplicating the registry.
+`lib.aiStackModels` is a function `{ defaultLocalModelId }` (no home-manager module system
+required) that maps every stable capability-class name to the supplied physical
+`mlx-community/*` model ID. The caller provides `defaultLocalModelId` (sourced from the
+`AI_MODEL_LOCAL_LLM` org variable / Doppler secret — never hardcoded in this repo). Foreign
+consumers such as the orbstack-kubernetes Bifrost gateway can call it directly so
+`model: "default"` resolves prefix-free without duplicating the registry.
 
 ```nix
 inputs.nix-ai.url = "github:JacobPEvans/nix-ai";
@@ -79,7 +81,7 @@ inputs.nix-ai.url = "github:JacobPEvans/nix-ai";
 # Build Bifrost alias table from role names to mlx-local/ prefixed physical IDs
 aliases = lib.mapAttrs
   (_role: physical: "mlx-local/${physical}")
-  inputs.nix-ai.lib.aiStackModels;
+  (inputs.nix-ai.lib.aiStackModels { defaultLocalModelId = "mlx-community/<provider-tag>-<model-name>-<quant>"; });
 ```
 
 The module option `services.aiStack.models` remains the public API for nix-ai home-manager

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -9,6 +9,13 @@
   pal-mcp-server,
 }:
 let
+  # Placeholder physical model id for regression tests. The real value is
+  # sourced by consumers (nix-darwin) from AI_MODEL_LOCAL_LLM; tests only need
+  # a valid non-empty mlx-community/* string to populate services.aiStack and
+  # exercise lib/ai-stack-models.nix (a function since the role registry was
+  # parameterized).
+  testLocalModelId = "mlx-community/test-model";
+
   # Shared test module configuration — used by claude, mlx, and fabric regression checks
   hmConfig = home-manager.lib.homeManagerConfiguration {
     inherit pkgs;
@@ -18,6 +25,7 @@ let
         _module.args.userConfig = {
           user.fullName = "JacobPEvans";
         };
+        services.aiStack.defaultLocalModelId = testLocalModelId;
         home = {
           username = "test-user";
           homeDirectory = "/home/test-user";
@@ -37,6 +45,7 @@ let
         _module.args.userConfig = {
           user.fullName = "JacobPEvans";
         };
+        services.aiStack.defaultLocalModelId = testLocalModelId;
         home = {
           username = "test-user";
           homeDirectory = "/home/test-user";
@@ -48,7 +57,7 @@ let
   };
 in
 (import ./checks/lint.nix { inherit pkgs src; })
-// (import ./checks/ai-stack.nix { inherit pkgs; })
+// (import ./checks/ai-stack.nix { inherit pkgs testLocalModelId; })
 // (import ./checks/claude.nix { inherit pkgs hmConfig; })
 // (import ./checks/agent-skills.nix { inherit pkgs hmConfig; })
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })

--- a/lib/checks/ai-stack.nix
+++ b/lib/checks/ai-stack.nix
@@ -1,8 +1,10 @@
 # lib.aiStackModels regression tests
 # Verifies the role → physical-id registry that is exported as a public flake output.
-{ pkgs }:
+# ai-stack-models.nix is a function (parameterized by defaultLocalModelId); the
+# aggregator passes a placeholder test id so the registry can be materialized.
+{ pkgs, testLocalModelId }:
 let
-  models = import ../ai-stack-models.nix;
+  models = import ../ai-stack-models.nix { defaultLocalModelId = testLocalModelId; };
 
   expectedRoles = [
     "coding"

--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -80,12 +80,12 @@ in
         {
           name = "mlx.proxy.idleTtl";
           actual = mlxCfg.proxy.idleTtl;
-          expected = 3600;
+          expected = 1800;
         }
         {
           name = "mlx.proxy.concurrencyLimit";
           actual = mlxCfg.proxy.concurrencyLimit;
-          expected = 4;
+          expected = 2;
         }
         {
           name = "mlx.prefillBatchSize";


### PR DESCRIPTION
## Summary

Restores the x86_64-linux `nix flake check` (`Nix Validate`), which has been **red on `main` since #878** ("parameterize default local model id; tighten mlx defaults"). The breakage was invisible locally because darwin `nix flake check` omits the `x86_64-linux` checks, and `CI Gate` only runs on pull requests — so every PR inherited the red, but no main-push run surfaced it.

#878 made three changes without updating their dependents:

1. `lib/ai-stack-models.nix` became a function `{ defaultLocalModelId }`, but `lib/checks/ai-stack.nix` still `import`ed it as a set → `error: expected a set but found a function`.
2. The shared test `hmConfig` never set `services.aiStack.defaultLocalModelId` (no default), so `programs.mlx.defaultModel` → `services.aiStack.models.default` threw `option has no value`.
3. #878 tightened `proxy.idleTtl` 3600→1800 and `proxy.concurrencyLimit` 4→2, but `mlx-defaults-regression` still asserted the old values.

## Changes

- `lib/checks.nix`: add a shared `testLocalModelId` placeholder, set `services.aiStack.defaultLocalModelId` on both test configs, and pass the id into the ai-stack check.
- `lib/checks/ai-stack.nix`: call the now-parameterized function with the test id.
- `lib/checks/mlx.nix`: align `idleTtl`/`concurrencyLimit` expectations with the tightened module defaults.
- `README.md`: document `lib.aiStackModels` as a function (not a plain attrset).

## Test Plan

- [x] `nix fmt` — clean
- [x] `nix flake check` (darwin) — passes
- [x] Evaluated every assert-based `x86_64-linux` check locally (ai-stack, mlx, codex, gemini, fabric, agent-skills) — all pass
- [ ] CI `Nix Validate` green on this PR

Refs: #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)