### PR TITLE
docs(ai-stack): correct defaultLocalModelId sourcing note

### DIFF
--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -44,10 +44,10 @@ in
     example = "mlx-community/<provider-tag>-<model-name>-<quant>";
     description = ''
       Local MLX physical model id used as the single resident model for
-      every role in `services.aiStack.models`. Sourced by the consuming
-      configuration (typically `nix-darwin`) from the dryvist
-      `AI_MODEL_LOCAL_LLM` org variable / Doppler secret / macOS
-      no-password automation keychain. **Never hardcoded in this repo.**
+      every role in `services.aiStack.models`. Supplied by the consuming
+      configuration (typically `nix-darwin`) — e.g. committed in the
+      consumer's user config, or injected via env/secret for CI.
+      **Never hardcoded in this repo.**
 
       The deliberate posture: one model resident, every alias pointing
       at it, swap-thrash impossible. To introduce per-role


### PR DESCRIPTION
The `services.aiStack.defaultLocalModelId` option description listed "dryvist AI_MODEL_LOCAL_LLM org variable / Doppler secret / macOS no-password automation keychain" as the value sources. The primary consumer (nix-darwin) now commits the value in its user config (dryvist/nix-darwin#1198), so that list is stale.

Reworded to "supplied by the consuming configuration … e.g. committed in the consumer's user config, or injected via env/secret for CI" — keeps the consumer-supplies-it contract and the **never hardcoded in this repo** invariant without prescribing stale specifics. Comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)