### PR TITLE
fix(claude): restore opusplan model, enable traces, clean up moot settings

### DIFF
--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -107,11 +107,9 @@ in
           expected = 180;
         }
         {
-          # Intentionally unset → null → Claude Code uses the account-tier
-          # default. The literal "default" is invalid and Claude Code rejects it.
           name = "model";
           actual = cfg.model;
-          expected = null;
+          expected = "opusplan";
         }
         {
           # Intentionally unset → null → Claude Code uses the upstream default.

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -136,10 +136,8 @@ in
       # scriptPath default: .local/bin/claude-api-key-helper
     };
 
-    # Model intentionally left unset: nix-claude-code defaults `model` to null,
-    # which Claude Code reads as the account-tier default. (The literal string
-    # "default" is NOT a valid model — Claude Code rejects it as missing.)
-    # Override per-session via /model, or via ANTHROPIC_MODEL in settings-env.nix.
+    # Model: opusplan — Opus for planning, Sonnet for execution (1M context).
+    model = "opusplan";
 
     # Effort intentionally left unset: nix-claude-code defaults `effortLevel`
     # to null, which Claude Code reads as the upstream default. Override
@@ -148,8 +146,8 @@ in
     # Enable Remote Control for all sessions (Feb 2026 feature).
     remoteControlAtStartup = true;
 
-    # Auto-approve CLAUDE.md external imports for all repos discovered under ~/git/.
-    trustedProjectDirs = [ "~/git" ];
+    # Auto-approve CLAUDE.md external imports for all repos discovered under ~/git/public/.
+    trustedProjectDirs = [ "~/git/public/" ];
 
     # Commit trailer per https://docs.kernel.org/process/coding-assistants.html.
     attribution = {
@@ -251,11 +249,6 @@ in
 
       sandbox = {
         enabled = false;
-        excludedCommands = [
-          "git"
-          "nix"
-          "darwin-rebuild"
-        ];
       };
     };
 

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -32,9 +32,6 @@
   # See: https://code.claude.com/docs/en/agent-teams
   CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
 
-  # Adaptive thinking for Opus/Sonnet (explicitly enabled)
-  CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "0";
-
   # DEFAULT VALUES (upstream) - reference only, do not uncomment unless tuning
   # MAX_THINKING_TOKENS = "31999";
   # CLAUDE_CODE_MAX_OUTPUT_TOKENS = "32000";
@@ -65,5 +62,5 @@
   OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
   OTEL_METRICS_EXPORTER = "otlp";
   OTEL_LOGS_EXPORTER = "otlp";
-  OTEL_TRACES_EXPORTER = "none"; # Only metrics + logs; no trace overhead
+  OTEL_TRACES_EXPORTER = "otlp";
 }


### PR DESCRIPTION
## Summary

- Restores `model = "opusplan"` (Opus for planning, Sonnet for execution) after the account-default experiment; `effortLevel` stays unset (upstream default)
- `trustedProjectDirs`: `~/git` → `~/git/public/` to exclude private repos from auto-trust
- `sandbox.excludedCommands`: removed — moot while `sandbox.enabled = false`
- `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`: removed — upstream default is already on, no need to explicitly set `"0"`
- `OTEL_TRACES_EXPORTER`: `none` → `otlp` — enables the full metrics + logs + traces OTEL pipeline

Regression test updated to expect `"opusplan"` for `model`.

## Test plan

- [ ] `nix flake check` passes (defaults-regression expects `"opusplan"`)
- [ ] After `darwin-rebuild switch`, `/model` shows `opusplan` in a fresh Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)