### PR TITLE
feat: declare AI-tool Homebrew taps/casks and trust.json in nix-ai

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
         "x86_64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      homebrewNix = import ./lib/homebrew.nix;
     in
     {
       homeManagerModules = import ./flake/home-manager-modules.nix {
@@ -193,6 +194,12 @@
         brewFormulae = [
           "qwen-code" # programs.qwen-code with installVia = "brew"
         ];
+
+        # AI-tool Homebrew taps and casks. nix-darwin merges these into
+        # homebrew.taps and homebrew.casks. Source of truth: lib/homebrew.nix
+        # (same file drives the trust.json written by the home-manager module).
+        homebrewTaps = homebrewNix.taps;
+        homebrewCasks = homebrewNix.casks;
 
         # Shared permission + formatter engine. Exposed for cross-flake consumers
         # (e.g., nix-ai-claude) so the source of truth for tool-agnostic command

--- a/lib/homebrew.nix
+++ b/lib/homebrew.nix
@@ -1,0 +1,33 @@
+# AI tool Homebrew taps and casks managed by nix-ai.
+# Single source of truth consumed by:
+#   - flake.nix lib exports  → nix-darwin homebrew.nix (taps + casks)
+#   - modules/default.nix   → ~/.homebrew/trust.json (macOS only)
+#
+# Homebrew 5.2.0/6.0.0 enforces HOMEBREW_REQUIRE_TAP_TRUST. Having the tap
+# list here means adding a new AI tap is one edit that updates both the
+# nix-darwin tap declaration and the trust.json simultaneously.
+{
+  taps = [
+    "anthropics/tap" # claude-code@latest
+    "google/antigravity" # antigravity suite
+  ];
+
+  casks = [
+    {
+      name = "claude-code@latest";
+      greedy = true;
+    }
+    {
+      name = "antigravity";
+      greedy = true;
+    }
+    {
+      name = "antigravity-cli";
+      greedy = true;
+    }
+    {
+      name = "antigravity-ide";
+      greedy = true;
+    }
+  ];
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -52,6 +52,19 @@ let
 
   versions = import ../lib/versions.nix;
   browserUseVersion = versions.browserUse;
+
+  homebrewCfg = import ../lib/homebrew.nix;
+
+  # ~/.homebrew/trust.json — macOS only. Homebrew 5.2.0/6.0.0 enforces
+  # HOMEBREW_REQUIRE_TAP_TRUST; pre-trust the AI-tool taps declared in
+  # lib/homebrew.nix so brew bundle keeps working when the default flips.
+  # Read-only Nix store symlink is intentional — add new taps in
+  # lib/homebrew.nix; never run brew trust directly.
+  brewTrustFiles = lib.optionalAttrs pkgs.stdenv.isDarwin {
+    ".homebrew/trust.json".text = builtins.toJSON {
+      trustedtaps = homebrewCfg.taps;
+    };
+  };
 in
 {
   imports = [
@@ -83,7 +96,7 @@ in
       # AI development tools (MCP servers, linters, CLI wrappers)
       inherit (import ./ai-tools.nix { inherit pkgs; }) packages;
 
-      file = copilotFiles // agentsMdSymlinks;
+      file = copilotFiles // agentsMdSymlinks // brewTrustFiles;
 
       activation = {
         # Claude Code Settings Validation (post-rebuild)


### PR DESCRIPTION
## Summary

- Adds `lib/homebrew.nix` as the single source of truth for the Homebrew taps and casks nix-ai owns (`anthropics/tap`, `google/antigravity` and their four casks).
- Exports `lib.homebrewTaps` and `lib.homebrewCasks` from `flake.nix` for nix-darwin to consume (same pattern as the existing `lib.brewFormulae`).
- Writes `~/.homebrew/trust.json` via `home.file` in `modules/default.nix` so Homebrew pre-trusts those taps before the 5.2.0/6.0.0 `HOMEBREW_REQUIRE_TAP_TRUST` enforcement.

The trust.json is a read-only Nix store symlink — adding a new AI tap means editing `lib/homebrew.nix` once; the tap declaration and trust entry stay in lockstep automatically.

## Merge Order

This PR merges **before** the companion nix-darwin PR (`dryvist/nix-darwin` `feat/homebrew-from-nix-ai`), which switches nix-darwin off its hardcoded tap/cask list and onto these new lib exports.

## Related Issues

No open issue tracks this — the original trigger was Homebrew 5.1.15 warning:
```
Warning: The following taps are not trusted: anthropics/tap
```

## Test Plan

- [ ] CI passes (module eval + deadnix + statix + flake check)
- [ ] After merge and nix-darwin flake.lock bump: `cat ~/.homebrew/trust.json` shows both taps
- [ ] `brew update` no longer warns about untrusted `anthropics/tap` or `google/antigravity`