### PR TITLE
test(checks): guard against hardcoded MLX model ids in nix-ai

### DIFF
--- a/lib/checks/lint.nix
+++ b/lib/checks/lint.nix
@@ -44,4 +44,26 @@
     ' bash
     touch $out
   '';
+
+  # Guard: physical MLX model ids belong only in the runtime registry
+  # (services.aiStack.defaultLocalModelId, sourced from AI_MODEL_LOCAL_LLM).
+  # Every consumer references a capability role, never a hardcoded id — so a
+  # model swap touches only the registry. Allowed: the "mlx-community/<...>"
+  # placeholder in option examples and the "test-model" id in the check harness.
+  # lib/checks/* is excluded since it names the pattern itself.
+  no-hardcoded-model-id = pkgs.runCommand "check-no-hardcoded-model-id" { } ''
+    cd ${src}
+    bad=$(grep -rnoE 'mlx-community/[A-Za-z0-9][^[:space:]"]*' \
+      --include='*.nix' --include='*.sh' --include='*.md' \
+      --exclude-dir=.git --exclude-dir=result --exclude-dir=.direnv . \
+      | grep -vE 'lib/checks' \
+      | grep -vE 'mlx-community/test-model' || true)
+    if [ -n "$bad" ]; then
+      echo "ERROR: hardcoded physical MLX model id(s) found — use an ai-stack capability role instead:" >&2
+      echo "$bad" >&2
+      exit 1
+    fi
+    echo "no hardcoded mlx-community/* model ids outside the registry/SSOT"
+    touch $out
+  '';
 }

--- a/modules/fabric/options.nix
+++ b/modules/fabric/options.nix
@@ -41,8 +41,8 @@
         services.aiStack.models. Routes through the local MLX stack at
         http://127.0.0.1:11434/v1.
 
-        Override to a cloud provider model name (e.g. "claude-3-5-sonnet-20241022",
-        "gpt-4o", "gemini-1.5-pro") but be aware fabric needs API keys
+        Override to a cloud provider model id (any Claude, Gemini, or GPT model
+        your provider exposes) but be aware fabric needs API keys
         configured in ~/.config/fabric/.env for those backends.
       '';
     };


### PR DESCRIPTION
Part of the **Local LLM Stack** registry single-source effort (Linear JAC-107, milestone M0 — Registry SSOT). Sibling to dryvist/ai-assistant-instructions#673/#675 and dryvist/claude-code-plugins#346, which de-drifted the consumer docs.

## What
The ai-stack registry (`vars/ai-stack.nix` → `~/.config/ai-stack/registry.json`) is already the SSOT for the resident model, but nothing stopped a physical id from being hardcoded into a module/script/doc. This adds a `lib/checks/lint.nix` source guard (`no-hardcoded-model-id`) that fails `nix flake check` if a real `mlx-community/<id>` literal appears outside the registry.

## How
- Greps the flake source for `mlx-community/[A-Za-z0-9]...` (real ids — wildcards/namespace mentions like `mlx-community/*` are ignored).
- Allowlists `lib/checks/*` (it names the pattern), the `mlx-community/<...>` option-example placeholder, and the `test-model` harness id.
- Also genericizes the fabric `defaultModel` examples — dropped versioned cloud ids (`gpt-4o`, `gemini-1.5-pro`, a dated Claude id) per the no-model-numbers rule.

## Validation
- `nix fmt`: 0 files changed (already clean).
- Guard derivation **evaluates** (`drvPath` resolves) — wiring valid.
- The guard's grep logic, run against the working tree, returns **no matches** → passes.
- Note: checks are scoped to `x86_64-linux`; couldn't execute the sandboxed build on this aarch64-darwin host (no linux builder), so **CI runs it for real**.

Refs JAC-107

🤖 Generated with [Claude Code](https://claude.com/claude-code)