### PR TITLE
fix(homebrew): drop nonexistent google/antigravity tap

### DIFF
--- a/lib/homebrew.nix
+++ b/lib/homebrew.nix
@@ -9,7 +9,6 @@
 {
   taps = [
     "anthropics/tap" # claude-code@latest
-    "google/antigravity" # antigravity suite
   ];
 
   casks = [
@@ -17,6 +16,7 @@
       name = "claude-code@latest";
       greedy = true;
     }
+    # antigravity suite ships in the default homebrew-cask tap — no vendor tap needed
     {
       name = "antigravity";
       greedy = true;


### PR DESCRIPTION
## Summary

- `github.com/google/homebrew-antigravity` does not exist (404), aborting every `brew bundle` run at the tap-clone step
- All three antigravity casks (`antigravity`, `antigravity-cli`, `antigravity-ide`) ship in the default `Homebrew/homebrew-cask` core tap — no vendor tap is needed
- Remove the one dead `"google/antigravity"` tap entry from `lib/homebrew.nix`; cask declarations unchanged
- `~/.homebrew/trust.json` (`trustedtaps`) auto-updates on next `darwin-rebuild switch` since `modules/default.nix` reads the taps list dynamically

## Test plan

- [ ] `nix eval .#lib.homebrewTaps` returns `[ "anthropics/tap" ]` (google/antigravity gone)
- [ ] `nix eval .#lib.homebrewCasks` still includes all three antigravity casks
- [ ] `nix flake check` passes
- [ ] After `darwin-rebuild switch --override-input nix-ai <worktree>`: `brew bundle` completes without "Tapping google/antigravity" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)