### PR TITLE
fix(homebrew): add aws/tap to trusted taps

### DIFF
--- a/lib/homebrew.nix
+++ b/lib/homebrew.nix
@@ -9,6 +9,7 @@
 {
   taps = [
     "anthropics/tap" # claude-code@latest
+    "aws/tap"
   ];
 
   casks = [

--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -34,7 +34,7 @@ let
   # non-Nix consumers (orbstack-kubernetes, ansible, shell scripts) read a
   # complete registry.
   populatedRegistry = registryAttrs // {
-    models = config.services.aiStack.models;
+    inherit (config.services.aiStack) models;
   };
   registryJson = pkgs.writeText "ai-stack-registry.json" (builtins.toJSON populatedRegistry);
 in


### PR DESCRIPTION
Homebrew was throwing warnings because aws/tap is used locally but wasn't trusted. Adding it to the nix-ai list so trust.json renders it correctly.