### PR TITLE
feat(homebrew): expose programs.ai-homebrew.trustedTaps option

### DIFF
--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -34,7 +34,7 @@ let
   # non-Nix consumers (orbstack-kubernetes, ansible, shell scripts) read a
   # complete registry.
   populatedRegistry = registryAttrs // {
-    models = config.services.aiStack.models;
+    inherit (config.services.aiStack) models;
   };
   registryJson = pkgs.writeText "ai-stack-registry.json" (builtins.toJSON populatedRegistry);
 in

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -62,11 +62,17 @@ let
   # lib/homebrew.nix; never run brew trust directly.
   brewTrustFiles = lib.optionalAttrs pkgs.stdenv.isDarwin {
     ".homebrew/trust.json".text = builtins.toJSON {
-      trustedtaps = homebrewCfg.taps;
+      trustedtaps = config.programs.ai-homebrew.trustedTaps;
     };
   };
 in
 {
+  options.programs.ai-homebrew.trustedTaps = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = homebrewCfg.taps;
+    description = "List of trusted Homebrew taps. Defaults to AI taps but can be extended by other modules.";
+  };
+
   imports = [
     ./ai-shell.nix
     ./ai-stack


### PR DESCRIPTION
Exposes an option so consumers (e.g. nix-darwin or nix-home) can append extra non-AI taps to trust.json.