### PR TITLE
fix(mlx): default launchd ProcessType to Interactive — Background QoS clamps Metal decode ~8x

### DIFF
--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -47,8 +47,10 @@ in
         KeepAlive = true;
         # 2 min throttle — 70GB model loads take 20-60s, prevents rapid crash-restart loops (closes #256)
         ThrottleInterval = 120;
-        # Background = Jetsam-eligible (applies to proxy; vllm-mlx children inherit separately).
-        ProcessType = "Background";
+        # Interactive by default — Background QoS clamps Metal decode ~8x
+        # (see options-runtime.nix processType). OOM backstop is the RSS
+        # hard limit, not Jetsam eligibility.
+        ProcessType = cfg.processType;
         # Do not abandon the process group; ensure child vllm-mlx processes
         # are terminated when launchd stops the proxy.
         AbandonProcessGroup = false;

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -2,8 +2,12 @@
 # MLX Module — Runtime safety + model-swap proxy options
 #
 # OOM PREVENTION (2026-03-21 incident: 171.9 GB on 128 GB RAM):
-# ProcessType=Background makes vllm-mlx Jetsam-eligible; HardResourceLimits
-# sets a kernel-enforced RSS ceiling. KeepAlive auto-restarts after Jetsam kill.
+# HardResourceLimits sets a kernel-enforced RSS ceiling; KeepAlive auto-restarts
+# after a kill. ProcessType=Background was originally part of this mitigation
+# (Jetsam eligibility), but Background QoS clamps Metal GPU work ~8x on Apple
+# Silicon — measured 11 -> 87 tok/s decode on the same model when switching to
+# Interactive (2026-06-09). The RSS hard limit alone is the OOM backstop now;
+# see the processType option below.
 #
 # MODEL SWITCHING (llama-swap proxy):
 # llama-swap sits on the API port and manages vllm-mlx backends as child
@@ -17,6 +21,25 @@
       type = lib.types.ints.positive;
       default = 100;
       description = "Hard RSS limit in GB. Kernel kills process above this. Leaves 28GB for OS + apps on 128GB systems.";
+    };
+
+    processType = lib.mkOption {
+      type = lib.types.enum [
+        "Background"
+        "Standard"
+        "Adaptive"
+        "Interactive"
+      ];
+      default = "Interactive";
+      description = ''
+        launchd ProcessType for the llama-swap proxy (inherited by vllm-mlx
+        children). Background makes the tree Jetsam-eligible but its QoS clamp
+        throttles Metal decode roughly 8x (11 -> 87 tok/s measured 2026-06-09
+        on an M4 Max). Interactive restores full GPU performance; OOM
+        protection remains via memoryHardLimitGb (HardResourceLimits) and
+        KeepAlive restart. Set back to Background only if Jetsam eligibility
+        matters more than inference speed.
+      '';
     };
 
     models = lib.mkOption {


### PR DESCRIPTION
## Summary

`ProcessType=Background` on the llama-swap LaunchAgent (introduced with the 2026-03-21 OOM mitigation for Jetsam eligibility) turns out to clamp Metal GPU work roughly **8×** on Apple Silicon: the same model on the same host measured **11 tok/s** decode under Background and **87 tok/s** under Interactive (M4 Max 128GB, 2026-06-09). This silently degraded every consumer of the local inference endpoint.

## Changes

- New `programs.mlx.processType` option (enum, default `Interactive`), consumed by the LaunchAgent.
- OOM protection is unchanged: `memoryHardLimitGb` (kernel `HardResourceLimits` RSS ceiling) + `KeepAlive` restart remain the backstop. Hosts that prefer Jetsam eligibility over inference speed can set `Background` explicitly.
- Header comments updated with both incident references.

## Verification

Live A/B on the running service: `plutil -replace ProcessType -string Interactive` + re-bootstrap → decode went from 11.1 to 86.8 tok/s on the identical model and request shape. `nix flake check` passes.

Refs: #914 #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)