### PR TITLE
feat(permissions): read permission data from nix-claude-code (Checkpoint 3)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
               inherit (nixpkgs) lib;
               ncc = nix-claude-code.lib;
               aiCommon = import ./modules/common {
-                inherit ai-assistant-instructions lib;
+                inherit nix-claude-code lib;
                 config = {
                   home.homeDirectory = "/home/user";
                 };
@@ -164,7 +164,7 @@
           codexRules =
             let
               aiCommon = import ./modules/common {
-                inherit ai-assistant-instructions;
+                inherit nix-claude-code;
                 inherit (nixpkgs) lib;
                 config = {
                   home.homeDirectory = "/home/user";
@@ -204,7 +204,7 @@
         # Shared permission + formatter engine. Exposed for cross-flake consumers
         # (e.g., nix-ai-claude) so the source of truth for tool-agnostic command
         # permissions stays in this flake. Callers pass { lib, config,
-        # ai-assistant-instructions, excludeDenyFiles?, excludeDenyCommands? }
+        # nix-claude-code, excludeDenyCategories?, excludeDenyCommands? }
         # and receive { permissions, formatters } — see modules/common/default.nix.
         aiCommon = import ./modules/common;
       };

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -111,6 +111,7 @@ in
     _module.args = {
       inherit
         ai-assistant-instructions
+        nix-claude-code
         marketplaceInputs
         ;
     };
@@ -125,6 +126,7 @@ in
     _module.args = {
       inherit
         ai-assistant-instructions
+        nix-claude-code
         marketplaceInputs
         ;
     };
@@ -138,7 +140,7 @@ in
     ];
     _module.args = {
       inherit
-        ai-assistant-instructions
+        nix-claude-code
         marketplaceInputs
         ;
     };

--- a/modules/antigravity-cli/settings.nix
+++ b/modules/antigravity-cli/settings.nix
@@ -12,7 +12,7 @@
   pkgs,
   config,
   lib,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
@@ -22,7 +22,7 @@ let
   gitDir = "${homeDir}/git";
 
   aiCommon = import ../common {
-    inherit lib config ai-assistant-instructions;
+    inherit lib config nix-claude-code;
   };
   inherit (aiCommon) permissions formatters;
 

--- a/modules/antigravity-ide/default.nix
+++ b/modules/antigravity-ide/default.nix
@@ -8,7 +8,7 @@
   config,
   lib,
   pkgs,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
@@ -17,7 +17,7 @@ let
   homeDir = config.home.homeDirectory;
 
   aiCommon = import ../common {
-    inherit lib config ai-assistant-instructions;
+    inherit lib config nix-claude-code;
   };
   inherit (aiCommon) permissions formatters;
 

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -25,15 +25,15 @@
 
 let
   # Permission engine still lives in nix-ai's `modules/common` because it's
-  # also consumed by Codex/Gemini formatters. The data behind it
-  # (allow/ask/deny/domains/tool-specific) is mirrored in
-  # `nix-claude-code.lib.permissions` for Checkpoint-3 cutover; today we
-  # source from the local engine to preserve the formatter API.
+  # also consumed by Codex/Gemini formatters. The raw permission data
+  # (allow/ask/deny/domains) now comes from `nix-claude-code.lib.permissions`
+  # (Checkpoint 3, step 2; data true-up verified in dryvist/nix-claude-code#50);
+  # only the formatter API stays local.
   aiCommon = import ./common {
-    inherit lib config ai-assistant-instructions;
-    excludeDenyFiles = [
-      "shell.json"
-      "network.json"
+    inherit lib config nix-claude-code;
+    excludeDenyCategories = [
+      "shell"
+      "network"
     ];
     excludeDenyCommands = [
       "npm run"

--- a/modules/codex/settings.nix
+++ b/modules/codex/settings.nix
@@ -7,7 +7,7 @@
   pkgs,
   config,
   lib,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
@@ -16,7 +16,7 @@ let
   homeDir = config.home.homeDirectory;
 
   aiCommon = import ../common {
-    inherit lib config ai-assistant-instructions;
+    inherit lib config nix-claude-code;
   };
   inherit (aiCommon) permissions formatters;
 

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -5,7 +5,7 @@
 #
 # USAGE:
 #   let
-#     aiCommon = import ./common { inherit lib config ai-assistant-instructions; };
+#     aiCommon = import ./common { inherit lib config nix-claude-code; };
 #     geminiAllowedTools = aiCommon.formatters.gemini.formatAllowedTools aiCommon.permissions;
 #   in { ... }
 #
@@ -22,8 +22,8 @@
 {
   lib,
   config,
-  ai-assistant-instructions,
-  excludeDenyFiles ? [ ],
+  nix-claude-code,
+  excludeDenyCategories ? [ ],
   excludeDenyCommands ? [ ],
   ...
 }:
@@ -34,8 +34,8 @@
     inherit
       lib
       config
-      ai-assistant-instructions
-      excludeDenyFiles
+      nix-claude-code
+      excludeDenyCategories
       excludeDenyCommands
       ;
   };

--- a/modules/common/permissions.nix
+++ b/modules/common/permissions.nix
@@ -4,7 +4,7 @@
 # Each tool uses formatters to convert these to their specific format.
 #
 # STRUCTURE:
-# - allow: Auto-approved commands (from ai-assistant-instructions)
+# - allow: Auto-approved commands (from nix-claude-code data/permissions)
 # - deny: Permanently blocked, catastrophic operations
 # - directories: Shared directory trust configuration
 # - toolSpecific: Non-shell tool identifiers
@@ -18,8 +18,8 @@
 {
   lib,
   config,
-  ai-assistant-instructions,
-  excludeDenyFiles ? [ ],
+  nix-claude-code,
+  excludeDenyCategories ? [ ],
   excludeDenyCommands ? [ ],
   ...
 }:
@@ -27,73 +27,102 @@
 let
   homeDir = config.home.homeDirectory;
 
-  # Read all JSON files from a directory into an attribute set
-  # Returns {filename = parsed-json-content} for efficient reuse
-  readJsonsFromDir =
-    dir:
-    if builtins.pathExists dir then
-      let
-        files = builtins.readDir dir;
-        jsonFiles = lib.filterAttrs (n: v: v == "regular" && lib.hasSuffix ".json" n) files;
-      in
-      lib.mapAttrs' (
-        name: _:
-        let
-          filePath = "${dir}/${name}";
-          fileContents = builtins.readFile filePath;
-          parsed = builtins.tryEval (builtins.fromJSON fileContents);
-        in
-        if parsed.success then
-          lib.nameValuePair name parsed.value
-        else
-          throw "Invalid JSON in AI permission file: ${filePath}"
-      ) jsonFiles
-    else
-      { };
+  # Permission data vendored in nix-claude-code (data/permissions/*.nix,
+  # exposed as lib.permissions). Verified meaning-equivalent to the legacy
+  # ai-assistant-instructions/agentsmd/permissions JSON in
+  # dryvist/nix-claude-code#50 (Checkpoint 3, step 1).
+  sourcePermissions = nix-claude-code.lib.permissions;
 
-  # Paths to permission directories in ai-assistant-instructions
-  allowDir = "${ai-assistant-instructions}/agentsmd/permissions/allow";
-  denyDir = "${ai-assistant-instructions}/agentsmd/permissions/deny";
-  askDir = "${ai-assistant-instructions}/agentsmd/permissions/ask";
-  domainsFile = "${ai-assistant-instructions}/agentsmd/permissions/domains/webfetch.json";
+  # Deny categories that callers may exclude from the static deny list
+  # (excluded categories are handled by auto mode's AI classifier instead).
+  #
+  # The vendored deny list in nix-claude-code is flat, so the per-category
+  # split lives here. Keys are the legacy deny/*.json category names; values
+  # are snapshots of those files' command lists (derived once from
+  # ai-assistant-instructions deny/{shell,network}.json, which match the
+  # correspondingly commented blocks in nix-claude-code's
+  # data/permissions/deny.nix). Exclusion is by membership, so ordering here
+  # is irrelevant; entries are sorted for stable diffs.
+  denyCategoryCommands = {
+    # network: mutating HTTP verbs and inbound listeners
+    network = [
+      "curl --data"
+      "curl --request DELETE"
+      "curl --request PATCH"
+      "curl --request POST"
+      "curl --request PUT"
+      "curl -X DELETE"
+      "curl -X PATCH"
+      "curl -X POST"
+      "curl -X PUT"
+      "curl -d"
+      "nc -l"
+      "ncat -l"
+      "socat"
+    ];
 
-  # Read all permission files once to avoid redundant I/O
-  allowJsons = readJsonsFromDir allowDir;
-  denyJsons = readJsonsFromDir denyDir;
-  askJsons = readJsonsFromDir askDir;
+    # shell: inline interpreter execution and temp-file writes
+    shell = [
+      "bash -c"
+      "cat > /tmp/"
+      "cat >> /tmp/"
+      "dash -c"
+      "fish -c"
+      "ksh -c"
+      "node --eval"
+      "node -e"
+      "perl -c"
+      "perl -e"
+      "python -"
+      "python -c"
+      "python /dev/"
+      "python /tmp/"
+      "python <<"
+      "python3 -"
+      "python3 -c"
+      "python3 /dev/"
+      "python3 /tmp/"
+      "python3 <<"
+      "ruby --eval"
+      "ruby -e"
+      "sh -c"
+      "tee /tmp/"
+      "zsh -c"
+    ];
+  };
 
-  # Apply deny exclusions: drop entire files, then filter specific commands.
-  # Excluded categories are handled by auto mode's AI classifier instead.
-  filteredDenyJsons = lib.filterAttrs (name: _: !(builtins.elem name excludeDenyFiles)) denyJsons;
+  # Full set of deny commands to drop: whole excluded categories plus any
+  # individually excluded commands.
+  excludedDenyCommands =
+    excludeDenyCommands
+    ++ lib.concatMap (
+      category:
+      denyCategoryCommands.${category}
+        or (throw "Unknown deny category to exclude: ${category} (known: ${lib.concatStringsSep ", " (builtins.attrNames denyCategoryCommands)})")
+    ) excludeDenyCategories;
 
 in
 {
-  # Auto-approved commands from ai-assistant-instructions
-  allow = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) allowJsons);
+  # Auto-approved commands from nix-claude-code
+  allow = sourcePermissions.allow.commands;
 
   # Denied commands with exclusions applied
-  deny = lib.filter (cmd: !(builtins.elem cmd excludeDenyCommands)) (
-    lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) filteredDenyJsons)
-  );
+  deny = lib.filter (cmd: !(builtins.elem cmd excludedDenyCommands)) sourcePermissions.deny.commands;
 
   # Commands that require explicit user confirmation
-  ask = lib.flatten (lib.mapAttrsToList (_: v: v.commands or [ ]) askJsons);
+  ask = sourcePermissions.ask.commands;
 
   # MCP tool permissions (non-shell, bare identifiers like mcp__plugin_*)
-  mcpAllow = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) allowJsons);
-  mcpDeny = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) filteredDenyJsons);
-  mcpAsk = lib.flatten (lib.mapAttrsToList (_: v: v.mcp or [ ]) askJsons);
+  mcpAllow = sourcePermissions.allow.mcp or [ ];
+  mcpDeny = sourcePermissions.deny.mcp or [ ];
+  mcpAsk = sourcePermissions.ask.mcp or [ ];
 
   # WebFetch domains
-  webfetchDomains =
-    if builtins.pathExists domainsFile then
-      (builtins.fromJSON (builtins.readFile domainsFile)).domains
-    else
-      [ ];
+  webfetchDomains = sourcePermissions.domains.webfetch;
 
   # File patterns to deny (for Claude Read tool)
-  # These come from dangerous.json's "patterns" field
-  denyPatterns = denyJsons."dangerous.json".patterns or [ ];
+  # These come from the deny data's "patterns" field (legacy dangerous.json)
+  denyPatterns = sourcePermissions.deny.patterns or [ ];
 
   # Trusted directories (local config)
   directories = {
@@ -153,7 +182,7 @@ in
         "TodoWrite"
       ];
 
-      # WebFetch with allowed domains (dynamically generated from ai-assistant-instructions)
+      # WebFetch with allowed domains (dynamically generated from nix-claude-code)
       # This will be populated by formatters.nix using webfetchDomains
 
       # Special read patterns
@@ -162,7 +191,7 @@ in
       ];
 
       # Deny patterns for sensitive files (Claude-specific Read tool)
-      # Populated from ai-assistant-instructions deny/dangerous.json patterns field
+      # Populated from nix-claude-code deny data's patterns field
       # This will be transformed by formatters.nix to Read(...) format
     };
   };

--- a/modules/copilot.nix
+++ b/modules/copilot.nix
@@ -16,13 +16,13 @@
   config,
   lib,
   pkgs,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
 let
   copilotAllow = import ./permissions/copilot-permissions-allow.nix {
-    inherit config lib ai-assistant-instructions;
+    inherit config lib nix-claude-code;
   };
 
   # Copilot settings object

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -11,6 +11,7 @@
   pkgs,
   lib,
   ai-assistant-instructions,
+  nix-claude-code,
   userConfig ? {
     user.fullName = "JacobPEvans";
   },
@@ -40,7 +41,7 @@ let
       config
       lib
       pkgs
-      ai-assistant-instructions
+      nix-claude-code
       ;
   };
 

--- a/modules/permissions/antigravity-cli-permissions-allow.nix
+++ b/modules/permissions/antigravity-cli-permissions-allow.nix
@@ -9,12 +9,12 @@
 {
   config,
   lib,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
 let
-  aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
+  aiCommon = import ../common { inherit lib config nix-claude-code; };
   inherit (aiCommon) permissions formatters;
 in
 {

--- a/modules/permissions/antigravity-cli-permissions-ask.nix
+++ b/modules/permissions/antigravity-cli-permissions-ask.nix
@@ -9,12 +9,12 @@
 {
   config,
   lib,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
 let
-  aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
+  aiCommon = import ../common { inherit lib config nix-claude-code; };
   inherit (aiCommon) permissions formatters;
 in
 {

--- a/modules/permissions/antigravity-cli-permissions-deny.nix
+++ b/modules/permissions/antigravity-cli-permissions-deny.nix
@@ -9,12 +9,12 @@
 {
   config,
   lib,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
 let
-  aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
+  aiCommon = import ../common { inherit lib config nix-claude-code; };
   inherit (aiCommon) permissions formatters;
 in
 {

--- a/modules/permissions/copilot-permissions-allow.nix
+++ b/modules/permissions/copilot-permissions-allow.nix
@@ -17,13 +17,13 @@
 {
   config,
   lib,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
 let
   # Import unified permissions and formatters
-  aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
+  aiCommon = import ../common { inherit lib config nix-claude-code; };
   inherit (aiCommon) permissions formatters;
 
 in

--- a/modules/permissions/copilot-permissions-deny.nix
+++ b/modules/permissions/copilot-permissions-deny.nix
@@ -27,13 +27,13 @@
 {
   config,
   lib,
-  ai-assistant-instructions,
+  nix-claude-code,
   ...
 }:
 
 let
   # Import unified permissions and formatters
-  aiCommon = import ../common { inherit lib config ai-assistant-instructions; };
+  aiCommon = import ../common { inherit lib config nix-claude-code; };
   inherit (aiCommon) permissions formatters;
 
 in


### PR DESCRIPTION
## Checkpoint 3 context

This is **step 2 of 3** of the Checkpoint 3 plan to make `nix-claude-code`'s `data/permissions/` the single source of truth:

1. True-up the vendored Nix data against the current JSON — dryvist/nix-claude-code#50
2. **Flip nix-ai's permission reader to consume from nix-claude-code** (this PR)
3. Retire the JSON copy in `ai-assistant-instructions` after a soak period

## What moved

`modules/common/permissions.nix` previously read `${ai-assistant-instructions}/agentsmd/permissions/{allow,deny,ask,domains}` via `builtins.readDir` + `fromJSON`. It now consumes **`nix-claude-code.lib.permissions`** (the vendored `data/permissions/*.nix`):

| Engine output | Source attribute |
| --- | --- |
| `allow` / `ask` / `deny` | `allow.commands` / `ask.commands` / `deny.commands` |
| `mcpAllow` / `mcpDeny` / `mcpAsk` | `allow.mcp` / `deny.mcp or []` / `ask.mcp or []` (deny/ask have no MCP entries, matching the JSON) |
| `webfetchDomains` | `domains.webfetch` |
| `denyPatterns` | `deny.patterns` |

**Exclude semantics**: `excludeDenyFiles = ["shell.json" "network.json"]` becomes `excludeDenyCategories = ["shell" "network"]`. The vendored deny list is flat (categories survive only as comments), so the shell (25 commands) and network (13 commands) category lists are snapshotted in `modules/common/permissions.nix` and excluded by membership. The effective exclusion set is byte-for-byte the same as the old per-file filtering; `excludeDenyCommands` (`npm run`, `npm test`) is unchanged.

All `aiCommon` callers (claude-config, codex, copilot, antigravity-cli/-ide, `lib.ci` helpers) now pass `nix-claude-code`; the codex/antigravity module groups gain `nix-claude-code` in `_module.args` (antigravity-ide drops its now-unused `ai-assistant-instructions` arg).

## What stayed

- **Formatters untouched** — `modules/common/formatters*` has zero diff.
- `toolSpecific` and `directories` stay local to nix-ai.
- The `ai-assistant-instructions` flake input **remains** — still used for agentsmd rules/agents symlinks, AGENTS.md/CLAUDE.md, and skill overrides. Only the permission read moved.
- **No pin bump needed**: nix-ai's locked `nix-claude-code` rev (`087ddde`, v0.1.11) already ships `data/permissions/*.nix` + `lib.permissions`, and #50 verified that data is meaning-equivalent to the current JSON (its diff is comment/README-only). When #49/#50/#51 merge in nix-claude-code, the regular lock refresh picks them up with no behavior change here.

## Byte-equivalence evidence

Rendered before/after on the same machine:

| Output | Before | After | Result |
| --- | --- | --- | --- |
| `lib.ci.claudeSettingsJson` | 16,801 B | 16,801 B | arrays are permutations; sorted-array diff empty |
| `lib.ci.codexRules` | 517 lines / 21,059 B | 517 lines / 21,059 B | sorted-line diff empty |
| Full formatter sweep (claude allow/deny/ask, gemini allow/deny/ask rules + allowed/exclude tools, copilot trusted folders + deny flags, codex rules, antigravity-ide grants; both with and without the deny exclusions) | 232,349 B | 232,349 B | every list set-equal after sorting; counts identical (allow 311, ask 117, deny 90, deny-with-exclusions 50, mcp 7, domains 29, patterns 13) |

**Not byte-identical — ordering only.** The vendored lists are sorted within category (deliberate in #50) while the legacy JSON files were unsorted, and no formatter sorts. Every delta is a reordering inside a list: zero entries added, removed, or changed. Permission lists are set-semantic for every consumer (Claude/Codex/Gemini/Copilot match rules individually; precedence is deny > ask > allow by list, not by position), so the reorder is a behavioral no-op.

## Validations

- `nix fmt` — clean
- `nix flake check` — passes (darwin host; x86_64-linux checks evaluated explicitly: every check's drvPath evaluates; the only two failures, `agent-skills-home-files` and `antigravity-cli-policy-engine`, are pre-existing linux-only IFD failures reproduced identically on `origin/main` and covered by CI)
- `checks.x86_64-linux.module-eval` and `codex-permissions` evaluate cleanly with the new wiring
- `darwin-rebuild switch` deliberately **not** run (operator does that post-merge)

## Follow-ups (step 3)

- `modules/routines/prompts/permission-sync.md` still describes syncing into the ai-assistant-instructions JSON; it should be repointed at `nix-claude-code/data/permissions` when the JSON is retired.
- The codex rules header comment (`# Generated by nix-ai from ai-assistant-instructions/agentsmd/permissions/`) lives in `formatters/codex.nix`, which this PR deliberately does not touch; update alongside step 3.

Refs: dryvist/nix-claude-code#50

🤖 Generated with [Claude Code](https://claude.com/claude-code)