### PR TITLE
feat(mlx): tighten idleTtl default to 900s to cut idle-weight dwell

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -80,7 +80,7 @@ in
         {
           name = "mlx.proxy.idleTtl";
           actual = mlxCfg.proxy.idleTtl;
-          expected = 1800;
+          expected = 900;
         }
         {
           name = "mlx.proxy.concurrencyLimit";

--- a/modules/mlx/discover-models.py
+++ b/modules/mlx/discover-models.py
@@ -159,7 +159,7 @@ def main() -> None:
 
     model_env = default_entry.get("env", [])
     check_endpoint = default_entry.get("checkEndpoint", "/v1/models")
-    idle_ttl = current_config.get("idleTtl", 1800)
+    idle_ttl = current_config.get("idleTtl", 900)
     # Propagate concurrencyLimit from the default entry so auto-discovered
     # models inherit the same proxy-side cap (default: 4, matches
     # maxNumSeqs=4). Without this, discovered models would fall back to

--- a/modules/mlx/options-cache.nix
+++ b/modules/mlx/options-cache.nix
@@ -2,8 +2,10 @@
 # MLX Module — KV cache and prefill options
 #
 # vllm-mlx 0.2.9 PERFORMANCE TUNING.
-# Sizing target: M4 Max 128 GB. Effective wired ceiling 118 GB (from
-# nix-darwin's apple-silicon-tunables module via iogpu.wired_limit_mb=118000).
+# Sizing target: M4 Max 128 GB. Effective wired ceiling 104 GB (from
+# nix-darwin's apple-silicon-tunables module via iogpu.wired_limit_mb=104000;
+# lowered from 118000 on 2026-06-10 to guarantee 24 GB pageable headroom —
+# see nix-mac-performance RC14).
 #
 # vllm-mlx 0.2.9 adds Paged KV Cache + prefix sharing on top of the
 # memory-aware cache that auto-sizes based on available RAM.

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -86,8 +86,8 @@
       };
       idleTtl = lib.mkOption {
         type = lib.types.ints.unsigned;
-        default = 1800;
-        description = "Idle TTL in seconds applied uniformly to every model in the registry (including the default-aliased one). 0 = never auto-unload (escape hatch). Default 1800 s (30 min) — a bounded warm window. Tightened from the prior 3600 s default after the recurring `nix-ai#801` stuck-past-TTL family of incidents; shorter windows mean less time exposed when the upstream `llama-swap` race fires during unload.";
+        default = 900;
+        description = "Idle TTL in seconds applied uniformly to every model in the registry (including the default-aliased one). 0 = never auto-unload (escape hatch). Default 900 s (15 min). Tightened twice: 3600 -> 1800 after the recurring `nix-ai#801` stuck-past-TTL incidents, then 1800 -> 900 after the 2026-06-10 nix-mac-performance RC14 snapshot showed a single healthy in-TTL ~50 GB worker plus the desktop working set saturating compressor + swap on a 128 GB host — idle-weight dwell is the dominant memory cost, and a 4-bit MoE model reloads from NVMe in 10-20 s, so eviction is cheap relative to the host-wide paging it prevents.";
       };
       logLevel = lib.mkOption {
         type = lib.types.enum [


### PR DESCRIPTION
## What

- `proxy.idleTtl` default **1800 → 900** (+ `lib/checks/mlx.nix` drift-check expectation)
- `discover-models.py` TTL fallback 1800 → 900 to match
- `options-cache.nix` header comment tracks the nix-darwin wired-ceiling value (104000)

## How

`idleTtl` is the llama-swap idle window before a worker is unloaded. 900 s halves idle-weight residency; a 4-bit MoE model reloads from NVMe in ~10–20 s, so eviction is cheap. A shorter window also reduces exposure to the unload lifecycle race (#801). `cacheMemoryMb` is intentionally untouched (host override context: dryvist/nix-darwin#1230).

## Apply

`darwin-rebuild switch`; the base-config hash change re-seeds the runtime llama-swap config via `seed-config.py` and llama-swap reloads it via `--watch-config`.

Refs: dryvist/nix-darwin#1233, dryvist/nix-mac-performance#27, #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)