### PR TITLE
feat(mlx): native per-worker memory bounds via vllm-mlx flags

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -9,6 +9,7 @@ in
   mlx-options-regression =
     let
       expectedOptions = [
+        "autoUnloadIdleSeconds"
         "cacheMemoryMb"
         "chunkedPrefillTokens"
         "completionBatchSize"
@@ -16,7 +17,9 @@ in
         "defaultModel"
         "enable"
         "enableAutoToolChoice"
+        "enableMetrics"
         "enablePrefixCaching"
+        "gpuMemoryUtilization"
         "host"
         "huggingFaceHome"
         "maxTokens"
@@ -76,6 +79,21 @@ in
           name = "mlx.cacheMemoryMb";
           actual = mlxCfg.cacheMemoryMb;
           expected = 8192;
+        }
+        {
+          name = "mlx.gpuMemoryUtilization";
+          actual = mlxCfg.gpuMemoryUtilization;
+          expected = 0.5;
+        }
+        {
+          name = "mlx.autoUnloadIdleSeconds";
+          actual = mlxCfg.autoUnloadIdleSeconds;
+          expected = 1800;
+        }
+        {
+          name = "mlx.enableMetrics";
+          actual = mlxCfg.enableMetrics;
+          expected = true;
         }
         {
           name = "mlx.proxy.idleTtl";

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -90,6 +90,15 @@ let
           "--prefill-batch-size"
           (toString cfg.prefillBatchSize)
         ]
+        ++ lib.optionals (cfg.gpuMemoryUtilization != null) [
+          "--gpu-memory-utilization"
+          (toString cfg.gpuMemoryUtilization)
+        ]
+        ++ lib.optionals (cfg.autoUnloadIdleSeconds != 0) [
+          "--auto-unload-idle-seconds"
+          (toString cfg.autoUnloadIdleSeconds)
+        ]
+        ++ lib.optionals cfg.enableMetrics [ "--enable-metrics" ]
         ++ lib.optionals cfg.continuousBatching [ "--continuous-batching" ]
         ++ lib.optionals cfg.enablePrefixCaching [ "--enable-prefix-cache" ]
         ++ lib.optionals cfg.pagedKvCache [ "--use-paged-cache" ]

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -28,9 +28,12 @@ in
     # llama-swap proxy listens on the API port and manages vllm-mlx child
     # processes on ephemeral ports (startPort = 11436+). HardResourceLimits
     # is omitted — it would only cap the proxy process, not the vllm-mlx
-    # children where the actual memory lives. As a result, programs.mlx.memoryHardLimitGb
-    # is not enforced under the llama-swap architecture; primary OOM protection
-    # is --cache-memory-mb on each vllm-mlx backend (set in the generated config).
+    # children where the actual memory lives (and macOS does not reliably
+    # enforce RSS rlimits). Per-worker OOM protection is native and inside
+    # each worker: --gpu-memory-utilization (Metal allocation ceiling +
+    # emergency cache clear; programs.mlx.gpuMemoryUtilization) plus
+    # --cache-memory-mb and --auto-unload-idle-seconds (set in the generated
+    # config). programs.mlx.memoryHardLimitGb remains declarative intent only.
     launchd.agents.vllm-mlx = {
       enable = true;
       config = {

--- a/modules/mlx/options-cache.nix
+++ b/modules/mlx/options-cache.nix
@@ -38,6 +38,22 @@
       description = "KV cache reservation in MB (vllm-mlx --cache-memory-mb). Null = server auto-detect. Default 8 GB right-sized for maxNumSeqs=4 and maxTokens=8192; raise per-host if a workload needs more.";
     };
 
+    # gpuMemoryUtilization — Per-worker Metal allocation ceiling (--gpu-memory-utilization).
+    # Fraction of device memory each vllm-mlx worker may allocate via Metal; the
+    # server also uses it as the emergency cache-clear threshold. The upstream
+    # default is 0.90, which on a 128 GB host lets a single worker reach ~115 GB
+    # before any native bound engages. 0.50 bounds each worker to half of device
+    # memory — comfortably above a healthy worker's working set while keeping the
+    # host responsive if a worker's allocator grows under sustained load.
+    # This is the per-worker enforcement layer that HardResourceLimits could not
+    # provide (see launchd.nix) because it acts inside the worker process itself.
+    # Ref: https://github.com/ml-explore/mlx-lm/issues/883
+    gpuMemoryUtilization = lib.mkOption {
+      type = lib.types.nullOr (lib.types.numbers.between 0.05 1.0);
+      default = 0.5;
+      description = "Fraction of device memory each worker may allocate via Metal (vllm-mlx --gpu-memory-utilization). Null = upstream default (0.90). Also the worker's emergency cache-clear threshold.";
+    };
+
     # enablePrefixCaching — Enable prefix sharing across requests (--enable-prefix-cache).
     # Eliminates re-prefill of unchanged conversation context — the single
     # biggest speed win for multi-turn tool-calling workloads.

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -1,13 +1,17 @@
 #
 # MLX Module — Runtime safety + model-swap proxy options
 #
-# OOM PREVENTION (2026-03-21 incident: 171.9 GB on 128 GB RAM):
-# HardResourceLimits sets a kernel-enforced RSS ceiling; KeepAlive auto-restarts
-# after a kill. ProcessType=Background was originally part of this mitigation
-# (Jetsam eligibility), but Background QoS clamps Metal GPU work ~8x on Apple
-# Silicon — measured 11 -> 87 tok/s decode on the same model when switching to
-# Interactive (2026-06-09). The RSS hard limit alone is the OOM backstop now;
-# see the processType option below.
+# OOM PREVENTION:
+# The enforced per-worker memory bound is programs.mlx.gpuMemoryUtilization
+# (options-cache.nix) — a Metal allocation ceiling applied inside each
+# vllm-mlx worker, where the memory actually lives. launchd
+# HardResourceLimits is NOT serialized into the plist: it would only cap the
+# llama-swap proxy, and macOS does not reliably enforce RSS rlimits (see
+# launchd.nix). memoryHardLimitGb below is therefore declarative intent, not
+# an enforced kernel limit. autoUnloadIdleSeconds adds a worker-side idle
+# failsafe. ProcessType=Background was once part of the mitigation (Jetsam
+# eligibility) but its QoS clamp throttles Metal decode ~8x — see the
+# processType option below.
 #
 # MODEL SWITCHING (llama-swap proxy):
 # llama-swap sits on the API port and manages vllm-mlx backends as child
@@ -20,7 +24,18 @@
     memoryHardLimitGb = lib.mkOption {
       type = lib.types.ints.positive;
       default = 100;
-      description = "Hard RSS limit in GB. Kernel kills process above this. Leaves 28GB for OS + apps on 128GB systems.";
+      description = "Declared RSS budget in GB for the LLM stack (documentation/dashboards). NOT kernel-enforced: launchd HardResourceLimits would only cap the proxy process and macOS does not reliably enforce RSS rlimits. The enforced per-worker bound is gpuMemoryUtilization.";
+    };
+
+    # autoUnloadIdleSeconds — Worker-side idle self-unload (--auto-unload-idle-seconds).
+    # Defense in depth alongside llama-swap's proxy.idleTtl: the worker frees its
+    # own model weights after this many idle seconds even if the proxy loses
+    # track of it (upstream lifecycle race, see nix-ai#801). Keep LONGER than
+    # proxy.idleTtl so the proxy remains the primary eviction path.
+    autoUnloadIdleSeconds = lib.mkOption {
+      type = lib.types.ints.unsigned;
+      default = 1800;
+      description = "Worker self-unloads its model after this many idle seconds (vllm-mlx --auto-unload-idle-seconds). 0 = disabled. Keep greater than proxy.idleTtl; this is the failsafe when the proxy cannot evict.";
     };
 
     processType = lib.mkOption {
@@ -36,9 +51,9 @@
         children). Background makes the tree Jetsam-eligible but its QoS clamp
         throttles Metal decode roughly 8x (11 -> 87 tok/s measured 2026-06-09
         on an M4 Max). Interactive restores full GPU performance; OOM
-        protection remains via memoryHardLimitGb (HardResourceLimits) and
-        KeepAlive restart. Set back to Background only if Jetsam eligibility
-        matters more than inference speed.
+        protection comes from gpuMemoryUtilization (per-worker Metal ceiling)
+        and KeepAlive restart. Set back to Background only if Jetsam
+        eligibility matters more than inference speed.
       '';
     };
 

--- a/modules/mlx/options-server.nix
+++ b/modules/mlx/options-server.nix
@@ -41,6 +41,15 @@ in
       description = "Path to HuggingFace model cache (dedicated APFS volume)";
     };
 
+    # enableMetrics — Native Prometheus metrics endpoint (--enable-metrics).
+    # Exposes /metrics on each worker for scrape-based monitoring (Cribl Edge
+    # has a built-in Prometheus input). No custom collectors required.
+    enableMetrics = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Expose the native Prometheus /metrics endpoint on each vllm-mlx worker (--enable-metrics).";
+    };
+
     telemetry = {
       enable = lib.mkEnableOption "OpenTelemetry trace export from the MLX inference stack";
 


### PR DESCRIPTION
## What

Three new `programs.mlx` options, each serializing an existing native vllm-mlx serve flag into the generated worker command (same plumbing as `--cache-memory-mb`):

| Option | Flag | Default | Effect |
|---|---|---|---|
| `gpuMemoryUtilization` | `--gpu-memory-utilization` | 0.5 | Metal allocation ceiling + emergency cache-clear threshold, enforced inside each worker (upstream default is 0.90) |
| `autoUnloadIdleSeconds` | `--auto-unload-idle-seconds` | 1800 | Worker-side idle self-unload — operates even when the proxy cannot evict (#801); kept above `proxy.idleTtl` so the proxy remains primary |
| `enableMetrics` | `--enable-metrics` | true | Native Prometheus `/metrics` endpoint per worker for scrape-based monitoring |

## How

- `mkVllmCmd` in `modules/mlx/default.nix` gains three optionals; options declared beside their peers (`options-cache.nix`, `options-runtime.nix`, `options-server.nix`); drift-check expectations extended in `lib/checks/mlx.nix`.
- Documentation correction: `memoryHardLimitGb` was documented as a kernel-enforced RSS limit but was never serialized into the plist (HardResourceLimits would cap only the proxy process, and macOS does not reliably enforce RSS rlimits). It is now documented as declarative intent; the enforced per-worker bound is `gpuMemoryUtilization`.

## Apply

`darwin-rebuild switch` after merge; the base-config hash change re-seeds the runtime llama-swap config.

Refs: #801, ml-explore/mlx-lm#883, dryvist/nix-mac-performance#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)