### PR TITLE
fix(deps): bump transitive jacobpevans-cc-plugins pin to v4.2.0 era

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -404,11 +404,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1779660353,
-        "narHash": "sha256-Wst459BiRSLXaE2PtSpQk1wYMev0uhDlOTmW5ks7ZEo=",
+        "lastModified": 1781125547,
+        "narHash": "sha256-622YuZh3rESR4F08WC2SMAD9HLkwsiWYhvHUELxNT8o=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "36a6a281d5d4d1120c857e212eca6d061ca1c6bc",
+        "rev": "6b5af8fe1fc215abcc6c9f7be675e647b09e4daf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Why

`jacobpevans-cc-plugins` is a **transitive** flake input (owned by nix-claude-code's flake), and Renovate's `lockFileMaintenance` only refreshes root inputs — so it sat at 2026-05-24 while the root pins moved. That predates claude-code-plugins **v4.2.0**, which added the three skills migrated out of always-loaded `agentsmd/rules/` (`pre-commit-architecture`, `nix-tool-policy`, `shared-workflow-org-refs`).

Plugin auto-discovery (`modules/claude/plugins/03-personal.nix`) walks this input for plugin names, so it should track current.

## Change

`nix flake update nix-claude-code/jacobpevans-cc-plugins`: `36a6a28` (2026-05-24) → `6b5af8f` (2026-06-10). Lock-only.

## Note for Renovate config

Transitive inputs are invisible to lockFileMaintenance — if this recurs, consider whether the input should be promoted to a root input with a `follows` from nix-claude-code, or periodically full-updated.

Refs: dryvist/ai-assistant-instructions#680

🤖 Generated with [Claude Code](https://claude.com/claude-code)