### PR TITLE
fix(antigravity): shadow home-manager's new antigravity-cli module

### DIFF
--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -246,19 +246,21 @@ in
   # Verify OOM prevention: ProcessType in LaunchAgent.
   # HardResourceLimits is intentionally absent — it would only cap the llama-swap
   # proxy process, not the vllm-mlx child processes where the actual memory lives.
-  # Jetsam eligibility via ProcessType=Background still applies to the proxy.
+  # ProcessType defaults to Interactive since #916: Background's QoS clamp
+  # throttles Metal decode ~8x; the OOM backstop is the RSS hard limit
+  # (programs.mlx.memoryHardLimitGb), not Jetsam eligibility.
   mlx-launchd-memory-safety =
     let
       launchdCfg = hmConfig.config.launchd.agents.vllm-mlx.config;
     in
     assert
-      launchdCfg.ProcessType == "Background"
-      || throw "ProcessType must be \"Background\" for Jetsam eligibility";
+      launchdCfg.ProcessType == "Interactive"
+      || throw "ProcessType default must be \"Interactive\" — Background QoS clamps Metal decode ~8x (#916)";
     assert
       (!(launchdCfg ? HardResourceLimits) || launchdCfg.HardResourceLimits == null)
       || throw "HardResourceLimits must NOT be set on the llama-swap proxy (only constrains proxy, not vllm-mlx children)";
     pkgs.runCommand "check-mlx-launchd-memory-safety" { } ''
-      echo "MLX LaunchAgent memory safety: ProcessType=Background verified; HardResourceLimits correctly absent from proxy"
+      echo "MLX LaunchAgent memory safety: ProcessType=Interactive verified; HardResourceLimits correctly absent from proxy"
       touch $out
     '';
 

--- a/modules/antigravity-cli/default.nix
+++ b/modules/antigravity-cli/default.nix
@@ -25,6 +25,13 @@ let
   cfg = config.programs.antigravity-cli;
 in
 {
+  # home-manager release-26.05 gained its own programs.antigravity-cli
+  # module (added between 4eb4fec and d899b01); its `commands` option is
+  # typed attrsOf (submodule str) and cannot coexist with this module's
+  # nested commands.{fromFlakeInputs,local} options. This module predates
+  # and supersedes the upstream one — shadow it.
+  disabledModules = [ "programs/antigravity-cli.nix" ];
+
   imports = [
     ./options.nix
     ./settings.nix


### PR DESCRIPTION
## Problem

`nix-validate` has failed on **every nix-ai PR since lock maintenance #919** (June 10 22:18 UTC). #919, #920, and #923 merged red anyway — the Merge Gate job fails but is evidently not an enforced required status check (separate issue worth fixing in branch protection).

## Root cause

#919 bumped home-manager (release-26.05) from `4eb4fec` → `d899b01`, and upstream added its own `modules/programs/antigravity-cli.nix` in that window. Its `programs.antigravity-cli.commands` is typed `attrsOf (submodule str)`, which cannot parent nix-ai's nested `commands.{fromFlakeInputs,local}` options:

```text
error: The option 'programs.antigravity-cli.commands' ... would be a parent of the
following options, but its type 'attribute set of (open submodule of string)' does
not support nested options.
```

Every hmConfig-based check fails eval on this single collision.

## Fix

`disabledModules = [ "programs/antigravity-cli.nix" ];` in nix-ai's antigravity module — the standard home-manager mechanism for shadowing an upstream module you maintain a replacement for.

## Verification

All previously-failing checks evaluate clean locally: `antigravity-cli-options-regression`, `antigravity-cli-defaults-regression`, `fabric-launchd-negative`, `mlx-options-regression`, `options-regression`.

## Follow-up (not this PR)

Evaluate whether nix-ai's module should eventually migrate to/extend the upstream `programs.antigravity-cli` instead of shadowing it.

Unblocks #928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)