### PR TITLE
feat(agent-skills): integrate dashmotion animated diagram skill

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,14 @@
       flake = false;
     };
 
+    # DashMotion - animated technical diagram skill (flowcharts + architecture
+    # diagrams as self-contained HTML+SVG files using stroke-dashoffset +
+    # animateMotion; no external dependencies).
+    dashmotion = {
+      url = "github:csthink/dashmotion";
+      flake = false;
+    };
+
   };
 
   outputs =
@@ -78,6 +86,7 @@
       karpathy-skills,
       pal-mcp-server,
       fabric-src,
+      dashmotion,
       ...
     }:
     let
@@ -96,6 +105,7 @@
           karpathy-skills
           pal-mcp-server
           nixpkgs-unstable
+          dashmotion
           ;
       };
 

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -4,6 +4,7 @@
   karpathy-skills,
   pal-mcp-server,
   nixpkgs-unstable,
+  dashmotion,
 }:
 let
   # Marketplace flake inputs now live inside nix-claude-code. Surface the
@@ -37,6 +38,7 @@ let
       wakatime
       ;
     inherit karpathy-skills;
+    inherit dashmotion;
   };
 in
 {

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -139,6 +139,18 @@ let
       source = "${skillsPath}/${name}/SKILL.md";
     }) (lib.filterAttrs (name: _: builtins.pathExists "${skillsPath}/${name}/SKILL.md") skillDirs);
 
+  # Discovers a SKILL.md at the repo root (single-skill repo pattern).
+  # Pattern: <repo>/SKILL.md
+  # Used for repos like dashmotion that ship exactly one skill at the root
+  # alongside supporting resources (references/, resources/) in the same tree.
+  # The entire repo directory is deployed so relative paths inside SKILL.md resolve.
+  discoverRootSkill =
+    name: input:
+    lib.optional (builtins.pathExists "${input}/SKILL.md") {
+      inherit name;
+      source = "${input}/SKILL.md";
+    };
+
   # Applies all known SKILL.md discovery patterns to one input path.
   # Each pattern short-circuits (via pathExists) when the layout is absent.
   # The one-level subpath walk ("plugins", "external_plugins") handles inputs
@@ -173,7 +185,10 @@ let
   # is decoupled from Claude's registry and operates on a generic set of input
   # paths supplied by the consumer flake. When this module is split into its own
   # flake, the consumer decides which inputs to pass; the walker stays unchanged.
-  sharedSkills = lib.concatMap walkAllPatterns (lib.attrValues marketplaceInputs);
+  # discoverRootSkill runs separately (it needs the input name, which attrValues discards).
+  sharedSkills =
+    lib.concatMap walkAllPatterns (lib.attrValues marketplaceInputs)
+    ++ lib.concatLists (lib.mapAttrsToList discoverRootSkill marketplaceInputs);
 in
 {
   imports = [


### PR DESCRIPTION
## Summary

- Adds [csthink/dashmotion](https://github.com/csthink/dashmotion) as a `flake = false` input — a Claude skill that generates animated flowcharts and architecture diagrams as self-contained HTML+SVG files (pure CSS `stroke-dashoffset` + SVG `animateMotion`, no external deps, dark-themed, accessibility-aware)
- Adds a new `discoverRootSkill` discovery pattern to `modules/agent-skills/default.nix` for single-skill repos that ship `SKILL.md` at the repo root (rather than inside a `skills/<name>/` subdirectory)
- Threads `dashmotion` through `flake/home-manager-modules.nix` into `marketplaceInputs` so it is auto-discovered alongside all other marketplace inputs

### How it works

DashMotion deploys to `~/.agents/skills/dashmotion/` with its full directory tree (including `references/flow-mode.md`, `references/architecture-mode.md`, `resources/template-flow.html`, `resources/template-architecture.html`) so the relative paths inside `SKILL.md` resolve correctly during skill execution.

The new `discoverRootSkill` pattern is name-aware (unlike `walkAllPatterns` which discards input names) and runs via `lib.mapAttrsToList` over all `marketplaceInputs`. It short-circuits with `lib.optional (builtins.pathExists ...)` for inputs that don't have a root-level `SKILL.md`, so it's safe to apply universally.

## ⚠️ Lock file update required

This remote execution environment does not have the `nix` binary available, so `flake.lock` could not be updated automatically. Before CI can evaluate the new input, run locally:

```bash
nix flake lock --update-input dashmotion
git add flake.lock
git commit -m "chore(lock): add dashmotion flake input"
git push
```

## Test plan

- [ ] `nix flake lock --update-input dashmotion` succeeds and adds the dashmotion entry
- [ ] `nix flake check` passes (agent-skills regression tests: options, defaults, home-files)
- [ ] `~/.agents/skills/dashmotion/SKILL.md` exists after `darwin-rebuild switch`
- [ ] `~/.agents/skills/dashmotion/references/flow-mode.md` and `resources/template-flow.html` are accessible
- [ ] Claude Code recognizes the skill (ask: "create an animated flowchart for a CI pipeline")

https://claude.ai/code/session_01VgdwVf62GGrUDmZuzSEpAc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgdwVf62GGrUDmZuzSEpAc)_