### PR TITLE
fix(ci): repoint reusable workflows from JacobPEvans-personal to dryvist hub

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -103,7 +103,7 @@ jobs:
     name: Nix Validate
     needs: changes
     if: needs.changes.outputs.nix == 'true' && needs.changes.outputs.is-deps-only != 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
+    uses: dryvist/.github/.github/workflows/_nix-validate.yml@main
     with:
       # `nix flake check --all-systems` needs disk/RAM for darwin source
       # substitution; m7+c7 family with s3-cache fits.
@@ -114,7 +114,7 @@ jobs:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
+    uses: dryvist/.github/.github/workflows/_markdown-lint.yml@main
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
@@ -122,7 +122,7 @@ jobs:
     name: File Size
     needs: changes
     if: needs.changes.outputs.nix == 'true' || needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
+    uses: dryvist/.github/.github/workflows/_file-size.yml@main
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
@@ -130,7 +130,7 @@ jobs:
     name: Python Security
     needs: changes
     if: needs.changes.outputs.python == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_python-security.yml@main
+    uses: dryvist/.github/.github/workflows/_python-security.yml@main
     with:
       python-dirs: 'mlx-server orchestrator'
       # MUST mirror osv-scanner.toml `[[IgnoredVulns]]`. Each ID is documented
@@ -153,7 +153,7 @@ jobs:
     name: OSV Scan
     needs: changes
     if: always()
-    uses: JacobPEvans-personal/.github/.github/workflows/_osv-scan.yml@main
+    uses: dryvist/.github/.github/workflows/_osv-scan.yml@main
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,8 +1,8 @@
 name: Retrigger PR Checks
 
 # Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
-# Calls shared logic from JacobPEvans/.github.
-# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans/.github
+# Calls shared logic from dryvist/.github.
+# See: .github/workflows/_retrigger-pr-checks.yml in dryvist/.github
 
 on:
   schedule:
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   retrigger:
-    uses: JacobPEvans-personal/.github/.github/workflows/_retrigger-pr-checks.yml@main
+    uses: dryvist/.github/.github/workflows/_retrigger-pr-checks.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,6 @@
 {
-  // Inherits org-wide defaults from .github/configs/.markdownlint-cli2.yaml in CI.
-  // This file provides local overrides only where nix-ai differs from the org config.
+  // Canonical org-wide config: .markdownlint-cli2.yaml at the root of dryvist/.github.
+  // This file deliberately diverges from it; local overrides below document each delta.
   "config": {
     "default": true,
     // MD013: org uses heading 80, code_block 80, tables true.


### PR DESCRIPTION
## Summary

GitHub Actions `uses:` references do not follow account-rename redirects, so dryvist repos must never depend on `JacobPEvans-personal/*` reusable workflows. This PR repoints all such references to the dryvist shared-CI hub (`dryvist/.github`), where every target already exists — including the freshly relocated `_retrigger-pr-checks.yml`.

## Changes

- **`.github/workflows/ci-gate.yml`** — `_nix-validate.yml`, `_markdown-lint.yml`, `_file-size.yml`, `_python-security.yml`, `_osv-scan.yml`: owner segment `JacobPEvans-personal` → `dryvist` (paths and `@main` refs preserved).
- **`.github/workflows/retrigger-pr-checks.yml`** — `_retrigger-pr-checks.yml` repointed to `dryvist/.github`; stale `JacobPEvans/.github` header comments updated.
- **`.markdownlint-cli2.jsonc`** — header comment now names the canonical org config (`.markdownlint-cli2.yaml` at the root of `dryvist/.github`); the file remains deliberately divergent with documented deltas (MD013 wider limits, MD060 disabled pending nixpkgs markdownlint v0.39.0+).

## Left unchanged (intentional)

- **`.github/workflows/gh-aw-pin-refresh.yml`** — `_gh-aw-pin-refresh.yml` has no copy in `dryvist/.github`; repointing it would break the workflow. Still references `JacobPEvans-personal/.github` until the hub gains a copy.
- `*.lock.yml` files and `{{#import}}` directives in gh-aw markdown (compiled/templated content).
- `deps-update-flake.yml` prose comment mentioning `JacobPEvans/.github` (no `uses:` change needed in that file).
- `dispatch-to-nix-darwin.yml` already points at `dryvist/.github` — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)