### PR TITLE
fix(ci): grant actions read to retrigger-pr-checks caller

### DIFF
--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read # callee inspects ci-gate.yml runs; omitting startup-fails the run
   contents: read
   pull-requests: read
 


### PR DESCRIPTION
## Why

"Retrigger PR Checks" startup-fails (0s, zero jobs) on every scheduled run: the hub `_retrigger-pr-checks.yml` job requests `actions: read` to inspect ci-gate runs, and a called workflow can never exceed the caller's token grant — this caller granted only `contents: read` + `pull-requests: read`.

## What

Adds `actions: read` to the caller's workflow-level permissions. Same caller/callee permission-escalation class as dryvist/.github#32; terraform-proxmox's caller already grants it and runs past graph validation.

Note: after this fix the run will still fail at the GitHub App token mint until App 2520943 is installed on the dryvist org (known pending user action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)