### PR TITLE
fix(mlx): tighten seeded runtime config to owner-only perms (0o600)

### DIFF
--- a/modules/mlx/seed-config.py
+++ b/modules/mlx/seed-config.py
@@ -22,8 +22,8 @@ def _atomic_write(target: Path, content: bytes) -> None:
 
     shutil.copy2 would preserve the read-only mode of the Nix-store source,
     making the runtime config un-overwritable on the next activation. Using
-    tmp + os.replace gives us atomicity, an explicit 0o644 mode, and clear
-    swap semantics even when the target already exists.
+    tmp + os.replace gives us atomicity, an explicit owner-only (0o600) mode,
+    and clear swap semantics even when the target already exists.
     """
     fd, tmp = tempfile.mkstemp(
         dir=target.parent, prefix=target.name + ".", suffix=".tmp"
@@ -31,7 +31,9 @@ def _atomic_write(target: Path, content: bytes) -> None:
     try:
         with os.fdopen(fd, "wb") as f:
             f.write(content)
-        os.chmod(tmp, 0o644)
+        # Owner-only: this is a per-user runtime config under ~/.config/mlx,
+        # read only by the user's own llama-swap LaunchAgent.
+        os.chmod(tmp, 0o600)
         os.replace(tmp, target)
     except Exception:
         if os.path.exists(tmp):
@@ -58,7 +60,7 @@ def main() -> None:
     # Atomically create runtime config if it doesn't exist (avoids TOCTOU race
     # with concurrent darwin-rebuild or LaunchAgent startup).
     try:
-        fd = os.open(str(runtime), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        fd = os.open(str(runtime), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         with os.fdopen(fd, "wb") as f:
             f.write(base_content)
         marker.write_text(base_hash + "\n")


### PR DESCRIPTION
## What

Resolves the **2 high-severity** `py/overly-permissive-file` CodeQL alerts in `modules/mlx/seed-config.py` (alerts #24, #25).

`seed-config.py` seeds the llama-swap runtime config at `~/.config/mlx/llama-swap.json` — a per-user file, seeded on `darwin-rebuild switch` and read only by the same user's llama-swap LaunchAgent (`--watch-config`) and `mlx-discover`. World/group-readable `0o644` is unnecessarily broad for an owner-private config.

- `_atomic_write` chmod: `0o644` → `0o600` (+ comment)
- `O_CREAT | O_EXCL | O_WRONLY` create mode: `0o644` → `0o600`
- Docstring updated to say owner-only (0o600)

No behavior change: every reader/writer of this file runs as the owner.

## Verification

- `python3 -c "import ast; ast.parse(...)"` parses.
- Repo pre-commit passes.
- CodeQL is default-setup: alerts #24/#25 auto-close after merge + re-scan.

One of two dedicated CodeQL-remediation PRs for nix-ai (the other pins unpinned Actions). Together they clear all 7 open alerts and unblock the held #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)