### PR TITLE
fix(ci): pin untrusted re-actors/alls-green action to SHA

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -167,7 +167,7 @@ jobs:
     runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
     steps:
       - name: Check all results
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           allowed-skips: nix-validate, markdown-lint, file-size, python-security
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## What

Corrected approach to the `actions/unpinned-tag` CodeQL alerts, per repo policy:

- **Trusted / popular actions keep their `@vN` tags** and their alerts are **dismissed** as accepted (`actions/checkout`, `actions/create-github-app-token`, `DeterminateSystems/determinate-nix-action`, `peter-evans/create-pull-request`, `dorny/paths-filter`).
- **Less-popular third-party actions get SHA-pinned** with a version comment.

The only action in that second bucket here is **`re-actors/alls-green`** — this PR pins it to `05ac9388…# release/v1` (one line in `ci-gate.yml`). Resolves alert **#20** on re-scan.

The other four alerts (**#19** dorny, **#21**/**#23** determinate, **#22** peter-evans) are **dismissed** ("won't fix" — trusted action, tag accepted), not code-changed.

## Verification

- `zizmor` + `check-yaml` pass; diff is a single line.
- After merge + re-scan, alert #20 auto-closes; combined with the 4 dismissals, nix-ai reaches 0 open CodeQL alerts.

(Supersedes the earlier broad SHA-pin attempt on this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)