### PR TITLE
ci: enforce token budgets on AI-read prose via the shared gate

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -126,6 +126,16 @@ jobs:
     with:
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
+  # Token-budgets AI-read prose via the shared tiktoken counter. Config lives in
+  # .token-limits.yaml; pairs with file-size (the byte gate skips token-gated files).
+  token-limits:
+    name: Token Limits
+    needs: changes
+    if: needs.changes.outputs.markdown == 'true'
+    uses: dryvist/.github/.github/workflows/_token-limits.yml@main
+    with:
+      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
+
   python-security:
     name: Python Security
     needs: changes
@@ -155,12 +165,12 @@ jobs:
   # ==========================================================================
   gate:
     name: Merge Gate
-    needs: [changes, nix-validate, markdown-lint, file-size, python-security, osv-scan]
+    needs: [changes, nix-validate, markdown-lint, file-size, token-limits, python-security, osv-scan]
     if: ${{ !cancelled() }}
     runs-on: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
     steps:
       - name: Check all results
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
-          allowed-skips: nix-validate, markdown-lint, file-size, python-security
+          allowed-skips: nix-validate, markdown-lint, file-size, token-limits, python-security
           jobs: ${{ toJSON(needs) }}

--- a/.token-limits.yaml
+++ b/.token-limits.yaml
@@ -1,0 +1,15 @@
+# Token budgets for AI-read prose, enforced by the shared tiktoken counter
+# (dryvist/.github -> _token-limits.yml, wired in .github/workflows/ci-gate.yml).
+# First matching glob wins, so list specific patterns before general ones.
+# Pairs with the byte file-size gate, which skips any file matched here.
+limits:
+  # Always-loaded entry point — keep the per-session cost low.
+  CLAUDE.md: 2000
+
+  # Rule files an agent loads as background context.
+  .claude/rules/*.md: 2000
+  modules/claude/rules/*.md: 2000
+
+  # Module and architecture documentation.
+  modules/*/README.md: 3000
+  docs/*.md: 3000

--- a/.token-limits.yaml
+++ b/.token-limits.yaml
@@ -1,6 +1,9 @@
 # Token budgets for AI-read prose, enforced by the shared tiktoken counter
 # (dryvist/.github -> _token-limits.yml, wired in .github/workflows/ci-gate.yml).
 # First matching glob wins, so list specific patterns before general ones.
+# Patterns use Python fnmatch, where '*' also crosses '/' — so 'docs/*.md'
+# covers docs/ AND every subdirectory (architecture/, adr/, runbooks/), and
+# 'modules/*/README.md' covers any depth. Do not "fix" these to '**'.
 # Pairs with the byte file-size gate, which skips any file matched here.
 limits:
   # Always-loaded entry point — keep the per-session cost low.


### PR DESCRIPTION
## What

Wires this repo into the shared **token-limits** gate. Two minimal, repo-local
artifacts only — no scripts, no copy of the upstream tokenizer:

- `.github/workflows/ci-gate.yml`: a thin `token-limits` job calling
  `dryvist/.github/.github/workflows/_token-limits.yml@main`, added to the Merge
  Gate `needs` + `allowed-skips`.
- `.token-limits.yaml`: budgets for AI-read prose (CLAUDE.md/rules 2000, docs +
  module READMEs 3000), mirroring the `ai-assistant-instructions` pattern.

The tiktoken counter and all logic stay upstream and are sparse-checked-out at
runtime. Pairs with the byte `file-size` gate (the byte gate skips token-gated files).

## Verification

Ran the upstream `check-token-limits.py` logic locally with the real `o200k_base`
tokenizer: **20 files gated, 0 exceeding** (largest `per-agent-flakes.md` at
2592/3000). No prose needed trimming.