### PR TITLE
feat: evaluate homeManagerModules.default with zero consumer config

### DIFF
--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -40,6 +40,11 @@ in
 {
   options.services.aiStack.defaultLocalModelId = lib.mkOption {
     type = lib.types.str;
+    # Empty default so `homeManagerModules.default` evaluates with zero consumer
+    # config — local MLX inference is simply inert until a real id is set. The
+    # maintainer's nix-darwin sets it from AI_MODEL_LOCAL_LLM. Never hardcode a
+    # physical model id in this repo.
+    default = "";
     example = "mlx-community/<provider-tag>-<model-name>-<quant>";
     description = ''
       Local MLX physical model id used as the single resident model for

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -75,6 +75,7 @@ in
   };
 
   imports = [
+    ./user-defaults.nix
     ./ai-shell.nix
     ./ai-stack
     ./agent-skills

--- a/modules/user-defaults.nix
+++ b/modules/user-defaults.nix
@@ -1,0 +1,13 @@
+# Default user identity, so `homeManagerModules.default` evaluates with zero
+# consumer config. Several modules read `userConfig` via `_module.args`; this
+# guarantees it always resolves. Consumers (e.g. nix-darwin) override by setting
+# `_module.args.userConfig` at a higher priority — `mkDefault` yields to them.
+#
+# This module intentionally does NOT consume `userConfig` itself, to avoid a
+# `_module.args` self-reference cycle.
+{ lib, ... }:
+{
+  _module.args.userConfig = lib.mkDefault {
+    user.fullName = "JacobPEvans";
+  };
+}

--- a/modules/user-defaults.nix
+++ b/modules/user-defaults.nix
@@ -1,13 +1,24 @@
 # Default user identity, so `homeManagerModules.default` evaluates with zero
-# consumer config. Several modules read `userConfig` via `_module.args`; this
-# guarantees it always resolves. Consumers (e.g. nix-darwin) override by setting
-# `_module.args.userConfig` at a higher priority — `mkDefault` yields to them.
+# consumer config. Several modules read `userConfig` via `_module.args`.
 #
-# This module intentionally does NOT consume `userConfig` itself, to avoid a
-# `_module.args` self-reference cycle.
-{ lib, ... }:
+# Declaring it as a typed option lets consumers override individual fields
+# (e.g. `userConfig.user.fullName = "Alice";`) with normal merge semantics;
+# binding `_module.args.userConfig` to that option avoids a self-reference
+# cycle. The binding is `mkDefault` so a consumer (or the regression harness)
+# may also set `_module.args.userConfig` directly at higher priority.
+{ lib, config, ... }:
 {
-  _module.args.userConfig = lib.mkDefault {
-    user.fullName = "JacobPEvans";
+  options.userConfig = lib.mkOption {
+    type = lib.types.submodule {
+      options.user.fullName = lib.mkOption {
+        type = lib.types.str;
+        default = "JacobPEvans";
+        description = "Full name / GitHub handle used to derive the trusted org and docs host.";
+      };
+    };
+    default = { };
+    description = "Global user configuration shared across nix-ai modules.";
   };
+
+  config._module.args.userConfig = lib.mkDefault config.userConfig;
 }


### PR DESCRIPTION
## What

Makes `homeManagerModules.default` **evaluate with zero consumer config** — a bare
consumer setting only `home.{username,homeDirectory,stateVersion}` no longer throws.

Two required-but-undefaulted args were the blockers:
- `services.aiStack.defaultLocalModelId` (no default) → defaults to `""`. Local MLX
  inference is inert until a real id is set. The maintainer's nix-darwin still
  supplies it from `AI_MODEL_LOCAL_LLM`; no hardcoded model id enters this repo.
- `userConfig` (read via `_module.args` by several modules) → a global `mkDefault`
  in `modules/user-defaults.nix`. Consumers override at higher priority.

## Verification

`nix eval` of `cfg.config.home.activationPackage` on **x86_64-linux** with only the
three required `home.*` values → `ZERO-CONFIG-OK`. `nix flake check` passes (the
existing regression tests still inject explicit values; `mkDefault` yields to them).

## Not in scope (tracked separately)

Deeper de-personalization — see the tracking issue.