### PR TITLE
docs(readme): beautify — badges, accurate content, standalone read

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ that merge into your existing configuration:
 ### Self-contained design
 
 The module injects its own dependencies via `_module.args`. Your consuming flake
-only needs two follows lines:
+only needs two `follows` lines:
 
 ```nix
 inputs.nixpkgs.follows = "nixpkgs";

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # nix-ai
 
 [![CI](https://github.com/JacobPEvans/nix-ai/actions/workflows/ci-gate.yml/badge.svg)](https://github.com/JacobPEvans/nix-ai/actions/workflows/ci-gate.yml)
+[![Release](https://img.shields.io/github/v/release/JacobPEvans/nix-ai?sort=semver)](https://github.com/JacobPEvans/nix-ai/releases)
+[![License](https://img.shields.io/github/license/JacobPEvans/nix-ai)](LICENSE)
+[![Built with Nix](https://img.shields.io/badge/built%20with-Nix-5277C3?logo=nixos&logoColor=white)](https://nixos.org/)
 
 ## Your AI coding toolkit, declared once. Reproduced everywhere
 
 Ever spent hours configuring Claude Code plugins, Gemini settings, and MCP servers
--- only to lose it all when you switch machines?
-**nix-ai** captures your entire AI setup as code using [Nix](https://nixos.org/).
-One command rebuilds everything, identically, every time.
+— only to lose it all when you switch machines? **nix-ai** captures your entire AI
+setup as code using [Nix](https://nixos.org/). One command rebuilds everything,
+identically, every time.
 
 ---
 
@@ -15,24 +18,24 @@ One command rebuilds everything, identically, every time.
 
 | Tool | What you get |
 | ---- | ------------ |
-| **Claude Code** | [Plugin ecosystem](modules/claude/README.md), hooks, agents, commands, rules, statusline |
-| **Gemini CLI** | Settings, custom commands, permission rules |
+| **Claude Code** | [Plugin ecosystem](modules/claude/plugins/README.md), hooks, agents, commands, rules |
+| **Gemini / Antigravity** | CLI + IDE settings, custom commands, permission rules |
 | **GitHub Copilot** | Configuration, permissions |
-| **OpenAI Codex** | Settings |
-| **MCP Servers** | 15+ servers — GitHub, Terraform, Context7, filesystem, memory, and more |
-| **Plugin Marketplace** | [Curated marketplaces](modules/claude/plugins/README.md) with Nix-pinned flake inputs |
-| **AI Dev Tools** | cclint, doppler-mcp, claude-flow, splunk-mcp-connect |
-| **MLX** | Local Apple Silicon inference via vllm-mlx with macOS launchd integration |
+| **OpenAI Codex** | Settings, rules, approval policy |
+| **Qwen Code & Cecli** | Settings for the Alibaba and Aider-fork CLIs |
+| **MCP Servers** | One [catalog](modules/mcp/README.md) (GitHub, Terraform, Context7, filesystem, memory, …) fanned out to every agent |
+| **AI Dev Tools** | cclint, doppler-mcp, claude-flow, and more |
+| **MLX** *(macOS)* | Local Apple Silicon inference via vllm-mlx with launchd integration |
 
 ## Prerequisites
 
-- [Nix](https://nixos.org/) (Determinate Nix recommended)
+- [Nix](https://nixos.org/) with flakes (Determinate Nix recommended)
 - [home-manager](https://github.com/nix-community/home-manager)
-- Compatible platform: `aarch64-darwin` or `x86_64-linux`
+- A supported platform: `aarch64-darwin` or `x86_64-linux`
 
 ## Installation
 
-Add to your Nix flake:
+Add the input to your flake:
 
 ```nix
 {
@@ -44,120 +47,84 @@ Add to your Nix flake:
 }
 ```
 
-Then in your home-manager config:
+Then add the module to your home-manager config:
 
 ```nix
 sharedModules = [ nix-ai.homeManagerModules.default ];
 ```
 
-That's it. Every AI tool, every plugin, every permission rule — managed by Nix.
+That's it. The module evaluates with **zero extra configuration** — every AI tool,
+plugin, and permission rule comes preconfigured. (Local MLX inference stays idle
+until you point it at a model; see [Usage](#usage).)
 
 ## How it works
 
-nix-ai exports [home-manager](https://github.com/nix-community/home-manager) modules that merge into your existing configuration:
+nix-ai exports [home-manager](https://github.com/nix-community/home-manager) modules
+that merge into your existing configuration:
 
 | Export | What it includes |
 | ------ | --------------- |
-| `homeManagerModules.default` | Full AI stack — Claude, Gemini, Copilot, Codex, MCP, MLX, dev tools |
+| `homeManagerModules.default` | The full AI stack — every tool below |
 | `homeManagerModules.claude` | Just Claude Code |
 | `homeManagerModules.codex` | Just OpenAI Codex |
+| `homeManagerModules.mcp` | Just the MCP server catalog |
 | `homeManagerModules.maestro` | Just Maestro orchestration |
-| `lib.ci.claudeSettingsJson` | Pure JSON for CI validation (no derivations needed) |
-| `lib.ci.codexRules` | Codex rules export for CI validation and downstream consumers |
-| `lib.aiStackModels` | Role-name → physical model ID registry builder — a function `{ defaultLocalModelId }` (no module system needed) |
-
-### Foreign consumption — `lib.aiStackModels`
-
-`lib.aiStackModels` is a function `{ defaultLocalModelId }` (no home-manager module system
-required) that maps every stable capability-class name to the supplied physical
-`mlx-community/*` model ID. The caller provides `defaultLocalModelId` (sourced from the
-`AI_MODEL_LOCAL_LLM` org variable / Doppler secret — never hardcoded in this repo). Any
-external flake can call it directly so `model: "default"` resolves prefix-free without
-duplicating the registry — for example, to build a model-gateway alias table:
-
-```nix
-inputs.nix-ai.url = "github:JacobPEvans/nix-ai";
-# ...
-# Map role names to mlx-local/ prefixed physical IDs
-aliases = lib.mapAttrs
-  (_role: physical: "mlx-local/${physical}")
-  (inputs.nix-ai.lib.aiStackModels { defaultLocalModelId = "mlx-community/<provider-tag>-<model-name>-<quant>"; });
-```
-
-The module option `services.aiStack.models` remains the public API for nix-ai home-manager
-consumers; `lib.aiStackModels` is for foreign consumers that do not import the module.
+| *(also: `agent-skills`, `antigravity-cli`, `antigravity-ide`, `cecli`, `qwen-code`)* | One module per tool |
+| `lib.ci.claudeSettingsJson` | Pure settings JSON for CI validation (no derivations) |
+| `lib.aiStackModels` | Role-name → model-ID registry, for foreign (non-module) consumers |
 
 ### Self-contained design
 
-The module injects its own dependencies via `_module.args`. Your consuming flake only needs two lines:
+The module injects its own dependencies via `_module.args`. Your consuming flake
+only needs two follows lines:
 
 ```nix
 inputs.nixpkgs.follows = "nixpkgs";
 inputs.home-manager.follows = "home-manager";
 ```
 
-No AI-specific inputs to wire up. No extra configuration. It just works.
+No AI-specific inputs to wire up, no extra configuration. It just works.
 
 ## Usage
 
-Key enable toggles exposed by the default module:
+Everything is enabled with sensible defaults. Common toggles on the default module:
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
-| `programs.claude.enable` | bool | — | Enable Claude Code configuration |
-| `programs.claude.apiKeyHelper.enable` | bool | false | Headless API key authentication via Bitwarden |
-| `programs.claudeStatusline.enable` | bool | false | Claude Code powerline statusline |
-| `programs.claude.settings.sandbox.enabled` | bool | false | Filesystem/network sandbox isolation |
-| `programs.claude.settings.alwaysThinkingEnabled` | bool | true | Extended thinking mode |
-| `programs.claude.remoteControlAtStartup` | bool or null | null | Remote Control auto-start |
-| `programs.claude.model` | string or null | null | Override default model (e.g. `"opus"`, `"sonnet"`) |
-| `programs.claude.effortLevel` | enum or null | `null` | Adaptive reasoning effort (`"low"`, `"medium"`, `"high"`); null = upstream default (medium for Max/Team as of v2.1.68) |
-| `programs.claude.trustedProjectDirs` | list of str | `[]` | Base directories for auto-trust of CLAUDE.md imports |
+| `programs.claude.model` | str or null | `null` | Override the default model (e.g. `"opus"`, `"sonnet"`) |
+| `programs.claude.effortLevel` | enum or null | `null` | Reasoning effort (`"low"` / `"medium"` / `"high"`); null = upstream default |
+| `programs.claude.settings.sandbox.enabled` | bool | `false` | Filesystem/network sandbox isolation |
+| `programs.claude.trustedProjectDirs` | list of str | `[]` | Directories auto-trusted for CLAUDE.md imports |
+| `services.aiStack.defaultLocalModelId` | str | `""` | Local MLX model ID; set to enable on-device inference |
 
-For the full option set, see [`modules/claude/options.nix`](modules/claude/options.nix).
+Claude's full option schema comes from [nix-claude-code](https://github.com/dryvist/nix-claude-code);
+the MCP catalog is documented in [`modules/mcp/README.md`](modules/mcp/README.md).
 
 ## Testing and validation
 
-Run quality checks locally:
-
 ```bash
-nix flake check
-```
-
-This runs formatting (nixfmt), static analysis (statix), dead code detection (deadnix),
-shell script linting (shellcheck), and full module evaluation (module-eval) to verify
-the home-manager module instantiates correctly with real inputs.
-
-Fix formatting automatically:
-
-```bash
-nix fmt
+nix flake check   # nixfmt, statix, deadnix, shellcheck, and full module evaluation
+nix fmt           # auto-fix formatting
 ```
 
 ## Repository structure
 
 ```text
 modules/
-├── claude/          # Claude Code module — see [modules/claude/README.md](modules/claude/README.md)
-├── maestro/         # Maestro agent orchestration
-├── mcp/             # 15+ MCP server definitions
-├── common/          # Shared permission engine
-├── gh-extensions/   # GitHub CLI extensions (gh-aw)
-├── permissions/     # Per-tool permission rules
-├── mlx/             # MLX inference server (vllm-mlx)
-├── ai-tools.nix     # AI development tool packages
-├── gemini.nix       # Gemini CLI configuration
-├── copilot.nix      # GitHub Copilot configuration
-└── codex.nix        # OpenAI Codex configuration
-lib/                  # Key lib files (not full listing)
-├── claude-settings.nix    # Pure settings generator
-└── claude-registry.nix    # Marketplace format functions
+├── claude/         # Claude Code — plugins, hooks, agents, rules
+├── codex/          # OpenAI Codex
+├── antigravity-*/  # Gemini / Antigravity CLI + IDE
+├── cecli/          # Cecli (Aider fork)
+├── qwen-code/      # Alibaba Qwen Code
+├── mcp/            # MCP server catalog, fanned out to every agent
+├── mlx/            # MLX local inference (vllm-mlx, macOS)
+├── fabric/         # Fabric prompt patterns + CLI
+├── agent-skills/   # Cross-tool skill deployment
+└── common/         # Shared permission engine and formatters
+lib/                # Pure helpers (settings/registry generators, CI exports)
+docs/               # Architecture notes (docs/architecture) and ADRs (docs/adr)
 ```
 
 ## License
 
-MIT
-
----
-
-> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.
+[MIT](LICENSE)


### PR DESCRIPTION
Polishes the README for a popular, standalone repo.

- **Badges**: CI, latest release, license, built-with-Nix (all render under the
  current owner).
- **Accuracy**: exports table and repo-structure block now match the actual tree;
  removed hardcoded counts (`15+`, `252+`) per the no-hardcoded-counts rule.
- **Fixed broken links**: `modules/claude/README.md` and `modules/claude/options.nix`
  404'd on main (the Claude schema lives in nix-claude-code now) → repointed to
  `modules/claude/plugins/README.md` and the nix-claude-code repo.
- **Simpler**: trimmed the advanced `lib.aiStackModels` deep-dive to a pointer;
  noted the new zero-config behavior; dropped the cross-repo footer.

markdownlint clean; all links verified to resolve.