### PR TITLE
docs: streamline docs and scrub stale references

### DIFF
--- a/.claude/rules/plugin-cache-architecture.md
+++ b/.claude/rules/plugin-cache-architecture.md
@@ -3,9 +3,8 @@ description: Marketplace symlinks vs cache, never delete cache mid-session, neve
 paths:
   - "**/.claude/plugins/**"
   - "**/modules/claude/**"
-  - "**/plugins.nix"
+  - "**/claude-config.nix"
   - "**/plugins/*.nix"
-  - "**/orphan-cleanup.nix"
 ---
 
 # Plugin Cache Architecture
@@ -15,7 +14,7 @@ paths:
 Marketplace directories (`~/.claude/plugins/marketplaces/`) are single directory symlinks
 to the Nix store, NOT recursive per-file symlinks.
 
-**Never use `recursive = true` or `force = true` in `plugins.nix`:**
+**Never use `recursive = true` or `force = true` when symlinking marketplaces:**
 
 - `recursive = true` creates per-file symlinks, which allows `.backup` file pollution
 - `force = true` causes home-manager to rename existing files to `.backup`, polluting
@@ -53,8 +52,8 @@ call fails, including the Stop hook, creating an unbreakable error loop.
 The correct mechanism is:
 
 - **Nix-managed marketplace symlinks** update the store path on rebuild
-- **`verify-cache-integrity.sh`** (in `orphan-cleanup.nix`) detects stale caches via hash comparison
-  and purges only when the store path actually changed
+- **Cache-integrity verification** (in the `nix-claude-code` flake input) detects stale
+  caches via hash comparison and purges only when the store path actually changed
 - **Claude Code detects marketplace changes on new session start** — no forced re-index needed
 
 Commit `edba1ad` (2026-03-19) introduced an `updateClaudePlugins` activation script that violated
@@ -76,11 +75,5 @@ Additionally, Claude Code discovers marketplaces via `~/.claude/plugins/known_ma
 (its actual registry), NOT directly from `extraKnownMarketplaces` in `settings.json`. Entries
 propagate from `extraKnownMarketplaces` only when Claude Code can successfully fetch the
 marketplace from the declared GitHub source. Synthetic marketplaces fail this fetch (no upstream
-structure), so the `knownMarketplacesMerge` activation in `settings.nix` ensures the local
-`installLocation` is registered directly.
-
-## Migration Path
-
-Phase 1 of `orphan-cleanup.nix` handles the one-time migration from `recursive = true`
-(real directories with per-file symlinks) to directory symlinks. After the first rebuild,
-marketplace paths are already symlinks and the migration code is a no-op.
+structure), so the `knownMarketplacesMerge` activation in `modules/default.nix` ensures the
+local `installLocation` is registered directly.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,47 +1,52 @@
-# GitHub Copilot Instructions — terraform-proxmox
+# GitHub Copilot Instructions — nix-ai
 
 ## Repository Purpose
 
-Infrastructure as code for provisioning VMs and containers on Proxmox VE using
-OpenTofu + Terragrunt. Downstream repos (ansible-proxmox-apps, ansible-splunk) consume
-the outputs.
+nix-ai is an AI CLI ecosystem (Claude Code, Antigravity, Codex, Copilot, MCP
+servers, MLX inference) delivered as Nix home-manager modules. It exports
+modules consumed by `nix-darwin`; this repo holds the module definitions, not a
+deployed system.
 
-## CRITICAL: OpenTofu, Not Terraform
+## Critical Constraints
 
-This repo uses **OpenTofu** (`tofu`), not Terraform. Never generate `terraform` CLI commands.
-The binary is `tofu`. All HCL is OpenTofu-compatible.
+- **Flakes-only.** Never generate `nix-env` or other imperative Nix commands.
+- **Module args injection.** Flake inputs reach modules via `_module.args`, not
+  function parameters.
+- **No direct main commits.** Always work on a feature branch in a worktree.
 
-## Running Commands
+## Validation
 
-All commands must be wrapped with aws-vault and Doppler:
-
-```bash
-aws-vault exec terraform -- doppler run -- terragrunt <COMMAND>
-```
-
-For plan/apply:
+Static checks run on every change:
 
 ```bash
-aws-vault exec terraform -- doppler run -- terragrunt plan
-aws-vault exec terraform -- doppler run -- terragrunt apply
+nix flake check    # formatting, statix, deadnix, regression tests
+nix fmt            # auto-fix formatting
 ```
 
-## Technology Stack
+Runtime changes (plugins, hooks, settings, activations, MCP servers) also need a
+real rebuild and a fresh Claude Code session — static checks validate Nix
+evaluation, not runtime behavior:
 
-- **OpenTofu** (not Terraform) — IaC engine
-- **Terragrunt** — wrapper for DRY config and remote state
-- **Doppler** — secrets management (runtime env vars)
-- **aws-vault** — AWS credentials
-- **SOPS/age** — encrypted secrets in repo (`terraform.sops.json`)
+```bash
+sudo darwin-rebuild switch --flake "$HOME/git/nix-darwin/main" \
+  --override-input nix-ai "$HOME/git/nix-ai/<worktree>"
+```
 
-## HCL Conventions
+## Conventions
 
-- Module inputs in `variables.tf`, outputs in `outputs.tf`, providers in `providers.tf`
-- Use `deployment.json` for environment-specific non-secret config
-- Use `terraform.sops.json` for encrypted secrets (edit with `sops terraform.sops.json`)
-- Terragrunt config in `terragrunt.hcl` at each module root
+- Scripts longer than a few lines live in `scripts/*.sh`, never inline in `.nix`.
+- Never hardcode model IDs, endpoints, or version strings — read them from
+  `vars/ai-stack.nix` (the central registry).
+- Never put secrets in Nix expressions or `env:` blocks; they end up in the
+  world-readable Nix store. Use Doppler or the macOS Keychain.
 
-## CI
+## Key Files
 
-The `Terraform CI` workflow validates HCL syntax and runs `tofu validate`.
-Fix all validation errors before merging.
+- `modules/default.nix` — module entry point
+- `modules/mcp/catalog.nix` — shared MCP server catalog
+- `modules/mlx/` — local Apple Silicon inference (vllm-mlx LaunchAgent)
+- `vars/ai-stack.nix` — model/endpoint/version registry
+- `lib/checks/` — per-domain regression tests
+
+See [`CLAUDE.md`](../CLAUDE.md) and [`docs/architecture/`](../docs/architecture/README.md)
+for the full architecture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # nix-ai - AI Agent Instructions
 
-AI CLI ecosystem for Claude, Gemini, Copilot, MCP servers via Nix home-manager modules.
+AI CLI ecosystem for Claude, Antigravity, Codex, Copilot, and MCP servers via
+Nix home-manager modules.
 
 ## Critical Constraints
 
@@ -51,12 +52,12 @@ inputs.nix-ai.inputs.home-manager.follows = "home-manager";
 
 ### What belongs here (nix-ai)
 
-- AI CLI tools (Claude Code, Gemini, Copilot, Codex, block-goose)
+- AI CLI tools (Claude Code, Antigravity, Codex, Copilot, qwen-code, cecli)
 - MCP servers and wrappers (github-mcp-server, terraform-mcp-server, doppler-mcp, etc.)
 - AI-specific GitHub CLI extensions (gh-aw)
 - AI tool configuration files (`.claude/`, `.gemini/`, `.copilot/`)
 - MLX inference server (vllm-mlx LaunchAgent + wrappers)
-- AI-specific shell utilities (doppler-mcp, hf CLI wrapper)
+- AI-specific shell utilities (hf CLI wrapper, Doppler-wrapped aliases)
 
 ### Package placement
 
@@ -75,12 +76,12 @@ secrets-and-injection, mlx-stack. Design decisions in [`docs/adr/`](docs/adr/REA
 ## Key Files
 
 - `modules/default.nix` — Module entry point
-- `modules/claude/` — Claude Code module ([README](modules/claude/README.md))
-- `modules/mcp/` — MCP server definitions
+- `modules/claude-config.nix` — Claude Code config (settings/permissions/marketplace catalog come from the `nix-claude-code` flake input)
+- `modules/claude/plugins/` — Plugin tier files ([README](modules/claude/plugins/README.md))
+- `modules/mcp/catalog.nix` — MCP server definitions
 - `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools)
 - `modules/common/` — Shared permission engine and formatters
-- `lib/claude-settings.nix` — Pure settings generator (CI-only; deployment uses `modules/claude/settings.nix`)
-- `lib/claude-registry.nix` — Marketplace format functions
+- `vars/ai-stack.nix` — Central model/endpoint/version registry
 - `lib/checks/` — Per-domain regression tests (lint, claude, mlx)
 
 ## MLX Ecosystem

--- a/docs/ai-tool-decision-tree.md
+++ b/docs/ai-tool-decision-tree.md
@@ -8,7 +8,7 @@ When to use which tool for AI-assisted tasks in the nix-ai ecosystem.
 | --- | --- | --- |
 | One-shot text transformation in a shell pipeline | `fabric --pattern X` | Pipe-based, no Claude Code needed |
 | YouTube video processing | `fabric -y URL --pattern summarize` | Built-in yt-dlp + Jina extraction |
-| Want Claude Code to auto-invoke a pattern | Fabric skills (synthetic marketplace) | 32 curated patterns auto-loaded by description match |
+| Want Claude Code to auto-invoke a pattern | Fabric skills (synthetic marketplace) | Curated patterns auto-loaded by description match |
 | Want to explicitly call a pattern from Claude Code | Fabric MCP server | Pattern appears as a callable MCP tool |
 | Single external model call | Bifrost (`localhost:30080`) | OpenAI-compatible, multi-provider |
 | Writing Python/Go code that calls an LLM | Anthropic SDK / OpenAI SDK | Direct API, no middleware |
@@ -42,7 +42,7 @@ Use when:
 
 Best for: **letting Claude Code pick the right pattern automatically**
 
-32 curated patterns are registered as Claude Code skills via the synthetic
+A curated subset of patterns is registered as Claude Code skills via the synthetic
 marketplace. Claude Code loads them based on description matching — you don't
 need to ask for a specific pattern.
 
@@ -55,7 +55,7 @@ Use when:
 Not for:
 
 - Tasks that need a specific pattern — use the CLI or MCP server instead
-- Patterns not in the curated 32 — use CLI or expand the set (#446)
+- Patterns outside the curated subset — use the CLI or expand the set
 
 ## When to Use Fabric MCP Server
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,7 +16,7 @@ This directory contains cross-cutting architecture views for nix-ai's AI tool ec
 
 ### [system-integration-map.md](system-integration-map.md)
 
-Full integration diagram showing all 10 AI products and how they connect. Start here for
+Full integration diagram showing every AI product and how they connect. Start here for
 an overview of what talks to what, which ports are used, and which MCP servers are shared
 across tools vs product-specific.
 
@@ -60,7 +60,7 @@ flake. Reference implementations: `modules/cecli/` (`buildPythonApplication`) an
 `modules/qwen-code/` (brew). Includes a "Why not uv2nix" trade-off analysis.
 
 **Read when**: Adding a new AI agent CLI to nix-ai, refactoring one of the existing
-modules (Claude/Gemini/Codex/fabric) to the uniform layout, or extracting a module
+modules (Claude/Antigravity/Codex/fabric) to the uniform layout, or extracting a module
 into a standalone flake.
 
 ### [plugin-scoping.md](plugin-scoping.md)

--- a/docs/architecture/config-lifecycle.md
+++ b/docs/architecture/config-lifecycle.md
@@ -32,7 +32,7 @@ activation scripts via Nix store paths baked into the derivation at evaluation t
 **Examples:**
 
 - `modules/mlx/default.nix` → `pkgs.writeText "llama-swap-config.json"` (process management config)
-- `modules/claude/settings.nix` → JSON derivation for settings merge
+- `modules/claude-config.nix` (+ `nix-claude-code` flake input) → JSON derivation for settings merge
 - `modules/codex/settings.nix` → TOML derivation for config merge
 
 **Constraint**: The MLX model list in `llama-swap.json` is seeded from `programs.mlx.models`
@@ -65,13 +65,12 @@ All `home.activation` entries and their targets:
 
 | Activation Name | Source File | Target File | What It Does |
 |----------------|-------------|-------------|-------------|
-| `claudeJsonMerge` | `modules/claude/settings.nix` | `~/.claude.json` | MCP servers, project trust, remoteControl |
-| `claudeSettingsMerge` | `modules/claude/settings.nix` | `~/.claude/settings.json` | Permissions, plugins, hooks, model, sandbox |
-| `knownMarketplacesMerge` | `modules/claude/settings.nix` | `~/.claude/plugins/known_marketplaces.json` | Synthetic marketplace registry |
-| `mergeGeminiSettings` | `modules/gemini/settings.nix` | `~/.gemini/settings.json` | MCP servers, policies, folder trust |
+| Claude settings merge | `nix-claude-code` flake input (wired via `modules/claude-config.nix`) | `~/.claude.json`, `~/.claude/settings.json` | MCP servers, project trust, permissions, plugins, hooks, model, sandbox |
+| `knownMarketplacesMerge` | `modules/default.nix` | `~/.claude/plugins/known_marketplaces.json` | Synthetic marketplace registry |
+| `mergeAntigravitySettings` | `modules/antigravity-cli/settings.nix` | `~/.gemini/antigravity-cli/settings.json` | MCP servers, policies, folder trust |
 | `codexConfigMerge` | `modules/codex/settings.nix` | `~/.codex/config.toml` | Model, MCP servers, approval policy |
 | `seedLlamaSwapConfig` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Copies Nix-generated seed; preserves runtime models |
-| `wakaTimeConfig` | `modules/claude/default.nix` | `~/.wakatime.cfg` | Injects WakaTime API key from Doppler |
+| `discoverMlxModels` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Extends the seed with locally available MLX models |
 
 ## Config File Patterns
 
@@ -81,12 +80,12 @@ consuming tool writes to its own config file at runtime.
 | Pattern | Mechanism | Used When | Examples |
 |---------|-----------|-----------|---------|
 | **Nix store symlink** | `home.file` | Tool is read-only toward config | Plugin dirs, patterns, playbooks, copilot trusted folders |
-| **Activation deep-merge** | `home.activation` + shell script | Tool writes runtime state to config | `~/.claude.json`, `~/.gemini/settings.json`, `~/.codex/config.toml` |
+| **Activation deep-merge** | `home.activation` + shell script | Tool writes runtime state to config | `~/.claude.json`, `~/.gemini/antigravity-cli/settings.json`, `~/.codex/config.toml` |
 | **Activation seed + runtime extension** | `seed-config.py` + `mlx-discover` | Config is both Nix-seeded and runtime-extensible | `~/.config/mlx/llama-swap.json` |
 
-### Why `home.file` Symlinks Break for Claude/Gemini/Codex
+### Why `home.file` Symlinks Break for Claude/Antigravity/Codex
 
-Claude Code, Gemini, and Codex all write to their config files at runtime:
+Claude Code, Antigravity, and Codex all write to their config files at runtime:
 authentication tokens, session state, user preferences set via `claude config set`, etc.
 
 A `home.file` symlink points into `/nix/store/` which is world-readable but **not

--- a/docs/architecture/per-agent-flakes.md
+++ b/docs/architecture/per-agent-flakes.md
@@ -2,7 +2,7 @@
 
 ## Why this exists
 
-nix-ai grew organically: Claude, Gemini, Codex, fabric, and (formerly)
+nix-ai grew organically: Claude, Antigravity, Codex, fabric, and (formerly)
 Aider all live as sibling modules under `modules/`. Each has its own
 shape, its own opinions about install source, its own depth of
 configuration. Adding a new agent means re-deciding all of that.
@@ -45,7 +45,7 @@ Reference implementations:
   `optionalDependencies` need deeper packaging work and that path is
   deferred.
 
-Existing modules (`modules/claude/`, `modules/gemini/`, `modules/codex/`,
+Existing modules (`modules/claude/`, `modules/antigravity-cli/`, `modules/codex/`,
 `modules/fabric/`) predate this pattern. They work fine and are not
 being refactored in the same PR — that's a follow-up sweep tracked
 separately.
@@ -197,7 +197,7 @@ one of these triggers fires.
 
 ## Migration checklist for existing modules
 
-When refactoring `modules/claude/`, `modules/gemini/`, `modules/codex/`,
+When refactoring `modules/claude/`, `modules/antigravity-cli/`, `modules/codex/`,
 or `modules/fabric/` to this pattern:
 
 - [ ] Split `default.nix` into the 4-5 standard sub-files.

--- a/docs/architecture/plugin-scoping.md
+++ b/docs/architecture/plugin-scoping.md
@@ -104,16 +104,18 @@ level, so the per-repo override works without a rebuild.
 
 ## Budget headroom
 
-`modules/claude/options.nix` sets `skillListingBudgetFraction = 0.02` (2%) — double
-the 1% upstream default. The extra budget is headroom for the universal plugin set
-without dropping descriptions even if a few project plugins are also enabled per-repo.
+The `skillListingBudgetFraction` option (schema and default provided by the
+`nix-claude-code` flake input) controls how much of the context window Claude
+Code reserves for skill descriptions. Raising it above the upstream default gives
+headroom for the universal plugin set without dropping descriptions even if a few
+project plugins are also enabled per-repo.
 
 If `/doctor` ever reports drops again:
 
 1. Check whether new universal-tier plugins were added (Tier 1–4) — prefer pruning over
    raising the budget.
-2. If pruning is not viable, raise `skillListingBudgetFraction` in
-   `modules/claude/options.nix`.
+2. If pruning is not viable, set a higher `skillListingBudgetFraction` in
+   `modules/claude-config.nix`.
 
 ## Verification
 
@@ -134,6 +136,5 @@ After adding per-repo `.claude/settings.json` in a consumer repo:
 ## Related
 
 - `modules/claude/plugins/05-specialty.nix` — globally disabled project-specific plugins
-- `modules/claude/options.nix` — `skillListingBudgetFraction` option
-- `modules/claude/settings.nix` — settings.json generator
+- `modules/claude-config.nix` — Claude config wiring (`skillListingBudgetFraction`, plugin enables)
 - `.claude/rules/plugin-cache-architecture.md` — read/write boundaries for plugin cache

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -12,7 +12,7 @@ _This document is part of [`docs/architecture/`](README.md)._
 graph TD
     subgraph Clients["AI CLI Clients"]
         CC["Claude Code"]
-        GEM["Gemini CLI"]
+        GEM["Antigravity CLI"]
         CDX["Codex CLI"]
         COP["Copilot"]
     end
@@ -68,28 +68,28 @@ graph TD
 
 | Product | Module Path | Transport | Purpose | Key Config Files |
 |---------|------------|-----------|---------|-----------------|
-| Claude Code | `modules/claude/` | Desktop app | Primary AI coding assistant | `~/.claude/settings.json`, `~/.claude.json` |
-| Gemini CLI | `modules/gemini/` | CLI | Google AI assistant | `~/.gemini/settings.json` |
+| Claude Code | `modules/claude-config.nix` | Desktop app | Primary AI coding assistant | `~/.claude/settings.json`, `~/.claude.json` |
+| Antigravity CLI | `modules/antigravity-cli/` | CLI | Google Antigravity assistant | `~/.gemini/antigravity-cli/settings.json` |
 | Codex CLI | `modules/codex/` | CLI | OpenAI coding assistant | `~/.codex/config.toml` |
 | GitHub Copilot CLI | `modules/copilot.nix` | CLI | Trusted folder configuration | `~/.copilot/config.json` |
 | Bifrost | `orbstack-kubernetes` repo | HTTP :30080 | Multi-provider AI gateway | K8s secrets (Doppler Operator) |
 | MLX / llama-swap | `modules/mlx/` | HTTP :11434 | Local Apple Silicon inference | `~/.config/mlx/llama-swap.json` |
-| Fabric | `modules/fabric/` | CLI + HTTP :8180 | 252+ AI prompt patterns | `~/.config/fabric/` |
+| Fabric | `modules/fabric/` | CLI + HTTP :8180 | AI prompt pattern library | `~/.config/fabric/` |
 | Open WebUI | `modules/open-webui.nix` | HTTP :8080 | Browser UI for MLX | None (queries MLX at runtime) |
 | Maestro | `modules/maestro/` | Cron → subprocess | Scheduled Claude sessions | `~/Maestro/Auto Run Docs/` |
 
 ## MCP Server Connectivity
 
 The MCP server catalog (`modules/mcp/catalog.nix`) is exposed by the dedicated
-MCP module as `programs.aiMcp.servers`. Claude, Gemini, and Codex each normalize
-that shared option differently via their own settings modules.
+MCP module as `programs.aiMcp.servers`. Claude, Antigravity, and Codex each
+normalize that shared option differently via their own settings modules.
 
 ```mermaid
 graph LR
     MCPCAT["modules/mcp/catalog.nix\nprograms.aiMcp.servers"]
 
-    MCPCAT -->|normalized for Claude| CSETTINGS["modules/claude/settings.nix\n→ ~/.claude.json"]
-    MCPCAT -->|normalized for Gemini| GSETTINGS["modules/gemini/settings.nix\n→ ~/.gemini/settings.json"]
+    MCPCAT -->|normalized for Claude| CSETTINGS["modules/claude-config.nix\n→ ~/.claude.json"]
+    MCPCAT -->|normalized for Antigravity| GSETTINGS["modules/antigravity-cli/settings.nix\n→ ~/.gemini/antigravity-cli/settings.json"]
     MCPCAT -->|normalized for Codex| DSETTINGS["modules/codex/settings.nix\n→ ~/.codex/config.toml"]
 ```
 
@@ -130,7 +130,7 @@ Enable by overriding `programs.aiMcp.servers.<name>.disabled` and adding the key
 | 11436+ | vllm-mlx backends | HTTP (managed by llama-swap) | `modules/mlx/` |
 | 8080 | Open WebUI | HTTP | `modules/open-webui.nix` |
 | 8180 | Fabric REST API (opt-in) | HTTP + Swagger UI | `modules/fabric/` |
-| 9379 | LiteRT-LM classifier (Gemini CLI gemma router, opt-in) | HTTP | `modules/gemini/` |
+| 9379 | LiteRT-LM classifier (Antigravity CLI gemma router, opt-in) | HTTP | `modules/antigravity-cli/` |
 | 30080 | Bifrost AI gateway | HTTP | `orbstack-kubernetes` repo |
 | 30030 | Cribl MCP | HTTP | `orbstack-kubernetes` repo |
 | 30317 | OTEL Collector (gRPC receiver) | gRPC | `orbstack-kubernetes` repo |
@@ -171,7 +171,7 @@ graph LR
     MLX["MLX :11434"]
 
     CC -->|"1. stdio MCP\n(fabric-mcp server)"| FAB
-    CC -->|"2. Skills marketplace\n(32 curated patterns as SKILL.md)"| FAB
+    CC -->|"2. Skills marketplace\n(curated patterns as SKILL.md)"| FAB
     FAB -->|"3. CLI pipeline\n(fabric | claude)"| CC
     FAB -->|"4. REST API :8180\n(programmatic access)"| EXTERNAL["External tools"]
     FAB -->|routes to| MLX
@@ -180,6 +180,6 @@ graph LR
 | Channel | How | Use Case |
 |---------|-----|---------|
 | stdio MCP | `fabric-mcp` uvx server | Direct pattern execution from Claude |
-| Skills marketplace | `fabric-patterns` plugin, 32 SKILL.md files | Auto-discovery by description match |
+| Skills marketplace | `fabric-patterns` plugin, curated SKILL.md files | Auto-discovery by description match |
 | CLI pipeline | Shell: `fabric -p pattern \| claude` | Ad-hoc pipeline composition |
 | REST API | `fabric --serve` LaunchAgent on :8180 | Programmatic external access |

--- a/modules/antigravity-cli/options.nix
+++ b/modules/antigravity-cli/options.nix
@@ -1,7 +1,8 @@
 # Antigravity Module Options
 #
 # Declarative options for Google Antigravity CLI configuration.
-# Follows the same patterns as modules/claude/options.nix.
+# Follows the same per-agent option patterns as the other agent modules
+# (see docs/architecture/per-agent-flakes.md).
 { lib, ... }:
 
 let

--- a/modules/claude/plugins/README.md
+++ b/modules/claude/plugins/README.md
@@ -2,7 +2,8 @@
 
 Reference for all plugin marketplaces and enabled plugins managed by this module.
 
-Parent doc: [`modules/claude/README.md`](../README.md)
+Related: [`docs/architecture/plugin-scoping.md`](../../../docs/architecture/plugin-scoping.md)
+— user-level vs per-repo plugin partitioning.
 
 ## How Plugins Work
 
@@ -41,8 +42,11 @@ reorganizing tiers.
 
 ## Marketplaces
 
-All registered marketplaces, defined in [`marketplaces.nix`](marketplaces.nix). The
-"Tier" column matches the priority system above.
+All registered marketplaces. The catalog (names + source URLs) and the
+synthetic-marketplace derivations live in the `nix-claude-code` flake input
+(`lib.marketplaceCatalog`, `lib.marketplaceOverrides`); the tier files here only
+toggle which `plugin@marketplace` pairs are enabled. The "Tier" column matches the
+priority system above.
 
 | Key | GitHub | Stars (2026-05-02) | Tier |
 | --- | ------ | -----------------: | ---- |
@@ -102,8 +106,8 @@ at a glance.
 
 ```text
 plugins/
-├── default.nix          # imports + merge (5 tier files)
-├── marketplaces.nix     # marketplace definitions (one entry per repo)
+├── default.nix          # imports + merge (5 tier files); catalog comes from nix-claude-code
+├── packs.nix            # reusable plugin bundles (ai-pack)
 ├── README.md            # this file
 │
 ├── 01-official.nix      # Anthropic Official (claude-plugins-official core, anthropic-agent-skills)
@@ -115,8 +119,9 @@ plugins/
 
 ## Adding a New Marketplace
 
-1. Add the marketplace entry to [`marketplaces.nix`](marketplaces.nix) with the
-   key matching the `name` field from the repo's `.claude-plugin/marketplace.json`.
+1. Add the marketplace entry to the `nix-claude-code` catalog
+   (`lib.marketplaceCatalog`) with the key matching the `name` field from the
+   repo's `.claude-plugin/marketplace.json`.
 2. Verify popularity: `gh repo view <owner>/<repo> --json stargazerCount`.
 3. Decide tier:
    - Anthropic official → Tier 1 (`01-official.nix`)
@@ -139,14 +144,15 @@ plugins/
 
 ## Synthetic Marketplaces
 
-Three marketplaces lack native `.claude-plugin/` structure in their upstream repos.
-Nix wraps them via derivations in [`marketplace-overrides.nix`](../marketplace-overrides.nix):
+Some marketplaces lack native `.claude-plugin/` structure in their upstream repos.
+Nix wraps them via derivations (the marketplace-overrides derivation lives in the
+`nix-claude-code` flake input):
 
 | Marketplace | Upstream Repo | Wrapping Strategy |
 | ----------- | ------------- | ----------------- |
 | `browser-use-skills` | `browser-use/browser-use` | Wraps upstream skills directory |
 | `vct-cribl-pack-validator-skills` | `VisiCore/vct-cribl-pack-validator` | Wraps bare `.claude/skills/` layout |
-| `fabric-patterns` | `danielmiessler/fabric` | Wraps curated subset of 252+ patterns as individual skills |
+| `fabric-patterns` | `danielmiessler/fabric` | Wraps a curated subset of patterns as individual skills |
 | `jacobpevans-cc-plugins` | `JacobPEvans/claude-code-plugins` | Auto-generates `marketplace.json` from discovered `plugin.json` files |
 
 ## Token-Cost Awareness
@@ -163,6 +169,5 @@ load. **Reduce per-session overhead** by:
    [`modules/claude-config.nix`](../../claude-config.nix) (env block) so MCP
    schemas defer until needed.
 
-See [`docs/architecture/token-optimization.md`](../../../docs/architecture/token-optimization.md)
-for the full rationale and per-session measurements (if it exists; otherwise consult
-the user-level plan file at `~/.claude/plans/`).
+See [`docs/architecture/plugin-scoping.md`](../../../docs/architecture/plugin-scoping.md)
+for the skill listing budget and per-repo scoping rationale.

--- a/modules/codex/options.nix
+++ b/modules/codex/options.nix
@@ -1,7 +1,8 @@
 # Codex Module Options
 #
 # Declarative options for OpenAI Codex CLI configuration.
-# Follows the same patterns as modules/claude/options.nix.
+# Follows the same per-agent option patterns as the other agent modules
+# (see docs/architecture/per-agent-flakes.md).
 { lib, ... }:
 
 let

--- a/modules/fabric/README.md
+++ b/modules/fabric/README.md
@@ -1,8 +1,8 @@
 # Fabric Module
 
 Daniel Miessler's [Fabric](https://github.com/danielmiessler/fabric) — a Go CLI
-providing 252+ reusable AI prompt patterns — packaged as a Nix home-manager
-module for the nix-ai ecosystem.
+providing a large library of reusable AI prompt patterns — packaged as a Nix
+home-manager module for the nix-ai ecosystem.
 
 ## What it manages
 
@@ -10,8 +10,8 @@ This module owns the entire fabric runtime on a host:
 
 - The `fabric` Go binary (built from source via `buildGoModule`, pinned to a
   release tag, Renovate-managed via the annotation in `package.nix`)
-- The 252-pattern library symlinked read-only from the `fabric-src` flake input
-  to `~/.config/fabric/patterns/`
+- The upstream pattern library symlinked read-only from the `fabric-src` flake
+  input to `~/.config/fabric/patterns/`
 - A user-managed custom patterns directory at
   `~/.config/fabric/custom-patterns/` (created on activation, exported as
   `FABRIC_CUSTOM_PATTERNS_DIR`)
@@ -33,11 +33,11 @@ What it does NOT manage:
 | Capability | How |
 | --- | --- |
 | `fabric` CLI on PATH | `home.packages` (built from source via `buildGoModule`) |
-| 252 patterns at `~/.config/fabric/patterns/` | Nix-managed read-only symlink |
+| Pattern library at `~/.config/fabric/patterns/` | Nix-managed read-only symlink |
 | User-managed custom patterns directory | `programs.fabric.customPatternsDir` (default `~/.config/fabric/custom-patterns`) |
 | YouTube/multimedia extraction | `yt-dlp` added to `home.packages` |
 | Optional REST API server (LaunchAgent) | `programs.fabric.enableServer = true` (port 8180) |
-| 32 curated patterns as Claude Code skills | Synthetic marketplace at `modules/claude/marketplace-overrides.nix` |
+| Curated patterns as Claude Code skills | Synthetic marketplace (derivation lives in the `nix-claude-code` flake input) |
 | Fabric MCP server in Claude Code | `modules/mcp/catalog.nix` (community-maintained) |
 
 ## One-time runtime setup
@@ -135,13 +135,11 @@ Two paths exist:
 
 ### Path A: As Claude Code skills (always-on, auto-discovery)
 
-The synthetic marketplace at `modules/claude/marketplace-overrides.nix` wraps 32 curated
-fabric patterns as Claude Code skills via `modules/claude/fabric-curated-patterns.json`.
-Claude Code auto-loads them based on description matching when relevant to the user's task.
-
-To add or remove curated patterns: edit the JSON file. The
-`fabric-marketplace-build` regression check in `lib/checks/fabric.nix` will assert that
-the SKILL.md count matches the JSON entry count after the next `nix flake check`.
+A synthetic marketplace wraps a curated subset of fabric patterns as Claude Code
+skills. Claude Code auto-loads them based on description matching when relevant to
+the user's task. The marketplace derivation and its curated-patterns JSON live in
+the `nix-claude-code` flake input, along with the `fabric-marketplace-build`
+regression check that asserts the SKILL.md count matches the JSON entry count.
 
 ### Path B: As MCP tools (explicit invocation)
 
@@ -154,8 +152,8 @@ unmaintained, an alternative MCP wrapper will be needed.
 
 The fabric version is pinned in two places that MUST stay in sync:
 
-1. `flake.nix` input pin: `url = "github:danielmiessler/fabric/v1.4.444";`
-2. `lib/versions.nix`: `fabric = "1.4.444";` (read by `package.nix`)
+1. `flake.nix` input pin: `url = "github:danielmiessler/fabric/v<version>";`
+2. `lib/versions.nix`: `fabric = "<version>";` (read by `package.nix`)
 
 `package.nix` derives `version` from `lib/versions.nix`, and the marketplace
 metadata version is derived from the same package at Nix eval time — no
@@ -198,18 +196,14 @@ ports are reserved by other services.
 
 ### Marketplace SKILL.md count mismatch in `nix flake check`
 
-The `fabric-marketplace-build` check failed because the curated JSON
-(`modules/claude/fabric-curated-patterns.json`) was edited but the synthetic marketplace
-wasn't rebuilt. Just re-run `nix flake check` — the regression test recomputes the
-expected count from the JSON.
+The `fabric-marketplace-build` check failed because the curated-patterns JSON was
+edited but the synthetic marketplace wasn't rebuilt. The marketplace derivation,
+its JSON, and this check now live in the `nix-claude-code` flake input — re-run
+`nix flake check` there to recompute the expected count.
 
 ## See also
 
 - Upstream: <https://github.com/danielmiessler/fabric>
 - Pattern library: <https://github.com/danielmiessler/fabric/tree/main/data/patterns>
-- Curated subset: `modules/claude/fabric-curated-patterns.json`
+- Curated subset + synthetic marketplace: `nix-claude-code` flake input
 - Regression tests: `lib/checks/fabric.nix`
-- Follow-up issues: #442 (enable MCP), #443 (this README + completions), #444 (regression tests),
-  #445 (auth + Doppler), #446 (expand patterns), #447 (nix-devenv), #451 (SecLists),
-  #452 (decision tree docs), #453 (orchestrator cleanup), #454 (Renovate verification),
-  #455 (LaunchAgent enable on macbook-m4)

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -2,7 +2,7 @@
 
 MCP server definitions are owned by the `modules/mcp` Home Manager module. The
 shared catalog lives in `catalog.nix` and is exposed as `programs.aiMcp.servers`.
-Claude, Codex, and Gemini consume that option and render it into their own
+Claude, Codex, and Antigravity consume that option and render it into their own
 configuration formats during every `darwin-rebuild switch`.
 
 **Nix is the sole manager of user-scoped MCP servers.** Any entries added manually


### PR DESCRIPTION
A documentation pass to make the repo professional and accurate after the cleanup.

- **`.github/copilot-instructions.md`**: was entirely stale (copied terraform-proxmox
  / OpenTofu content) — rewritten to describe nix-ai.
- **Stale references fixed**: Gemini → Antigravity; removed-file references
  (`modules/gemini.nix`, `modules/codex.nix`, `settings.nix`, `options.nix`); the
  `config-lifecycle.md` activation table now lists the **real** entries
  (`codexConfigMerge`, `discoverMlxModels`, `mergeAntigravitySettings`,
  `seedLlamaSwapConfig`, …) — each verified to exist in-tree.
- **Links**: repointed to files that moved into the `nix-claude-code` input or were
  deleted; all internal links now resolve.
- **Hardcoded counts** removed (`252+`, `32`, `15+`) per the no-hardcoded-counts rule.
- **Stale inline comments** in `modules/codex/options.nix` and
  `modules/antigravity-cli/options.nix` repointed.

`nix flake check` passes; markdownlint clean; stale-ref grep empty.