### PR TITLE
feat(secrets): add .env.example; relocate inline secret docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,82 @@
+# .env.example — environment variables the nix-ai ecosystem can consume
+#
+# An EXAMPLE for repo users. It documents every variable the AI CLIs and MCP
+# servers may read, what each is for, and whether it is required.
+#
+# CANONICAL METHOD: direct injection — no secret on disk.
+#   Inject credentials into each CLI run so nothing is ever written to a file:
+#     doppler run -p ai-ci-automation -c prd -- <command>
+#     aws-vault exec <profile> -- <command>
+#     security find-generic-password -s <svc> -a <acct> -w <keychain-db>  # inline
+#   The real injection runbook is AGENTS.local.md (gitignored, local).
+#
+# OPT-IN EASY PATH (writes secrets to disk — your call):
+#   cp .env.example .env  &&  edit .env  &&  direnv allow
+#   The root .envrc auto-loads .env via `dotenv_if_exists`. .env is gitignored.
+#   Prefer direct injection; only use a real .env if you accept on-disk keys.
+#
+# LEGEND:  [required] tool FAILS at runtime without it.  [optional] has a default
+#          or the server ships disabled.  "source:" = where the real value lives.
+#
+# IP HYGIENE: example IPs use 192.168.0.x only. Real LAN/topology values are
+#             secrets — fetch from Doppler/Keychain, never commit them.
+#
+# Placeholders below are deliberately not real tokens (the __REPLACE_ME__ marker
+# keeps them out of secret scanners). Replace with real values only in a local
+# .env you never commit — or skip .env entirely and inject directly.
+
+# ───────────────────────────── MCP servers ─────────────────────────────
+
+# [required] huggingface MCP + `hf` CLI — HuggingFace Hub access.
+# source: Keychain automation.keychain-db, or Doppler ai-ci-automation/prd.
+HF_TOKEN=hf___REPLACE_ME__
+
+# [required] github MCP — GitHub API access. (github MCP ships disabled.)
+# source: Keychain or Doppler.
+GITHUB_PERSONAL_ACCESS_TOKEN=ghp___REPLACE_ME__
+
+# [optional] context7 docs retrieval (the context7 *plugin* is preferred).
+# source: Keychain or Doppler.
+CONTEXT7_API_KEY=ctx7___REPLACE_ME__
+
+# unifi MCP ships DISABLED (LAN-only — enable deliberately). When enabled, the
+# server FAILS to start without UNIFI_API_KEY + UNIFI_LOCAL_HOST.
+# [required-if-enabled] API key from unifi.ui.com.  source: Doppler/Keychain.
+UNIFI_API_KEY=__REPLACE_ME__unifi_api_key
+# [required-if-enabled] gateway IP (local mode). The REAL value is topology — a
+# secret; fetch from the no-password store. 192.168.0.1 here is an example only.
+UNIFI_LOCAL_HOST=192.168.0.1
+# [optional] API mode — pinned to "local" by the catalog; override only if needed.
+UNIFI_API_TYPE=local
+# [optional] gateway port / TLS verify (defaults: 443 / false).
+UNIFI_LOCAL_PORT=443
+UNIFI_LOCAL_VERIFY_SSL=false
+
+# [optional] archived/disabled MCP servers — only if you re-enable them.
+EXA_API_KEY=exa___REPLACE_ME__
+FIRECRAWL_API_KEY=fc___REPLACE_ME__
+CLOUDFLARE_API_TOKEN=cf___REPLACE_ME__
+
+# monarch MCP — NO env var. Auth is browser OAuth on first connect. Nothing to set.
+
+# ──────────────── AI provider keys (Doppler fallback paths) ────────────────
+# All [optional] — local MLX is the default. Used by the d-claude / cecli / qwen
+# fallback paths. source: Doppler ai-ci-automation/prd. Don't hand-set these —
+# run `doppler run -p ai-ci-automation -c prd -- <cmd>`.
+ANTHROPIC_API_KEY=sk-ant___REPLACE_ME__
+GEMINI_API_KEY=__REPLACE_ME__gemini
+OPENAI_API_KEY=sk___REPLACE_ME__openai
+OPENROUTER_API_KEY=sk-or___REPLACE_ME__
+DASHSCOPE_API_KEY=sk___REPLACE_ME__dashscope
+
+# ───────────────────────── Observability / tooling ─────────────────────────
+# [optional] Galileo AI observability.  source: Doppler ai-ci-automation/prd.
+GALILEO_API_KEY=__REPLACE_ME__galileo
+# [optional] per-session trace toggle (set by the `galileo-on` shell function).
+GALILEO_TRACE=0
+# [optional] WakaTime coding metrics.  source: Doppler (activation-time fetch).
+WAKATIME_API_KEY=waka___REPLACE_ME__
+
+# [optional] Doppler service token. Canonical path is `doppler login` /
+# `doppler run`; set this only for non-interactive/CI direct injection.
+DOPPLER_TOKEN=dp.st.__REPLACE_ME__

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# Opt-in convenience: auto-load a local .env (gitignored) if one exists.
+# Prefer direct injection (see AGENTS.local.md) — a .env writes secrets to disk.
+# After creating .env from .env.example, run `direnv allow` once.
+dotenv_if_exists .env

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,14 @@ result
 __pycache__
 .pytest_cache
 
+# Local secrets / overrides. `.env.example` is the committed template; real .env
+# files and the local agent runbook are never committed (see .env.example +
+# AGENTS.local.md — secrets are direct-injected, not stored on disk).
+.env
+.env.*
+!.env.example
+AGENTS.local.md
+
 # Git worktrees created inside the clone. `.claude/worktrees/` is Claude Code's
 # native EnterWorktree location; `.claude-wt/` was an ad-hoc manual base. Both
 # are nested worktrees that git reports as untracked — ignore them so they never

--- a/docs/architecture/secrets-and-injection.md
+++ b/docs/architecture/secrets-and-injection.md
@@ -3,6 +3,14 @@
 Three distinct patterns handle secrets across the AI tool ecosystem. Each enforces
 a different trust boundary and serves a different use case.
 
+**Governing principle — direct injection, no secret on disk.** Credentials are
+injected into each CLI/process at launch (`doppler run …`, `aws-vault exec …`,
+inline Keychain reads) and are never written to a committed or persisted file.
+The variable catalog (required vs optional, purpose, source) is
+[`.env.example`](../../.env.example); the local injection runbook is
+`AGENTS.local.md` (gitignored). A real `.env` on disk is an opt-in convenience
+only — prefer direct injection.
+
 ## Documents in This Directory
 
 _This document is part of [`docs/architecture/`](README.md)._
@@ -108,7 +116,10 @@ This is the cleanest pattern: zero credential exposure outside the cluster bound
   the Nix store derivation (world-readable at `/nix/store/`).
 - **Never hardcode API keys in Nix expressions.** Even in a private repo, they end up
   in the Nix store. Use Doppler or Keychain.
-- **Never commit `.env` files** containing real keys. The `~/.config/fabric/.env` file
-  (for Fabric's cloud providers) is user-created and gitignored; it is not managed by Nix.
+- **Never commit `.env` files** containing real keys. The repo's [`.env.example`](../../.env.example)
+  is the committed template; real `.env` files are gitignored (`.env`, `.env.*`).
+  Prefer direct injection over creating a `.env` at all.
 
-For the full MCP-specific secrets reference, see `modules/mcp/README.md` → Secrets Management.
+For the variable catalog see [`.env.example`](../../.env.example), the local
+injection runbook see `AGENTS.local.md` (gitignored), and the MCP-specific
+reference see `modules/mcp/README.md` → Secrets Management.

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -67,64 +67,25 @@ programs.aiMcp.servers.postgresql.disabled = lib.mkForce false;
 
 ## Secrets Management
 
-### Environment variables (default)
+The MCP config stores **no secrets** — it only references commands and URLs.
+Servers that need API keys read them from environment variables at runtime.
 
-Servers requiring API keys read them from environment variables at runtime.
-Use your secrets manager (Doppler, Keychain, 1Password, etc.) to inject env vars.
+**Inject secrets directly into each run — never write them to disk.** Use your
+secrets manager per command:
 
-Required env vars are documented in comments above each server definition.
-The config does NOT store any secrets — it only references commands and URLs.
+- Doppler-backed servers (Google Workspace, Splunk) use the `doppler-mcp` wrapper,
+  which runs `doppler run -p ai-ci-automation -c prd -- <cmd>` at launch (see
+  [Adding New Servers](#adding-new-servers)). Non-secret config (log levels,
+  flags) belongs in the Nix-managed `env` attribute, not Doppler.
+- Env-var-backed servers (HF_TOKEN, GitHub PAT, UniFi, …) read from the process
+  environment, injected directly (e.g. an inline Keychain read or `doppler run`).
 
-### macOS Keychain injection (PAT, HF_TOKEN, etc.)
-
-For tokens that are not in Doppler, the established pattern in nix-darwin injects them
-from the macOS Keychain via `_get_keychain_secret` in the shell init:
-
-```bash
-# In nix-darwin hosts/macbook-m4/home.nix:
-export HF_TOKEN=${HF_TOKEN:-"$(_get_keychain_secret 'HF_TOKEN' 'ai-cli-coder')"}
-```
-
-The account name (`ai-cli-coder`) and keychain db (`automation.keychain-db`) are defined
-in `lib/user-config.nix` in nix-darwin. Adapt these values if your setup uses different names.
-
-The shell exports the env var, and AI clients plus their MCP servers inherit it
-at startup. Secrets are never written to generated client config or any
-Nix-managed file.
-
-**One-time setup:** Add secrets to macOS Keychain:
-
-```bash
-security add-generic-password -U -s HF_TOKEN -a "ai-cli-coder" -w "your-token-here" automation.keychain-db
-```
-
-### Doppler injection via `doppler-mcp`
-
-For servers whose secrets live in Doppler (project `ai-ci-automation`, config `prd`),
-set `command = "doppler-mcp"` and shift the original command into `args[0]`:
-
-```nix
-google-workspace = {
-  command = "doppler-mcp";
-  args = [ "uvx" "--from" "google-workspace-mcp" "workspace-mcp" ];
-  env = {
-    LOG_LEVEL = "INFO";    # non-secret config → Nix
-    # GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET → injected by Doppler at runtime
-  };
-};
-```
-
-The `doppler-mcp` script (defined in `ai-tools.nix`) runs:
-
-```bash
-doppler run -p ai-ci-automation -c prd -- <original-command> [args...]
-```
-
-Secrets are fetched at subprocess launch time and injected as environment variables.
-They are never written to `~/.claude.json` or any other file Claude Code can read.
-
-**Non-secret config belongs in `env`, not Doppler.** Values like feature flags, timeouts,
-and log levels are not sensitive and belong in the Nix-managed `env` attribute.
+The full variable catalog — required vs optional, purpose, and source manager —
+is [`.env.example`](../../.env.example). The local injection runbook (the
+direct-injection commands and which manager holds what) is `AGENTS.local.md`
+(gitignored). Design rationale:
+[`docs/architecture/secrets-and-injection.md`](../../docs/architecture/secrets-and-injection.md).
+Full per-secret runbooks live in the `dryvist/docs` site and `docs-starlight`.
 
 ### Plugin-managed servers (context7)
 
@@ -140,13 +101,8 @@ conflicts on startup.
 
 The `huggingface` server provides tools for searching and exploring HuggingFace Hub.
 
-**Requires:** `HF_TOKEN` env var injected from macOS Keychain (see Secrets Management above).
-
-**One-time Keychain setup:**
-
-```bash
-security add-generic-password -U -s HF_TOKEN -a "ai-cli-coder" -w "your-hf-token-here" automation.keychain-db
-```
+**Requires:** `HF_TOKEN` (see [Secrets Management](#secrets-management) and
+[`.env.example`](../../.env.example)) — inject it directly at runtime.
 
 **Available tools:** search models, datasets, spaces, and papers; get model/dataset info; compare models.
 
@@ -157,27 +113,17 @@ installed via `uvx`) manages a local UniFi gateway/controller. It is **local-onl
 it talks to the gateway on the LAN, so it only works on a machine with network access
 to that gateway.
 
-`UNIFI_API_TYPE` is pinned to `local` in the catalog. The remaining variables are
-inherited from the shell environment (inject via macOS Keychain, same pattern as
-`HF_TOKEN`):
+`UNIFI_API_TYPE` is pinned to `local` in the catalog. The rest are injected
+directly at runtime from your secrets manager (see [`.env.example`](../../.env.example)
+and `AGENTS.local.md`):
 
 | Variable | Purpose |
 |----------|---------|
 | `UNIFI_API_KEY` | API key from unifi.ui.com (secret) |
-| `UNIFI_LOCAL_HOST` | Gateway IP, e.g. `192.168.1.1` (machine-specific) |
+| `UNIFI_LOCAL_HOST` | Gateway IP, e.g. `192.168.0.1` (real value is topology — keep it in the no-password secret store, never committed) |
 
-**One-time Keychain setup (secret):**
-
-```bash
-security add-generic-password -U -s UNIFI_API_KEY -a "ai-cli-coder" -w "your-key-here" automation.keychain-db
-```
-
-Then export both in the nix-darwin shell init (the gateway IP is not secret):
-
-```bash
-export UNIFI_API_KEY=${UNIFI_API_KEY:-"$(_get_keychain_secret 'UNIFI_API_KEY' 'ai-cli-coder')"}
-export UNIFI_LOCAL_HOST="192.168.1.1"
-```
+`unifi` ships disabled; enabling it without these set makes the server fail to
+start. Inject directly — do not write the key to disk.
 
 ## Monarch Money MCP
 

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -88,7 +88,7 @@ in
   };
 
   # GitHub - github-mcp-server from nixpkgs.
-  # Requires: GITHUB_PERSONAL_ACCESS_TOKEN env var (not yet in Doppler).
+  # Requires: GITHUB_PERSONAL_ACCESS_TOKEN — inject at runtime (see .env.example).
   github = {
     command = "github-mcp-server";
     disabled = true;
@@ -109,7 +109,7 @@ in
   # HuggingFace MCP - Model/dataset/paper search and documentation
   # ================================================================
   # Community stdio package: https://github.com/shreyaskarnik/huggingface-mcp-server
-  # Requires: HF_TOKEN env var (from macOS Keychain via nix-darwin shell init).
+  # Requires: HF_TOKEN — inject at runtime (see .env.example).
   huggingface = {
     command = "uvx";
     args = [
@@ -209,11 +209,11 @@ in
   # UniFi Network - local UniFi gateway/controller management
   # ================================================================
   # Source: https://github.com/enuno/unifi-mcp-server (PyPI: unifi-mcp-server)
-  # stdio server that talks to the UniFi gateway on the LAN. Requires env vars
-  # (inherited from the shell; inject via Keychain/Doppler like HF_TOKEN):
-  #   UNIFI_API_KEY     — API key from unifi.ui.com (secret)
-  #   UNIFI_LOCAL_HOST  — gateway IP, e.g. 192.168.1.1 (machine-specific)
-  # UNIFI_API_TYPE is non-secret config and is pinned to "local" here.
+  # stdio server that talks to the UniFi gateway on the LAN. Requires (inject at
+  # runtime — see .env.example): UNIFI_API_KEY (secret, unifi.ui.com) and
+  # UNIFI_LOCAL_HOST (gateway IP, e.g. 192.168.0.1 — real value is topology; keep
+  # it in the no-password secret store, never committed). UNIFI_API_TYPE is
+  # non-secret config and is pinned to "local" here.
   unifi = {
     command = "uvx";
     args = [


### PR DESCRIPTION
## What

Move nix-ai away from documenting host-specific secret-pulling **inline** in the repo, toward a committed example catalog plus a local runbook.

- **`.env.example`** (committed) — every env var the AI CLI/MCP ecosystem can consume, each marked `[required]` (tool fails at runtime without it) vs `[optional]`, with purpose + source manager. Scanner-safe placeholders (`__REPLACE_ME__` markers).
- **`.envrc`** (committed) — one line `dotenv_if_exists .env`: an opt-in easy path for repo users. `.env` / `.env.*` and `AGENTS.local.md` are gitignored.
- **Strip & relocate** the literal `security add-generic-password …` / `export …` commands from `modules/mcp/README.md`, `catalog.nix` comments, and `docs/architecture/secrets-and-injection.md` → pointers to `.env.example` / `AGENTS.local.md` / the `dryvist/docs` + `docs-starlight` sites.

## Governing invariant

The canonical method is **direct injection — no secret on disk** (`doppler run -p ai-ci-automation -c prd -- …`, `aws-vault exec -- …`, inline Keychain reads). A real `.env` on disk is an opt-in convenience only. The local `AGENTS.local.md` injection runbook is gitignored, not committed.

## Hygiene

- Example IPs normalized to `192.168.0.x`; real LAN/topology values stay in the no-password secret store, never committed.
- `git grep` guard confirms no `10.0.*` / `192.168.1.*` and no leftover secret-setup commands.

## Verification

- `nix fmt` clean; `nix flake check` ✅ (catalog comment edits evaluate).
- `gitleaks detect` → no leaks found (whole repo incl. `.env.example`).
- pre-commit (markdownlint, nixfmt, statix, deadnix, detect-private-key) all pass.
- `git check-ignore` confirms `.env` + `AGENTS.local.md` ignored, `.env.example` tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)