### PR TITLE
chore: omit claude.ai session link from commits and PRs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,11 +538,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1781921627,
-        "narHash": "sha256-Bhc1DRiDB5Wcw+Q0j5DjFqG2yhSVo9FU6Y79BcmN6vo=",
+        "lastModified": 1782068560,
+        "narHash": "sha256-4uDc+jXHYRKETTQ6aPLUXV1lZxkfJYMPBUohDgiPdH4=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "aceddc2d90fd65e9817ceca5f81c9800d6325a89",
+        "rev": "3a03b83e54841241387a1ee48c38f508ac5881e0",
         "type": "github"
       },
       "original": {

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -152,8 +152,12 @@ in
     trustedProjectDirs = userConfig.trustedProjectDirs or [ ];
 
     # Commit trailer per https://docs.kernel.org/process/coding-assistants.html.
+    # sessionUrl = false omits the claude.ai session link from commits and PRs:
+    # in a public single-dev workspace the traceability is moot, while the link
+    # writes a permanent session-id pointer into immutable public git history.
     attribution = {
       commit = "Assisted-by: Claude:{model}";
+      sessionUrl = false;
     };
 
     plugins = {

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -152,9 +152,6 @@ in
     trustedProjectDirs = userConfig.trustedProjectDirs or [ ];
 
     # Commit trailer per https://docs.kernel.org/process/coding-assistants.html.
-    # sessionUrl = false omits the claude.ai session link from commits and PRs:
-    # in a public single-dev workspace the traceability is moot, while the link
-    # writes a permanent session-id pointer into immutable public git history.
     attribution = {
       commit = "Assisted-by: Claude:{model}";
       sessionUrl = false;


### PR DESCRIPTION
# chore: omit claude.ai session link from commits and PRs

## What

Set `attribution.sessionUrl = false` in `modules/claude-config.nix`.

## Why

Claude Code appends a `claude.ai/code/session_…` link to commit trailers and PR
bodies in web / Remote Control sessions. In a public single-developer workspace
the traceability is moot, while the link writes a permanent session-id pointer
into immutable public git history for a workflow that routinely handles secrets
(Doppler, Keychain, AWS, Splunk). The link is auth-gated, not world-readable, but
the residual exposure (permanent public session id + metadata) outweighs the
near-zero upside here.

## ⚠️ Blocked on dryvist/nix-claude-code#62

`sessionUrl` is a **boolean**. The pinned `nix-claude-code` types `attribution`
as `attrsOf str`, so `nix flake check` here is **red until**:

1. dryvist/nix-claude-code#62 merges (widens the type to accept booleans), and
2. the `nix-claude-code` input is bumped in this repo's `flake.lock`.

Verified green locally with `nix flake check --override-input nix-claude-code <pr-62-branch>`.

## Validation after unblock

- `nix flake check` (post input-bump) — green.
- `darwin-rebuild build` + confirm generated `settings.json` contains
  `"attribution": { ..., "sessionUrl": false }` and a fresh session's test commit
  carries no `Claude-Session:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
