### PR TITLE
ci: scope fix-renovate-hashes to the package file it re-hashes

### DIFF
--- a/.github/workflows/fix-renovate-hashes.yml
+++ b/.github/workflows/fix-renovate-hashes.yml
@@ -13,6 +13,11 @@ on:
   push:
     branches:
       - "renovate/**"
+    # Only the package file holding the cecli/mcp version+hash strings needs
+    # re-hashing. lockFileMaintenance / flake-input renovate PRs don't touch it,
+    # so they no longer trigger this job (which would otherwise fail on them).
+    paths:
+      - "modules/cecli/package.nix"
 
 jobs:
   fix-hashes:


### PR DESCRIPTION
# ci: scope fix-renovate-hashes to the package file it re-hashes

## What

Add a `paths:` filter to `fix-renovate-hashes.yml` so the hash-fix job only fires
on pushes that touch `modules/cecli/package.nix` (the only file holding the cecli
and mcp version + hash strings).

## Why

The job ran on **every** `renovate/**` push and died at the `create-github-app-token`
step (org-migration credential issue, tracked separately). lockFileMaintenance and
flake-input renovate PRs don't touch the package file, so they have nothing to
re-hash — yet they kept failing on this unrelated job, blocking automerge
(dryvist/nix-ai#994). Scoping the trigger fixes that regardless of the token issue.

## Note

The stale `jacobpevans-github-actions` bot-detection in `ci-gate.yml` is a separate
follow-up — fixing it requires extracting the inline bash to `.github/scripts/`
(inline-script guard), and it only affects a fast-path, not pass/fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
