### PR TITLE
fix: drop invalid attribution.sessionUrl and conflicting antigravity-cli cask

### DIFF
--- a/lib/homebrew.nix
+++ b/lib/homebrew.nix
@@ -16,13 +16,12 @@
       name = "claude-code@latest";
       greedy = true;
     }
-    # antigravity suite ships in the default homebrew-cask tap — no vendor tap needed
+    # antigravity suite ships in the default homebrew-cask tap — no vendor tap needed.
+    # `antigravity` (umbrella) already ships the `agy` CLI binary, so the separate
+    # `antigravity-cli` cask is omitted — both target /opt/homebrew/bin/agy and
+    # collide ("already a Binary at '/opt/homebrew/bin/agy'") during brew bundle.
     {
       name = "antigravity";
-      greedy = true;
-    }
-    {
-      name = "antigravity-cli";
       greedy = true;
     }
     {

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -127,9 +127,11 @@ in
     trustedProjectDirs = userConfig.trustedProjectDirs or [ ];
 
     # Commit trailer per https://docs.kernel.org/process/coding-assistants.html.
+    # Only `commit`/`pr` are valid attribution keys in Claude Code's settings
+    # schema; a `sessionUrl` toggle does not exist (the session link is just
+    # text inside the trailer string, omitted by leaving it out here).
     attribution = {
       commit = "Assisted-by: Claude:{model}";
-      sessionUrl = false;
     };
 
     plugins = {


### PR DESCRIPTION
## What

- **sessionUrl**: `attribution.sessionUrl` is not a valid Claude Code settings key — the schema (json.schemastore.org/claude-code-settings.json) allows only `commit`/`pr` and rejects additional properties, so every activation logged `$.attribution: Additional properties are not allowed ('sessionUrl' …)`. The key did nothing; removed.
- **antigravity-cli**: the `antigravity` and `antigravity-cli` casks both install `/opt/homebrew/bin/agy` and collide during `brew bundle` ("already a Binary at '/opt/homebrew/bin/agy'"). The umbrella `antigravity` cask already ships `agy`, so `antigravity-cli` is dropped (keeps `antigravity` + `antigravity-ide`).

## Verified

Integration `darwin-rebuild switch`: Brewfile now has `antigravity`+`antigravity-ide` only, `brew bundle complete! 31 deps`, no sessionUrl in the closure, settings.json passes check-jsonschema, activation EXIT 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)