### PR TITLE
fix(ci): point code-simplifier caller at renamed reusable workflow

### DIFF
--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -7,15 +7,16 @@ on:
   #   - cron: "0 4 * * 0,3,6"
   # --- END DISABLED ---
 permissions:
+  actions: read
   contents: write
   id-token: write
   pull-requests: write
 
 concurrency:
   group: code-simplifier
-  cancel-in-progress: true
+  cancel-in-progress: false  # Never cancel — queue instead to avoid wasting AI tokens
 
 jobs:
   simplify:
-    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@v0
     secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
## What

Fix the stale `code-simplifier` thin-wrapper caller. The reusable workflow in `dryvist/ai-workflows` was renamed `code-simplifier.yml` → `cc-code-simplifier.yml`, so the existing `@v0.16` reference is broken/stale.

## Changes

- Repin to `dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@v0` (correct filename + floating major tag, matching sibling callers like `ai-ci.yml` / `issue-auto-resolve.yml`).
- Add `actions: read` to `permissions` — required by the reusable workflow's `check-daily-limit` job.
- `cancel-in-progress: true` → `false`, per the ai-workflows rule "never cancel AI workflows" (queue instead of cancel to avoid wasting AI tokens).

## Context

Companion to dryvist/ai-workflows#275, which re-normalizes the code-simplifier prompt to the upstream Anthropic agent. nix-ai is the first target repo for the re-normalized Sonnet simplifier. Schedule stays disabled; validate via manual `workflow_dispatch` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)