### PR TITLE
fix(ci): repin code-simplifier caller to @main

### DIFF
--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   simplify:
-    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@v0
+    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@main
     secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
## What

Repin the `code-simplifier` caller from `@v0` to `@main`.

## Why

`@v0` resolves to **v0.21.1**, which predates **#274** (the Verified Commit & PR standardization in `dryvist/ai-workflows`). v0.21.1's `cc-code-simplifier.yml` has **no workflow-side `Open PR` step** — it expected Claude to open the PR itself via `gh`.

But the prompt **loads from `main` at runtime** and now tells Claude to write `.claude-pr.md` and *not* run git/gh. New prompt + old (v0.21.1) workflow ⇒ the simplifier's edits are **silently discarded**. Observed on a validation dispatch: 14 turns / $0.87 of real work, green run, **no commit/branch/PR**.

`@main` has the #274 Open-PR step, so the edits land as a verified PR (proven by the ai-workflows dogfood). Switch back to a release tag once one advances `@v0` past #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)