### PR TITLE
ci(osv): pass repo config to shared scanner

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -157,7 +157,12 @@ jobs:
     needs: changes
     if: always()
     uses: dryvist/.github/.github/workflows/_osv-scan.yml@main
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     with:
+      config_file: osv-scanner.toml
       runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   # ==========================================================================

--- a/.github/workflows/osv-scheduled.yml
+++ b/.github/workflows/osv-scheduled.yml
@@ -21,10 +21,13 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
+  security-events: write
 
 jobs:
   scan:
     uses: dryvist/.github/.github/workflows/_osv-scan.yml@main
     with:
+      config_file: osv-scanner.toml
       runner_label: ubuntu-latest

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,8 +1,8 @@
-# OSV Scanner config — local override for JacobPEvans/nix-ai.
+# OSV Scanner config — local override for dryvist/nix-ai.
 #
-# The reusable workflow at JacobPEvans/.github/.github/workflows/_osv-scan.yml
-# auto-applies this file when present (otherwise it falls back to the org-wide
-# default at JacobPEvans/.github/osv-scanner.toml).
+# The ci-gate and scheduled OSV workflows pass this file to the dryvist/.github
+# reusable workflow with `config_file: osv-scanner.toml`, which applies these
+# exceptions to every recursively scanned lockfile.
 #
 # Each ignored vulnerability MUST:
 #   1. Link to the umbrella tracking issue (#812).


### PR DESCRIPTION
## Summary
- pass nix-ai's repo-local `osv-scanner.toml` through the shared OSV scanner wrapper
- grant the OSV jobs the token scopes required by Google's reusable OSV workflows
- update the local config header to describe explicit `config_file` usage

Refs: dryvist/.github#51

## Validation
- `actionlint .github/workflows/ci-gate.yml .github/workflows/osv-scheduled.yml`
- `git diff --check`