### PR TITLE
fix: point callers at renamed cc- reusable workflows

### DIFF
--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -17,5 +17,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@v0.16
+    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@v0.16
     secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
## Problem
Callers referenced `dryvist/ai-workflows/.github/workflows/<name>.yml@main` for
reusables that were renamed with a `cc-` prefix. The old names no longer exist,
so those runs failed at **startup** (0 jobs, "workflow file issue").

## Fix
Repoint the stale `uses:` refs to the current `cc-`-prefixed names
(cc-ci-fix / cc-code-simplifier / cc-issue-resolver / cc-next-steps /
cc-post-merge-docs-review / cc-post-merge-tests). Reusables that were never
renamed (issue-triage, best-practices, ci-fail-issue, issue-hygiene,
issue-sweeper) are left untouched. Pure reference rename, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)