### PR TITLE
feat: add throttled issue-backlog-sweep to drain the backlog

### DIFF
--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -1,0 +1,44 @@
+# Backlog activation. On a slow schedule (and on demand), Claude judges the
+# oldest UNTRIAGED open issues and labels the auto-resolvable ones `ai:ready`
+# via the App token, which fires issue-auto-resolve.yml (issues: labeled) to
+# open the resolving PR. This is how the pre-existing backlog shrinks.
+#
+# The schedule is deliberate: a backlog is static state, not an event, so there
+# is nothing to trigger on. Keep the cadence slow — it only tops up the
+# ai:ready queue as the resolver drains it.
+#
+# Throttling: max_issues caps labels per run; the resolver's own PR ceiling
+# (5 bot PRs / 24h) is the hard backstop on PRs actually opened.
+
+name: Issue Backlog Sweep
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_issues:
+        description: "Max backlog issues to label this run"
+        type: string
+        default: "5"
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC — top up the ai:ready queue weekly
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: issue-backlog-sweep-${{ github.repository }}
+  cancel-in-progress: false # Never cancel — queue instead to avoid wasting AI tokens
+
+jobs:
+  sweep:
+    uses: dryvist/ai-workflows/.github/workflows/issue-backlog-sweep.yml@v0
+    # Pass exactly the two secrets the reusable declares — not `secrets: inherit`.
+    secrets:
+      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+    with:
+      max_issues: ${{ inputs.max_issues || '5' }}


### PR DESCRIPTION
## What
Adds a thin caller for the `dryvist/ai-workflows` **issue-backlog-sweep**
reusable (pinned `@v0`), passing the two required secrets explicitly.

## Why
The triage→resolve chain only fires on *new* issues (`issues: labeled`). Nothing
labels the **existing** backlog, so nix-ai's 77 open issues just accumulate. This
sweep is the missing feeder: on a slow schedule it judges the oldest untriaged
issues and labels the auto-resolvable ones `ai:ready`, which the existing
`issue-auto-resolve.yml` already resolves into PRs.

## Safety (cannot run away)
- **Weekly** cron only (backlog is static state — the one justified schedule);
  `workflow_dispatch` for manual/first-run testing.
- `max_issues` caps labels per run (default 5).
- The resolver's **5-bot-PR/24h ceiling** is the hard backstop on PRs opened.
- `cancel-in-progress: false` — queue, never cancel.

## Secrets
Passes `GH_ACTION_AI_API_KEY` + `GH_APP_CLAUDE_BOT_PRIVATE_KEY` explicitly (not
`secrets: inherit`), matching the reusable's now-declared secrets block
(ai-workflows#288). Clears zizmor's secrets-inherit audit with no ignore comment.

## Rollout
nix-ai first. Recommend a manual `workflow_dispatch` with `max_issues: 1` to
confirm exactly one triage→resolve→draft-PR chain before the weekly cron kicks
in. Fan out to nix-darwin / terraform-proxmox / ansible-proxmox / nix-home after
a week of clean operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)