### PR TITLE
fix: pass backlog-sweep secrets via inherit (org secrets can't be mapped)

### DIFF
--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -36,9 +36,10 @@ concurrency:
 jobs:
   sweep:
     uses: dryvist/ai-workflows/.github/workflows/issue-backlog-sweep.yml@v0
-    # Pass exactly the two secrets the reusable declares — not `secrets: inherit`.
-    secrets:
-      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
-      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}
+    # Org-level secrets can only be forwarded to a reusable via `inherit` — GitHub
+    # rejects explicit mapping (`NAME: ${{ secrets.NAME }}`) of org secrets at
+    # instantiation (startup failure). zizmor's secrets-inherit audit is therefore
+    # a false positive here: the reusable is first-party and version-pinned.
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     with:
       max_issues: ${{ inputs.max_issues || '5' }}


### PR DESCRIPTION
## Problem
The backlog-sweep caller (merged in #1067) mapped its two secrets explicitly:

    secrets:
      GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
      GH_APP_CLAUDE_BOT_PRIVATE_KEY: ${{ secrets.GH_APP_CLAUDE_BOT_PRIVATE_KEY }}

Every dispatch **failed at startup** ("workflow file issue", 0 jobs). Root cause,
confirmed by isolation testing: GitHub forwards **organization-level** secrets to
a reusable only via `secrets: inherit` — explicit mapping of org secrets is
rejected at instantiation. Both secrets here are org-level. (The same reusable
runs fine when dispatched directly, reading the org secrets from its own context.)

## Fix
Revert to `secrets: inherit`, matching every other reusable caller in this repo.
zizmor's `secrets-inherit` audit is a documented **false positive** here — the
reusable is first-party (`dryvist/ai-workflows`) and version-pinned (`@v0`) — so
the line carries an inline `# zizmor: ignore[secrets-inherit]` with an explanatory
comment.

## Verification
After merge, a `workflow_dispatch` with `max_issues=1` should now instantiate and
run (the reusable was already proven working via direct dispatch in ai-workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)