### PR TITLE
fix: drop actions:read from backlog-sweep caller

### DIFF
--- a/.github/workflows/issue-backlog-sweep.yml
+++ b/.github/workflows/issue-backlog-sweep.yml
@@ -23,7 +23,6 @@ on:
     - cron: "0 9 * * 1" # Mondays 09:00 UTC — top up the ai:ready queue weekly
 
 permissions:
-  actions: read
   contents: read
   id-token: write
   issues: write


### PR DESCRIPTION
Follow-up to ai-workflows#296. The `issue-backlog-sweep` reusable dropped its
workflow-level `actions: read` (the `check-daily-limit` throttle that needed it
was removed) to fix cross-repo `workflow_call` startup failures. Drop the
matching grant from this caller.

**Merge only after** `v0` has released the ai-workflows change (verify:
`gh api repos/dryvist/ai-workflows/contents/.github/workflows/issue-backlog-sweep.yml?ref=v0 | ... | grep -c 'actions: read'` returns 0), then dispatch with `max_issues=1` to confirm the sweep finally instantiates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)