### PR TITLE
test: isolate backlog startup failure (minimal caller)

### DIFF
--- a/.github/workflows/zz-test-backlog-min.yml
+++ b/.github/workflows/zz-test-backlog-min.yml
@@ -1,0 +1,14 @@
+name: zz-test-backlog-min
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+jobs:
+  sweep:
+    uses: dryvist/ai-workflows/.github/workflows/issue-backlog-sweep.yml@v0
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    with:
+      max_issues: "1"


### PR DESCRIPTION
Temporary diagnostic — minimal caller of backlog@v0 to split caller-vs-reusable. Will be removed once root cause is found.