### PR TITLE
test: minimal caller to bisect backlog startup failure

### DIFF
--- a/.github/workflows/zz-test-backlog-reusable.yml
+++ b/.github/workflows/zz-test-backlog-reusable.yml
@@ -1,0 +1,12 @@
+name: zz-test-backlog-reusable
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: read
+jobs:
+  sweep:
+    uses: dryvist/ai-workflows/.github/workflows/issue-backlog-sweep.yml@v0
+    secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
Temporary. Minimal caller (issue-sweeper's working structure) pointing at issue-backlog-sweep@v0 to isolate whether the startup failure is the caller's extras or the reusable. Deleted immediately after the dispatch result.