### PR TITLE
fix(versions): bump huggingface-hub 1.15.0 -> 1.21.0 to restore hf CLI

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -6,8 +6,11 @@
 {
 
   # HuggingFace stack
+  # >=1.21.0 required: adds click>=8.4.0 as a direct dep and caps typer<0.26.0.
+  # Older pins left typer unbounded (>=0.20.0), floating to 0.26.x which vendored
+  # click and dropped the external dep the hf CLI imports → ModuleNotFoundError.
   # renovate: datasource=pypi depName=huggingface-hub
-  huggingfaceHub = "1.15.0";
+  huggingfaceHub = "1.21.0";
   # renovate: datasource=pypi depName=huggingface-mcp-server
   hfMcpServer = "0.1.0";
 


### PR DESCRIPTION
## Problem

The `hf` CLI (a Nix `writeShellScriptBin` wrapper around `uvx --from "huggingface-hub==${versions.huggingfaceHub}" hf`) is broken:

```
ModuleNotFoundError: No module named 'click'
```

## Root cause

`huggingface-hub 1.15.0` declares an **unbounded** `typer>=0.20.0`. That now floats to **typer 0.26.8**, which vendored click as `typer._click` and **dropped the external `click` dependency** that huggingface_hub's CLI (`_cli_utils.py`) still imports. `uvx` faithfully installs what's declared → no `click` → import error. `--refresh` can't help; the resolution is correct against broken upstream metadata.

## Fix

Bump the shared pin `huggingfaceHub` `1.15.0 → 1.21.0`. 1.21.0 fixes this **structurally**:

- adds `click>=8.4.0` as a **direct** dependency, and
- caps `typer<0.26.0,>=0.20.0`

Resolves to typer 0.25.1 + click 8.4.2. Verified working for **both** consumers of this pin:

- `hf` CLI (`modules/ai-tools.nix`) → `hf version` prints `1.21.0`
- HuggingFace MCP server (`modules/mcp/catalog.nix`) → starts and speaks JSON-RPC

## Note on Renovate

This pin *should* have auto-bumped weeks ago (custom-regex manager, Mon/Thu schedule, HF minor/patch auto-merge). It didn't: the update has been stuck in the Dependency Dashboard's **Rate-Limited** bucket since late May (target frozen at 1.16.1) because `branchConcurrentLimit: 3` is perpetually saturated by fast-moving deps held under `minimumReleaseAge: 3 days`. That starvation fix lives in `dryvist/.github` and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)