### PR TITLE
feat: multi-resident model serving prereqs + Open WebUI service

### DIFF
--- a/modules/ai-stack/default.nix
+++ b/modules/ai-stack/default.nix
@@ -38,47 +38,70 @@ let
   registryJson = pkgs.writeText "ai-stack-registry.json" (builtins.toJSON populatedRegistry);
 in
 {
-  options.services.aiStack.defaultLocalModelId = lib.mkOption {
-    type = lib.types.str;
-    # Empty default so `homeManagerModules.default` evaluates with zero consumer
-    # config — local MLX inference is simply inert until a real id is set. The
-    # maintainer's nix-darwin sets it from AI_MODEL_LOCAL_LLM. Never hardcode a
-    # physical model id in this repo.
-    default = "";
-    example = "mlx-community/<provider-tag>-<model-name>-<quant>";
-    description = ''
-      Local MLX physical model id used as the single resident model for
-      every role in `services.aiStack.models`. Supplied by the consuming
-      configuration (typically `nix-darwin`) — e.g. committed in the
-      consumer's user config, or injected via env/secret for CI.
-      **Never hardcoded in this repo.**
+  options.services.aiStack = {
+    defaultLocalModelId = lib.mkOption {
+      type = lib.types.str;
+      # Empty default so `homeManagerModules.default` evaluates with zero consumer
+      # config — local MLX inference is simply inert until a real id is set. The
+      # maintainer's nix-darwin sets it from AI_MODEL_LOCAL_LLM. Never hardcode a
+      # physical model id in this repo.
+      default = "";
+      example = "mlx-community/<provider-tag>-<model-name>-<quant>";
+      description = ''
+        Local MLX physical model id used as the single resident model for
+        every role in `services.aiStack.models`. Supplied by the consuming
+        configuration (typically `nix-darwin`) — e.g. committed in the
+        consumer's user config, or injected via env/secret for CI.
+        **Never hardcoded in this repo.**
 
-      The deliberate posture: one model resident, every alias pointing
-      at it, swap-thrash impossible. To introduce per-role
-      differentiation later, override `services.aiStack.models` directly
-      or change the role-population logic in `modules/ai-stack/default.nix`.
-    '';
-  };
-
-  options.services.aiStack.models = lib.mkOption {
-    type = lib.types.attrsOf lib.types.str;
-    default = import ../../lib/ai-stack-models.nix {
-      inherit (config.services.aiStack) defaultLocalModelId;
+        The deliberate posture: one model resident, every alias pointing
+        at it, swap-thrash impossible. To introduce per-role
+        differentiation later, set `services.aiStack.roleOverrides` (per-role
+        pins) or override `services.aiStack.models` wholesale.
+      '';
     };
-    defaultText = lib.literalExpression ''
-      import ../../lib/ai-stack-models.nix {
-        inherit (config.services.aiStack) defaultLocalModelId;
-      }
-    '';
-    description = ''
-      Role-name → physical model ID map. Each role becomes a first-class
-      llama-swap entry whose cmd runs `vllm-mlx serve <physical>`.
 
-      Default: every role resolves to `services.aiStack.defaultLocalModelId`
-      (read via `lib/ai-stack-models.nix`). Override here only when a
-      consumer needs a private mapping that should not propagate to
-      `~/.config/ai-stack/registry.json`.
-    '';
+    roleOverrides = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        coding = "mlx-community/<provider-tag>-<coder-model>-<quant>";
+      };
+      description = ''
+        Per-role physical model ID overrides merged on top of the
+        `defaultLocalModelId`-populated role map. Lets a host pin selected
+        roles (e.g. `coding`) to a different resident model while every
+        other role keeps following `defaultLocalModelId`. Unlike overriding
+        `services.aiStack.models` wholesale, the untouched roles keep their
+        default and the merged map still propagates to
+        `~/.config/ai-stack/registry.json`.
+      '';
+    };
+
+    models = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default =
+        (import ../../lib/ai-stack-models.nix {
+          inherit (config.services.aiStack) defaultLocalModelId;
+        })
+        // config.services.aiStack.roleOverrides;
+      defaultText = lib.literalExpression ''
+        (import ../../lib/ai-stack-models.nix {
+          inherit (config.services.aiStack) defaultLocalModelId;
+        })
+        // config.services.aiStack.roleOverrides
+      '';
+      description = ''
+        Role-name → physical model ID map. Each role becomes a first-class
+        llama-swap entry whose cmd runs `vllm-mlx serve <physical>`.
+
+        Default: every role resolves to `services.aiStack.defaultLocalModelId`
+        (read via `lib/ai-stack-models.nix`), then
+        `services.aiStack.roleOverrides` is merged on top for per-role pins.
+        Override this option directly only when a consumer needs a private
+        mapping that should not propagate to `~/.config/ai-stack/registry.json`.
+      '';
+    };
   };
 
   config.home.activation.writeAiStackRegistry = lib.hm.dag.entryAfter [ "writeBoundary" ] ''

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -224,14 +224,14 @@ let
     models = allModels;
 
     groups.mlx-models = {
-      swap = true;
+      swap = cfg.proxy.groupSwap;
       exclusive = true;
       members = builtins.attrNames allModels;
     };
 
     # Preload by role, not physical name. llama-swap resolves "default"
     # via the alias table on the registryModels entry.
-    hooks.on_startup.preload = [ "default" ];
+    hooks.on_startup.preload = cfg.preload;
   };
 
   # Use pkgs.writeText (not builtins.toFile) because content references store paths

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -93,7 +93,32 @@
       description = "Additional models available for on-demand switching via llama-swap proxy. All models (including the default-aliased one) share the uniform proxy.idleTtl unless overridden per-model.";
     };
 
+    # preload — llama-swap hooks.on_startup.preload entries. Role names (or
+    # physical ids) loaded at proxy startup so the first request never pays a
+    # cold start. Multi-resident hosts list every role they keep warm, e.g.
+    # [ "default" "coding" ]; each extra entry costs its full weight footprint
+    # until the idle TTL evicts it.
+    preload = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "default" ];
+      description = "Models (role aliases or physical ids) llama-swap preloads at startup. Every entry occupies memory concurrently until its idle TTL — size the list against the host's wired-memory budget.";
+    };
+
     proxy = {
+      # groupSwap — llama-swap `groups.mlx-models.swap`. true (default) keeps
+      # the one-resident-model posture: loading any model evicts the previous
+      # one, so swap-thrash is impossible on RAM-constrained workstations.
+      # false lets multiple registry models stay resident concurrently
+      # (server-class hosts serving e.g. a large default plus a coder model);
+      # the memory bound then falls to gpuMemoryUtilization/cacheMemoryMb per
+      # worker, which the host must size so the sum of resident workers fits
+      # its wired-memory budget.
+      groupSwap = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether llama-swap unloads the resident model before loading another (groups.mlx-models.swap). Set false on hosts with the memory headroom to keep several models resident at once.";
+      };
+
       healthCheckTimeout = lib.mkOption {
         type = lib.types.ints.positive;
         default = 180;

--- a/modules/open-webui.nix
+++ b/modules/open-webui.nix
@@ -98,6 +98,12 @@ in
         };
       };
 
+      # launchd does not create StandardOutPath/StandardErrorPath parent
+      # directories — without this the agent fails to start on a fresh host.
+      home.activation.createOpenWebuiLogDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        run mkdir -p "${config.home.homeDirectory}/Library/Logs/open-webui"
+      '';
+
       # Log rotation via newsyslog (follows mlx/launchd.nix pattern)
       home.file.".config/newsyslog.d/open-webui.conf".text = ''
         # logfilename                                                              [owner:group]  mode  count  size  when  flags

--- a/modules/open-webui.nix
+++ b/modules/open-webui.nix
@@ -1,4 +1,122 @@
-{ pkgs, ... }:
+#
+# Open WebUI Module — package + optional LaunchAgent (chat UI server)
+#
+# The package is always installed (CLI available for ad-hoc use). The
+# LaunchAgent is opt-in via programs.open-webui.enable: it runs
+# `open-webui serve` bound to loopback as the manual-query chat UI for the
+# local OpenAI-compatible inference endpoint (llama-swap on :11434). LAN
+# exposure, TLS, and access control are the consumer's concern (e.g. a
+# reverse proxy in front) — this module never binds beyond cfg.host.
+#
+# Endpoints (when running):
+#   - http://127.0.0.1:8080/  — chat UI (Open WebUI keeps its own login/auth)
+#
+# Logs: ~/Library/Logs/open-webui/open-webui.{log,error.log}
+#
 {
-  home.packages = [ pkgs.open-webui ];
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.open-webui;
+in
+{
+  options.programs.open-webui = {
+    enable = lib.mkEnableOption "Open WebUI LaunchAgent (dev.open-webui.server)";
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Bind address. Keep loopback; front with a reverse proxy for any off-host access.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Listen port (8080 is reserved for Open WebUI in the local port map).";
+    };
+
+    openaiApiBaseUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://127.0.0.1:11434/v1";
+      description = "OpenAI-compatible upstream the UI queries (llama-swap proxy by default).";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.local/share/open-webui";
+      description = "Persistent state (SQLite DB, uploads, vector cache).";
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Extra environment variables merged into the LaunchAgent (host-specific tuning, feature flags).";
+    };
+  };
+
+  config = lib.mkMerge [
+    { home.packages = [ pkgs.open-webui ]; }
+
+    (lib.mkIf cfg.enable {
+      launchd.agents.open-webui = {
+        enable = true;
+        config = {
+          Label = "dev.open-webui.server";
+          ProgramArguments = [
+            (lib.getExe pkgs.open-webui)
+            "serve"
+            "--host"
+            cfg.host
+            "--port"
+            (toString cfg.port)
+          ];
+          RunAtLoad = true;
+          KeepAlive = true;
+          ThrottleInterval = 30;
+          ProcessType = "Background";
+          EnvironmentVariables = {
+            HOME = config.home.homeDirectory;
+            DATA_DIR = cfg.dataDir;
+            OPENAI_API_BASE_URL = cfg.openaiApiBaseUrl;
+            # The local llama-swap endpoint is unauthenticated on loopback but
+            # Open WebUI requires a non-empty key when the OpenAI API is on.
+            OPENAI_API_KEY = "local";
+            # llama-swap speaks the OpenAI surface, not the Ollama native API
+            # — leaving this on makes the UI poll /api/tags and log errors.
+            ENABLE_OLLAMA_API = "False";
+            # No phone-home from an autonomous server.
+            SCARF_NO_ANALYTICS = "true";
+            DO_NOT_TRACK = "true";
+            ANONYMIZED_TELEMETRY = "false";
+          }
+          // cfg.environment;
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/open-webui/open-webui.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/open-webui/open-webui.error.log";
+        };
+      };
+
+      # Log rotation via newsyslog (follows mlx/launchd.nix pattern)
+      home.file.".config/newsyslog.d/open-webui.conf".text = ''
+        # logfilename                                                              [owner:group]  mode  count  size  when  flags
+        ${config.home.homeDirectory}/Library/Logs/open-webui/open-webui.error.log :              644   3      10240 *     J
+        ${config.home.homeDirectory}/Library/Logs/open-webui/open-webui.log       :              644   3      10240 *     J
+      '';
+
+      launchd.agents.open-webui-logrotate = {
+        enable = true;
+        config = {
+          Label = "dev.open-webui.logrotate";
+          ProgramArguments = [
+            "/usr/sbin/newsyslog"
+            "-f"
+            "${config.home.homeDirectory}/.config/newsyslog.d/open-webui.conf"
+          ];
+          StartCalendarInterval = [ { Minute = 0; } ]; # hourly
+        };
+      };
+    })
+  ];
 }


### PR DESCRIPTION
## Summary

Prerequisites for the Mac Studio (`jevans-ms`) llm-large serving host (consumed by nix-darwin in a follow-up PR):

- **`services.aiStack.roleOverrides`** — per-role physical model pins merged on top of the `defaultLocalModelId`-populated role map. A host can point `coding` at a dedicated coder model while all other roles keep following the default. The merged map still propagates to `~/.config/ai-stack/registry.json`.
- **`programs.mlx.preload` + `programs.mlx.proxy.groupSwap`** — expose the previously hardcoded llama-swap `hooks.on_startup.preload` list and `groups.mlx-models.swap` flag. Defaults (`["default"]` / `true`) preserve the existing one-resident-model posture bit-for-bit; a server-class host with wired-memory headroom sets `groupSwap = false` plus a two-entry preload to keep a large default model and a coder model resident concurrently.
- **`programs.open-webui`** — extends the package-only stub into an opt-in loopback LaunchAgent (`dev.open-webui.server`, `127.0.0.1:8080`) pointed at the llama-swap OpenAI endpoint (`OPENAI_API_BASE_URL=http://127.0.0.1:11434/v1`, Ollama-native API polling off, telemetry off), with newsyslog rotation following the fabric server pattern. Off by default; the unconditional package install is unchanged.

## Verification

- `nix flake check` clean
- `darwinConfigurations."jevans-ms"` and `."jevans-mbp"` both evaluate against this tree via `--override-input nix-ai` (defaults exercise the unchanged path)
- `statix check` 0 warnings; `deadnix` at pre-existing baseline (7, untouched files)

Part of the Mac Studio 24/7 LLM server bring-up (Linear JAC-155).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT