### PR TITLE
feat: vllm-mlx 0.4.0 + mlx 0.31.2/mlx-lm 0.31.3, per-model registry args

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -61,24 +61,26 @@
   unifiMcpServer = "0.2.5";
 
   # MLX inference stack (pypi)
+  # 0.4.0 adds GPT-OSS/harmony prompt rendering for tool calls (required to
+  # serve gpt-oss models with working tool calling) and requires
+  # mlx-lm>=0.31.3, which forces the mlx/mlx-lm pins below forward together.
   # renovate: datasource=pypi depName=vllm-mlx
-  vllmMlx = "0.3.0";
+  vllmMlx = "0.4.0";
   # renovate: datasource=pypi depName=parakeet-mlx
   parakeetMlx = "0.5.1";
   # renovate: datasource=pypi depName=mlx-vlm
   mlxVlm = "0.5.0";
-  # Pinned to 0.31.1 — mlx 0.31.2 changed cross-thread stream registration
-  # semantics, making generation_stream (created at mlx_lm module import in the
-  # main thread) invisible to vllm-mlx's scheduler thread, causing every
-  # inference call to crash with "There is no Stream(gpu, N) in current thread."
-  # See nix-ai#751. Re-evaluate when vllm-mlx is updated to initialize
-  # generation_stream per-thread or MLX restores cross-thread stream visibility.
+  # The nix-ai#751 hold at mlx 0.31.1 is RESOLVED: vllm-mlx 0.4.0 is built
+  # against mlx 0.31.2 / mlx-lm 0.31.3 (it requires mlx-lm>=0.31.3), and the
+  # cross-thread stream crash ("There is no Stream(gpu, N) in current thread")
+  # no longer reproduces — validated 2026-07-02 on jevans-mbp with three
+  # concurrent completions against Qwen3-30B-A3B-Instruct-2507-4bit under
+  # continuous batching + paged KV cache: zero errors. Keep mlx and mlx-lm
+  # pinned as a pair; they move in lockstep.
   # renovate: datasource=pypi depName=mlx
-  mlx = "0.31.1";
-  # Pinned to 0.31.2 to stay compatible with mlx 0.31.1 (mlx_lm 0.31.3 was
-  # released alongside mlx 0.31.2 and requires it). See nix-ai#751.
+  mlx = "0.31.2";
   # renovate: datasource=pypi depName=mlx-lm
-  mlxLm = "0.31.2";
+  mlxLm = "0.31.3";
   # renovate: datasource=pypi depName=lm-eval
   lmEval = "0.4.11";
 

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -174,8 +174,7 @@ let
     in
     {
       cmd =
-        mkVllmCmd physical
-        + lib.optionalString (extraArgs != [ ]) (" " + lib.concatStringsSep " " extraArgs);
+        mkVllmCmd physical + lib.optionalString (extraArgs != [ ]) (" " + lib.escapeShellArgs extraArgs);
       ttl = cfg.proxy.idleTtl;
       env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
       checkEndpoint = "/v1/models";

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 #
-# MLX Inference Server Module (vllm-mlx 0.2.9 + llama-swap proxy)
+# MLX Inference Server Module (vllm-mlx, pinned in lib/versions.nix, + llama-swap proxy)
 #
 # Manages the MLX inference stack as a macOS LaunchAgent for Apple Silicon.
 # MLX is ~2x faster than llama.cpp for token generation on M4 Max with ~50% less memory.
@@ -27,7 +27,7 @@
 #
 # Models stored on dedicated APFS volume: /Volumes/HuggingFace
 #
-# Parameter reference: vllm-mlx 0.2.9 `serve --help` output (captured from local binary).
+# Parameter reference: vllm-mlx 0.4.0 `serve --help` output (captured from local binary).
 #
 let
   cfg = config.programs.mlx;
@@ -41,6 +41,10 @@ let
   #     MLLM continuous-batching path failed parallel text requests.
   #   - 0.2.9: ships Paged KV Cache + prefix sharing + continuous batching
   #     (MLLM-detection bug fixed). Loads gemma-4-e4b architectures.
+  #   - 0.3.0: stable baseline after the 0.2.x line.
+  #   - 0.4.0: GPT-OSS/harmony prompt rendering for tool calls (required to
+  #     serve gpt-oss models with working tool calling); parser roster grows
+  #     to 17 tool + 7 reasoning parsers; requires mlx-lm>=0.31.3.
   vllmMlxVersion = versions.vllmMlx;
   parakeetMlxVersion = versions.parakeetMlx;
   mlxVlmVersion = versions.mlxVlm;
@@ -49,12 +53,11 @@ let
   # The LaunchAgent needs a Nix store path (not a PATH lookup), so the
   # derivation lives here. Also added to home.packages for CLI access.
   #
-  # mlx==0.31.1 + mlx-lm==0.31.2 are pinned together because mlx 0.31.2 changed
-  # cross-thread stream registration semantics: generation_stream (created at
-  # mlx_lm module import in the main thread) is no longer visible to vllm-mlx's
-  # scheduler thread, causing "There is no Stream(gpu, N) in current thread" on
-  # every inference call. mlx_lm 0.31.3 was released alongside mlx 0.31.2, so
-  # both are rolled back together. See nix-ai#751.
+  # mlx + mlx-lm are pinned together as a lockstep pair (see lib/versions.nix).
+  # History: mlx 0.31.2 originally broke vllm-mlx 0.2.9's scheduler thread
+  # ("There is no Stream(gpu, N) in current thread", nix-ai#751); vllm-mlx
+  # 0.4.0 is built against mlx 0.31.2 / mlx-lm 0.31.3 and the crash no longer
+  # reproduces under concurrent continuous batching (validated 2026-07-02).
   mlxPin = "mlx==${versions.mlx}";
   mlxLmPin = "mlx-lm==${versions.mlxLm}";
   vllmMlxPkg = pkgs.writeShellScriptBin "vllm-mlx" ''
@@ -166,8 +169,13 @@ let
 
   registryModels = lib.mapAttrs (
     physical: roles:
+    let
+      extraArgs = cfg.modelExtraArgs.${physical} or [ ];
+    in
     {
-      cmd = mkVllmCmd physical;
+      cmd =
+        mkVllmCmd physical
+        + lib.optionalString (extraArgs != [ ]) (" " + lib.concatStringsSep " " extraArgs);
       ttl = cfg.proxy.idleTtl;
       env = [ "HF_HOME=${cfg.huggingFaceHome}" ];
       checkEndpoint = "/v1/models";

--- a/modules/mlx/options-parsers.nix
+++ b/modules/mlx/options-parsers.nix
@@ -21,6 +21,9 @@
     # Default: "hermes" — handles Nemotron XML format (<tool_call><function=...>)
     # that Qwen3.5 produces, and supports native tool format for multi-turn
     # conversations. Override to "auto", "qwen3_coder", etc. if needed.
+    # Set to null on hosts that pin parsers per model via modelExtraArgs
+    # (a global parser and a per-model one would emit the flag twice).
+    # Enum matches the vllm-mlx 0.4.0 roster.
     toolCallParser = lib.mkOption {
       type = lib.types.nullOr (
         lib.types.enum [
@@ -30,13 +33,17 @@
           "qwen3_coder"
           "llama"
           "hermes"
+          "harmony"
+          "gpt-oss"
           "deepseek"
           "kimi"
           "granite"
           "nemotron"
           "xlam"
           "functionary"
+          "gemma4"
           "glm47"
+          "minimax"
         ]
       );
       default = "hermes";
@@ -57,11 +64,37 @@
         lib.types.enum [
           "qwen3"
           "deepseek_r1"
+          "gpt_oss"
           "harmony"
+          "gemma4"
+          "glm4"
+          "mistral"
         ]
       );
       default = null;
       description = "Reasoning content extraction parser. Disabled by default — conflicts with tool-call-parser in streaming mode (vllm-mlx bug).";
+    };
+
+    # modelExtraArgs — extra vllm-mlx serve args for REGISTRY models, keyed by
+    # physical model id. The role registry (services.aiStack.models) builds one
+    # backend per unique physical model with uniform global flags; this is the
+    # per-backend escape hatch for flags that genuinely differ per model —
+    # e.g. a host serving gpt-oss (--tool-call-parser harmony) alongside a
+    # Qwen coder (--tool-call-parser qwen3_coder) sets the global
+    # toolCallParser to null and pins one parser per physical id here.
+    # (cfg.models.*.extraArgs already covers ad-hoc non-registry models.)
+    modelExtraArgs = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "mlx-community/<large-model>" = [
+            "--tool-call-parser"
+            "harmony"
+          ];
+        }
+      '';
+      description = "Additional vllm-mlx serve arguments per physical registry model id, appended after the global flags.";
     };
   };
 }


### PR DESCRIPTION
## Summary

Unblocks serving **gpt-oss** models with working tool calling ahead of the Mac Studio two-resident rollout (gpt-oss-120b-MXFP4-Q8 + Qwen3-Coder-30B-A3B-4bit — Linear JAC-155):

- **vllm-mlx 0.3.0 → 0.4.0** (GPT-OSS/harmony prompt rendering for tool calls; parser roster grows to 17 tool + 7 reasoning parsers)
- **mlx 0.31.1 → 0.31.2, mlx-lm 0.31.2 → 0.31.3** — 0.4.0 requires `mlx-lm>=0.31.3`, forcing the pair forward. The nix-ai#751 hold ("There is no Stream(gpu, N) in current thread") is **resolved**: empirically validated today on the laptop — vllm-mlx 0.4.0 + the new pins served `Qwen3-30B-A3B-Instruct-2507-4bit` with continuous batching + paged KV and answered **three concurrent completions with zero errors** in the server log.
- **`programs.mlx.modelExtraArgs`** — per-physical-id extra serve args for registry models. A multi-resident host pins `--tool-call-parser harmony` on the gpt-oss backend and `--tool-call-parser qwen3_coder` on the coder backend (global `toolCallParser = null` there); single-model hosts are untouched.

## Impact

This bumps the runtime for the laptop too (it serves the same stack) — that is the point of the empirical smoke test above. Defaults for all new options are no-ops.

## Verification

- Smoke test: 0.4.0 + new pins, 3-way concurrent completions, `grep -c 'no Stream|Traceback|ERROR'` = 0
- `nix flake check` clean; `statix` 0; `darwinConfigurations."jevans-ms"` evaluates via `--override-input`
- Parser enum captured from the actual `vllm-mlx 0.4.0 serve --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT