### PR TITLE
chore(renovate): group lib/versions.nix pins into one scheduled PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,25 @@
     },
     {
       "description": [
+        "Batch all custom-regex version pins in lib/versions.nix into ONE scheduled,",
+        "auto-merged PR instead of one-PR-per-package. Renovate defaults to one PR per",
+        "dependency; without this, low-priority custom-regex pins (huggingface-hub,",
+        "browser-use, qwen-code, cclint, fabric, ...) each need their own branch/PR slot",
+        "and lose the twice-weekly window race to lock-file maintenance, starving for",
+        "weeks (huggingface-hub stuck at 1.15.0 from 2026-05 to 2026-07, which broke the",
+        "hf CLI). The mlx trio is re-grouped into 'mlx-core' by the rule below (later",
+        "packageRule wins on groupName), preserving its interlock and automerge:false.",
+        "Schedule is inherited from the org preset's Mon/Thu custom.regex rule; majors",
+        "are excluded so they still open individually under the 30-day major-default hold.",
+      ],
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["lib/versions.nix"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "nix tool version pins",
+      "automerge": true,
+    },
+    {
+      "description": [
         "Force the mlx core trio (mlx, mlx-lm, mlx-metal) to upgrade as a single PR",
         "regardless of which manager surfaced the bump (pep621 in mlx-server/, custom",
         "regex in lib/versions.nix). These packages have hard version interlocks:",


### PR DESCRIPTION
## Why

Renovate stalled the `huggingface-hub` pin at `1.15.0` for ~6 weeks (2026-05 → 2026-07) while 1.16–1.21 shipped, which broke the `hf` CLI (`ModuleNotFoundError: No module named 'click'`, fixed in #1081). Root cause is structural, not huggingface-specific:

- Renovate defaults to **one PR per dependency**. The custom-regex `.nix` pins in `lib/versions.nix` each need their own branch/PR slot.
- They run on a narrow **Mon/Thu** schedule and lose the per-window race to lock-file-maintenance PRs under the default `prHourlyLimit: 2`. Parked updates land in the Dependency Dashboard **Rate-Limited** bucket and never advance (huggingface-hub's target froze at `1.16.1`).
- Verified live: it is **not** `branchConcurrentLimit` saturation — Renovate's default `internalChecksFilter=strict` creates no branch for `minimumReleaseAge`-pending updates, and there are currently 0 `renovate/*` branches.

## What

Batch all `custom.regex` pins in `lib/versions.nix` into **one** scheduled, auto-merged **"nix tool version pins"** PR (minor/patch) — Renovate's documented [noise-reduction](https://docs.renovatebot.com/noise-reduction/) via grouping. N competing single-package updates → one branch / one PR / one slot, which sidesteps the rate-limit race entirely.

- Rule is placed **before** `mlx-core`, so the mlx trio keeps its interlock group and `automerge:false` (later packageRule wins on `groupName`) — same ordered-override convention already used for `mlx-packages` → `mlx-core`.
- **Majors excluded** (minor/patch only) → still open individually under the org 30-day major-default hold.
- **Schedule inherited** from the org preset's Mon/Thu `custom.regex` rule (no schedule change).

## Verification

- `renovate-config-validator renovate.json5` → **Config validated successfully**.
- Full local dry-run isn't possible here (config `extends: local>dryvist/.github`, unresolvable under `--platform=local`); behavioral confirmation is the first Mon/Thu run: dashboard #94 "Rate-Limited" drains and a single "nix tool version pins" PR opens + auto-merges, with mlx still separate.

Org-wide generalization of this rule + the corrected analysis are tracked in dryvist/.github#54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)