### PR TITLE
feat(mlx): add modelFlagOverrides for per-model serve-option overrides

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -78,61 +78,71 @@ let
   llamaSwapRuntimeConfigPath = "${config.home.homeDirectory}/.config/mlx/llama-swap.json";
 
   # Build the vllm-mlx serve command string for a given model ID.
+  # Global option values may be replaced per physical model via
+  # modelFlagOverrides; every override key must name an existing programs.mlx
+  # option so a typo fails the eval instead of silently keeping the global.
   # NOTE: \${PORT} is a llama-swap template macro — must be escaped to prevent
   # Nix string interpolation from consuming it before the config is written.
   mkVllmCmd =
     modelId:
     let
-      baseCmd = "${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${cfg.host}";
+      overrides = cfg.modelFlagOverrides.${modelId} or { };
+      unknown = lib.filter (k: !(cfg ? ${k})) (lib.attrNames overrides);
+      c =
+        if unknown == [ ] then
+          cfg // overrides
+        else
+          throw "programs.mlx.modelFlagOverrides.\"${modelId}\": unknown option name(s): ${lib.concatStringsSep ", " unknown}";
+      baseCmd = "${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
       flags = lib.concatStringsSep " " (
-        lib.optionals (cfg.cacheMemoryMb != null) [
+        lib.optionals (c.cacheMemoryMb != null) [
           "--cache-memory-mb"
-          (toString cfg.cacheMemoryMb)
+          (toString c.cacheMemoryMb)
         ]
-        ++ lib.optionals (cfg.prefillBatchSize != null) [
+        ++ lib.optionals (c.prefillBatchSize != null) [
           "--prefill-batch-size"
-          (toString cfg.prefillBatchSize)
+          (toString c.prefillBatchSize)
         ]
-        ++ lib.optionals (cfg.gpuMemoryUtilization != null) [
+        ++ lib.optionals (c.gpuMemoryUtilization != null) [
           "--gpu-memory-utilization"
-          (toString cfg.gpuMemoryUtilization)
+          (toString c.gpuMemoryUtilization)
         ]
-        ++ lib.optionals (cfg.autoUnloadIdleSeconds != 0) [
+        ++ lib.optionals (c.autoUnloadIdleSeconds != 0) [
           "--auto-unload-idle-seconds"
-          (toString cfg.autoUnloadIdleSeconds)
+          (toString c.autoUnloadIdleSeconds)
         ]
-        ++ lib.optionals cfg.enableMetrics [ "--enable-metrics" ]
-        ++ lib.optionals cfg.continuousBatching [ "--continuous-batching" ]
-        ++ lib.optionals cfg.enablePrefixCaching [ "--enable-prefix-cache" ]
-        ++ lib.optionals cfg.pagedKvCache [ "--use-paged-cache" ]
-        ++ lib.optionals (cfg.maxNumSeqs != null) [
+        ++ lib.optionals c.enableMetrics [ "--enable-metrics" ]
+        ++ lib.optionals c.continuousBatching [ "--continuous-batching" ]
+        ++ lib.optionals c.enablePrefixCaching [ "--enable-prefix-cache" ]
+        ++ lib.optionals c.pagedKvCache [ "--use-paged-cache" ]
+        ++ lib.optionals (c.maxNumSeqs != null) [
           "--max-num-seqs"
-          (toString cfg.maxNumSeqs)
+          (toString c.maxNumSeqs)
         ]
-        ++ lib.optionals (cfg.chunkedPrefillTokens != null) [
+        ++ lib.optionals (c.chunkedPrefillTokens != null) [
           "--chunked-prefill-tokens"
-          (toString cfg.chunkedPrefillTokens)
+          (toString c.chunkedPrefillTokens)
         ]
-        ++ lib.optionals (cfg.completionBatchSize != null) [
+        ++ lib.optionals (c.completionBatchSize != null) [
           "--completion-batch-size"
-          (toString cfg.completionBatchSize)
+          (toString c.completionBatchSize)
         ]
-        ++ lib.optionals (cfg.maxTokens != null) [
+        ++ lib.optionals (c.maxTokens != null) [
           "--max-tokens"
-          (toString cfg.maxTokens)
+          (toString c.maxTokens)
         ]
-        ++ lib.optionals (cfg.maxRequestTokens != null) [
+        ++ lib.optionals (c.maxRequestTokens != null) [
           "--max-request-tokens"
-          (toString cfg.maxRequestTokens)
+          (toString c.maxRequestTokens)
         ]
-        ++ lib.optionals cfg.enableAutoToolChoice [ "--enable-auto-tool-choice" ]
-        ++ lib.optionals (cfg.enableAutoToolChoice && cfg.toolCallParser != null) [
+        ++ lib.optionals c.enableAutoToolChoice [ "--enable-auto-tool-choice" ]
+        ++ lib.optionals (c.enableAutoToolChoice && c.toolCallParser != null) [
           "--tool-call-parser"
-          cfg.toolCallParser
+          c.toolCallParser
         ]
-        ++ lib.optionals (cfg.reasoningParser != null) [
+        ++ lib.optionals (c.reasoningParser != null) [
           "--reasoning-parser"
-          cfg.reasoningParser
+          c.reasoningParser
         ]
       );
     in

--- a/modules/mlx/options-parsers.nix
+++ b/modules/mlx/options-parsers.nix
@@ -96,5 +96,31 @@
       '';
       description = "Additional vllm-mlx serve arguments per physical registry model id, appended after the global flags.";
     };
+
+    # modelFlagOverrides — per-physical-id overrides of the GLOBAL serve
+    # options. modelExtraArgs can only APPEND flags; it cannot retract a
+    # default-on boolean like pagedKvCache, whose --use-paged-cache flag has
+    # no CLI negation. Keys must be existing programs.mlx option names — the
+    # command builder rejects unknown keys at eval time so typos fail the
+    # build instead of silently keeping the global value.
+    # Motivating case (vllm-mlx 0.4.0): the paged KV cache is incompatible
+    # with gpt-oss's alternating sliding-window attention — generation fails
+    # with "[broadcast_shapes] Shapes (1,8,64,64) and (1,8,115,64) cannot be
+    # broadcast" (paged-cache block size 64 vs. prompt length). Disabling
+    # pagedKvCache + enablePrefixCaching for that one model fixes it while
+    # sibling models keep prefix caching.
+    modelFlagOverrides = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.attrsOf lib.types.raw);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "mlx-community/<sliding-window-model>" = {
+            pagedKvCache = false;
+            enablePrefixCaching = false;
+          };
+        }
+      '';
+      description = "Per-physical-model overrides of programs.mlx serve options (e.g. pagedKvCache, enablePrefixCaching), merged over the global values when building that model's vllm-mlx command.";
+    };
   };
 }


### PR DESCRIPTION
## Why

vllm-mlx 0.4.0's paged KV cache is incompatible with gpt-oss's alternating sliding-window attention: generation fails with `[broadcast_shapes] Shapes (1,8,64,64) and (1,8,115,64) cannot be broadcast` (the paged-cache block size vs. the prompt length). Empirically isolated on hardware: the identical serve command minus `--use-paged-cache --enable-prefix-cache` generates correctly, with continuous batching still on.

`modelExtraArgs` cannot express this fix — it only appends flags, and `--use-paged-cache` has no CLI negation (`serve --help` offers `--disable-prefix-cache` but no paged-cache opposite).

## What

- New `programs.mlx.modelFlagOverrides` option: per-physical-model attrset merged over the global serve options when building that model's vllm-mlx command.
- Unknown override keys are rejected at eval time (must name an existing `programs.mlx` option), so typos fail the build instead of silently keeping the global value.
- `mkVllmCmd` now reads the effective per-model config; ad-hoc `cfg.models` entries simply miss the lookup and keep global flags.

## Verification

- `nix fmt` / `statix` / `deadnix` clean; pre-commit hooks pass.
- Downstream nix-darwin eval of the server host with this branch as `nix-ai` input succeeds.
- Closure neutrality: a host with no overrides produces a byte-identical system drvPath against current main.
- On-host proof of the underlying fix: gpt-oss-120b completion succeeds without the paged-cache flags (19.3 tok/s), fails reproducibly with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT