### PR TITLE
refactor(mlx): post-Studio cleanup — override guard, option placement, doc currency

### DIFF
--- a/docs/architecture/mlx-stack.md
+++ b/docs/architecture/mlx-stack.md
@@ -60,7 +60,7 @@ graph TD
 
 ## Version Management
 
-- **Version constants**: `modules/mlx/default.nix` — single source of truth with Renovate annotations
+- **Version constants**: `lib/versions.nix` — single source of truth with Renovate annotations
 - **uvx wrappers**: `modules/mlx/packages.nix` — declarative Nix derivations for the MLX tools
 - **Auto-update**: Renovate annotation-based manager bumps version constants, weekly schedule
 
@@ -71,9 +71,16 @@ models pass tool-calling validation with this parser; GLM and Seed-OSS models fa
 format errors despite correct reasoning. To use non-Qwen models for tool calling, switch to
 `auto` or a model-specific parser in the llama-swap config.
 
-**Idle penalty**: After ~1 hour idle, macOS memory compression evicts the model from active
-memory. The next request triggers a full reload, causing 300s+ timeouts through Bifrost.
-Restore with `mlx-default` to return to normal latency.
+**Idle penalty**: llama-swap evicts an idle model after `proxy.idleTtl` (default 15 min;
+the worker's `autoUnloadIdleSeconds` failsafe fires at 30 min). The next request pays a
+full reload — seconds for a small MoE, ~60-120s for a 120B model.
+
+**Multi-resident serving**: the defaults keep one model resident (`proxy.groupSwap = true`
+evicts on switch). Server-class hosts with the wired-memory headroom keep several models
+warm by setting `groupSwap = false`, listing each role in `preload`, and disabling
+eviction (`proxy.idleTtl = 0`, `autoUnloadIdleSeconds = 0`); per-model serve flags that
+must differ from the globals ride `modelExtraArgs` (append-only) or `modelFlagOverrides`
+(replaces a global option value, e.g. turning `pagedKvCache` off for one model).
 
 **MoE vs dense throughput** (M4 Max, 128GB): 122B MoE models achieve ~24 tok/s; dense models
 of similar parameter count (~123B) top out at ~6.6 tok/s. Prefer MoE for throughput-sensitive

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -79,20 +79,42 @@ let
 
   # Build the vllm-mlx serve command string for a given model ID.
   # Global option values may be replaced per physical model via
-  # modelFlagOverrides; every override key must name an existing programs.mlx
-  # option so a typo fails the eval instead of silently keeping the global.
+  # modelFlagOverrides; every override key must appear in overridableFlags —
+  # the serve options this builder reads below. Guarding against that list
+  # (not against programs.mlx as a whole) means a typo AND a real-but-unread
+  # option name (e.g. huggingFaceHome, preload) both fail the eval instead of
+  # silently keeping the global value.
   # NOTE: \${PORT} is a llama-swap template macro — must be escaped to prevent
   # Nix string interpolation from consuming it before the config is written.
+  overridableFlags = [
+    "host"
+    "cacheMemoryMb"
+    "prefillBatchSize"
+    "gpuMemoryUtilization"
+    "autoUnloadIdleSeconds"
+    "enableMetrics"
+    "continuousBatching"
+    "enablePrefixCaching"
+    "pagedKvCache"
+    "maxNumSeqs"
+    "chunkedPrefillTokens"
+    "completionBatchSize"
+    "maxTokens"
+    "maxRequestTokens"
+    "enableAutoToolChoice"
+    "toolCallParser"
+    "reasoningParser"
+  ];
   mkVllmCmd =
     modelId:
     let
       overrides = cfg.modelFlagOverrides.${modelId} or { };
-      unknown = lib.filter (k: !(cfg ? ${k})) (lib.attrNames overrides);
+      unknown = lib.filter (k: !(lib.elem k overridableFlags)) (lib.attrNames overrides);
       c =
         if unknown == [ ] then
           cfg // overrides
         else
-          throw "programs.mlx.modelFlagOverrides.\"${modelId}\": unknown option name(s): ${lib.concatStringsSep ", " unknown}";
+          throw "programs.mlx.modelFlagOverrides.\"${modelId}\": not overridable serve option(s): ${lib.concatStringsSep ", " unknown}";
       baseCmd = "${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
       flags = lib.concatStringsSep " " (
         lib.optionals (c.cacheMemoryMb != null) [
@@ -158,7 +180,7 @@ let
   # One entry per unique physical model. Every model — including the entry
   # owning the "default" alias — inherits the uniform proxy idle TTL.
   # The default model is still preloaded on startup via hooks.on_startup.preload
-  # below, so the first request never pays a cold-start cost; after one hour
+  # below, so the first request never pays a cold-start cost; after proxy.idleTtl
   # of idle it unloads and the next request reloads it (~15-30 s).
   #
   # useModelName makes llama-swap rewrite the OpenAI-compatible request body's

--- a/modules/mlx/options-batching.nix
+++ b/modules/mlx/options-batching.nix
@@ -69,11 +69,11 @@
     # requests. If a client asks for max_tokens=100000, vllm-mlx clamps it to
     # this value and returns finish_reason: "length" once the cap is hit.
     #
-    # Left null by default — keeps the 32768 server ceiling intact so
-    # legitimate expensive generations remain possible. Set to a positive
-    # integer only when you specifically need to cap client-requested
-    # generation length (e.g. cost control on a shared environment, or
-    # bounding wasted compute on a pathologically misconfigured caller).
+    # Default 8192 — bounds runaway client-requested generation lengths
+    # before they wait out a disconnect_guard timeout (tightened from null
+    # after the 2026-05/06 pipe-timeout storm; see description). Set null to
+    # restore the 32768 server ceiling when legitimately expensive
+    # generations matter more than bounding a misconfigured caller.
     maxRequestTokens = lib.mkOption {
       type = lib.types.nullOr lib.types.ints.positive;
       default = 8192;

--- a/modules/mlx/options-parsers.nix
+++ b/modules/mlx/options-parsers.nix
@@ -75,52 +75,5 @@
       description = "Reasoning content extraction parser. Disabled by default — conflicts with tool-call-parser in streaming mode (vllm-mlx bug).";
     };
 
-    # modelExtraArgs — extra vllm-mlx serve args for REGISTRY models, keyed by
-    # physical model id. The role registry (services.aiStack.models) builds one
-    # backend per unique physical model with uniform global flags; this is the
-    # per-backend escape hatch for flags that genuinely differ per model —
-    # e.g. a host serving gpt-oss (--tool-call-parser harmony) alongside a
-    # Qwen coder (--tool-call-parser qwen3_coder) sets the global
-    # toolCallParser to null and pins one parser per physical id here.
-    # (cfg.models.*.extraArgs already covers ad-hoc non-registry models.)
-    modelExtraArgs = lib.mkOption {
-      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
-      default = { };
-      example = lib.literalExpression ''
-        {
-          "mlx-community/<large-model>" = [
-            "--tool-call-parser"
-            "harmony"
-          ];
-        }
-      '';
-      description = "Additional vllm-mlx serve arguments per physical registry model id, appended after the global flags.";
-    };
-
-    # modelFlagOverrides — per-physical-id overrides of the GLOBAL serve
-    # options. modelExtraArgs can only APPEND flags; it cannot retract a
-    # default-on boolean like pagedKvCache, whose --use-paged-cache flag has
-    # no CLI negation. Keys must be existing programs.mlx option names — the
-    # command builder rejects unknown keys at eval time so typos fail the
-    # build instead of silently keeping the global value.
-    # Motivating case (vllm-mlx 0.4.0): the paged KV cache is incompatible
-    # with gpt-oss's alternating sliding-window attention — generation fails
-    # with "[broadcast_shapes] Shapes (1,8,64,64) and (1,8,115,64) cannot be
-    # broadcast" (paged-cache block size 64 vs. prompt length). Disabling
-    # pagedKvCache + enablePrefixCaching for that one model fixes it while
-    # sibling models keep prefix caching.
-    modelFlagOverrides = lib.mkOption {
-      type = lib.types.attrsOf (lib.types.attrsOf lib.types.raw);
-      default = { };
-      example = lib.literalExpression ''
-        {
-          "mlx-community/<sliding-window-model>" = {
-            pagedKvCache = false;
-            enablePrefixCaching = false;
-          };
-        }
-      '';
-      description = "Per-physical-model overrides of programs.mlx serve options (e.g. pagedKvCache, enablePrefixCaching), merged over the global values when building that model's vllm-mlx command.";
-    };
   };
 }

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -93,6 +93,54 @@
       description = "Additional models available for on-demand switching via llama-swap proxy. All models (including the default-aliased one) share the uniform proxy.idleTtl unless overridden per-model.";
     };
 
+    # modelExtraArgs — extra vllm-mlx serve args for REGISTRY models, keyed by
+    # physical model id. The role registry (services.aiStack.models) builds one
+    # backend per unique physical model with uniform global flags; this is the
+    # per-backend escape hatch when flags genuinely differ per model —
+    # e.g. a host serving gpt-oss (--tool-call-parser harmony) alongside a
+    # Qwen coder (--tool-call-parser qwen3_coder) sets the global
+    # toolCallParser to null and pins one parser per physical id here.
+    # (cfg.models.*.extraArgs already covers ad-hoc non-registry models.)
+    modelExtraArgs = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "mlx-community/<large-model>" = [
+            "--tool-call-parser"
+            "harmony"
+          ];
+        }
+      '';
+      description = "Additional vllm-mlx serve arguments per physical registry model id, appended after the global flags.";
+    };
+
+    # modelFlagOverrides — per-physical-id overrides of the GLOBAL serve
+    # options. modelExtraArgs can only APPEND flags; it cannot retract a
+    # default-on boolean like pagedKvCache, whose --use-paged-cache flag has
+    # no CLI negation. Keys must name serve options the command builder
+    # actually reads (the list in modules/mlx/default.nix mkVllmCmd) — any
+    # other key fails the eval instead of silently keeping the global value.
+    # Motivating case (vllm-mlx 0.4.0): the paged KV cache is incompatible
+    # with gpt-oss's alternating sliding-window attention — generation fails
+    # with "[broadcast_shapes] Shapes (1,8,64,64) and (1,8,115,64) cannot be
+    # broadcast" (paged-cache block size 64 vs. prompt length). Disabling
+    # pagedKvCache + enablePrefixCaching on that one model fixes it; sibling
+    # models keep prefix caching.
+    modelFlagOverrides = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.attrsOf lib.types.raw);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "mlx-community/<sliding-window-model>" = {
+            pagedKvCache = false;
+            enablePrefixCaching = false;
+          };
+        }
+      '';
+      description = "Per-physical-model overrides of programs.mlx serve options (e.g. pagedKvCache, enablePrefixCaching), merged over the global values when building that model's vllm-mlx command.";
+    };
+
     # preload — llama-swap hooks.on_startup.preload entries. Role names (or
     # physical ids) loaded at proxy startup so the first request never pays a
     # cold start. Multi-resident hosts list every role they keep warm, e.g.


### PR DESCRIPTION
## Summary

Post-bring-up cleanup of the mlx module after the Mac Studio multi-resident serving work (#1082, #1083, #1090):

- **Tighter `modelFlagOverrides` guard** — override keys must now name serve options `mkVllmCmd` actually reads (explicit `overridableFlags` list). Previously any `programs.mlx` option name passed the guard, so a real-but-unread key (e.g. `huggingFaceHome`) silently no-oped instead of failing the eval as the option docs promise.
- **Option placement** — `modelExtraArgs` + `modelFlagOverrides` move from `options-parsers.nix` (header: parser options) to `options-runtime.nix` beside the rest of the per-model surface (`models`, `preload`, `proxy.*`). Pure move, no wiring change.
- **Comment/doc currency** — `maxRequestTokens` comment claimed default null/32768 (actual: 8192); `mlx-stack.md` version SoT repointed to `lib/versions.nix`, idle-penalty note updated to the 15-min `proxy.idleTtl`, new multi-resident serving paragraph; stale one-hour idle comment in `default.nix`.

## Verification

- `nix flake check`, statix, deadnix, pre-commit all green
- `darwinConfigurations."jevans-ms"` and `"jevans-mbp"` in nix-darwin eval cleanly with `--override-input nix-ai` pointing at this branch — exercises the new guard against the Studio's live gpt-oss overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT