### PR TITLE
refactor(bifrost): decouple nix-ai clients from the Bifrost gateway

### DIFF
--- a/docs/adr/0003-galileo-ai-observability.md
+++ b/docs/adr/0003-galileo-ai-observability.md
@@ -3,6 +3,13 @@
 **Status**: Accepted
 **Date**: 2026-05-22
 
+> **Update 2026-07-03:** The Bifrost gateway is being relocated off the OrbStack k8s
+> cluster to the Proxmox homelab (nix-ai clients now call local MLX directly). The
+> Bifrost-side pending work below therefore moves to the homelab IaC repos, and the
+> Galileo pipeline now spans two hosts (OTEL Collector stays in `orbstack-kubernetes`;
+> Bifrost's exporter lands on Proxmox). This integration is still Pending and should be
+> re-scoped against the new topology before it ships.
+
 ## Documents in This Directory
 
 _This ADR is part of [`docs/adr/`](README.md)._
@@ -80,7 +87,7 @@ self-contained. The remaining work:
 |------|--------|--------|
 | `nix-ai` | `programs.mlx.telemetry.enable` option + LaunchAgent env | Done (this PR) |
 | `orbstack-kubernetes` | OTEL Collector: `otlphttp/galileo` exporter, routing connector, content denylist processor | Pending |
-| `orbstack-kubernetes` | Bifrost: OTel exporter + header→span-attr mapping for `X-Trace-Sink` | Pending |
+| `ansible-proxmox-apps` (homelab) | Bifrost: OTel exporter + header→span-attr mapping for `X-Trace-Sink` | Pending (moved off `orbstack-kubernetes` with the relocation) |
 | `nix-home` | `galileo-on` zsh function + `gcurl` wrapper + `~/.config/galileo/allowlist.toml` | Pending |
 | `orbstack-kubernetes` | Doppler Operator: `GALILEO_API_KEY` in `ai-ci-automation/prd` | Pending (manual Doppler config) |
 

--- a/docs/ai-tool-decision-tree.md
+++ b/docs/ai-tool-decision-tree.md
@@ -10,7 +10,8 @@ When to use which tool for AI-assisted tasks in the nix-ai ecosystem.
 | YouTube video processing | `fabric -y URL --pattern summarize` | Built-in yt-dlp + Jina extraction |
 | Want Claude Code to auto-invoke a pattern | Fabric skills (synthetic marketplace) | Curated patterns auto-loaded by description match |
 | Want to explicitly call a pattern from Claude Code | Fabric MCP server | Pattern appears as a callable MCP tool |
-| Single external model call | Bifrost (`localhost:30080`) | OpenAI-compatible, multi-provider |
+| Single local model call | llama-swap (`127.0.0.1:11434`) | OpenAI-compatible, direct to local MLX |
+| Second opinion / adversarial review from another model | `/delegate-to-ai` (Codex / native subagent) | No local gateway needed |
 | Writing Python/Go code that calls an LLM | Anthropic SDK / OpenAI SDK | Direct API, no middleware |
 
 ## When to Use Fabric CLI
@@ -74,18 +75,23 @@ Not for:
 - Shell pipelines (use CLI — faster, no MCP overhead)
 - Auto-discovery (use skills — MCP requires explicit invocation)
 
-## When to Use Bifrost
+## When to Call Local MLX Directly
 
-Best for: **external model calls and multi-provider routing**
+Best for: **a single local model call over an OpenAI-compatible API**
 
-| Tool | Use Case |
-| --- | --- |
-| Bifrost (`localhost:30080`) | Single model call via OpenAI-compatible API |
+Point any OpenAI-compatible client at llama-swap (`http://127.0.0.1:11434/v1`);
+it routes capability-class aliases (`default`, `coding`, …) to the resident
+MLX model. Fabric, qwen-code, and cecli already do this.
 
 Use when:
 
-- You need a non-Claude model (Gemini, OpenRouter, local MLX)
-- You're building a workflow that routes across providers
+- You need a local, non-Claude model for a quick task
+- You want to stay offline / keep the prompt on-device
+
+For a non-Claude *cloud* model or a second opinion from another model, use
+`/delegate-to-ai` (Codex or a native subagent) — there is no local gateway to
+route through. The multi-provider Bifrost gateway now lives on the Proxmox
+homelab (`https://bifrost.pve.jacobpevans.com`), not on this machine.
 
 ## Anti-Patterns
 
@@ -94,4 +100,3 @@ Use when:
 | Use MCP server for a quick shell pipeline | `echo "text" \| fabric --pattern X` |
 | Manually invoke fabric skills from Claude Code | Let auto-discovery match by description |
 | Use fabric for multi-step automated workflows | Use the orchestrator (when it has consumers) |
-| Route through Bifrost for a task fabric handles | Use fabric directly — it already talks to MLX |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,7 +8,7 @@ This directory contains cross-cutting architecture views for nix-ai's AI tool ec
 |----------|----------|--------|
 | `CLAUDE.md` (repo root) | Developers | **How to develop** in this repo — critical constraints, validation commands, key files, module separation rules |
 | `modules/mcp/README.md` | MCP users | **Per-module reference** — MCP transports, secrets, troubleshooting |
-| `docs/ai-tool-decision-tree.md` | Users | **When to use what** — Fabric vs Bifrost |
+| `docs/ai-tool-decision-tree.md` | Users | **When to use what** — Fabric vs local MLX vs delegation |
 | `docs/architecture/` (here) | Architects, AI assistants | **How the system works** — integration topology, data flows, design decisions |
 | `docs/adr/` | Decision-makers | **Why things are the way they are** — architectural decision records |
 

--- a/docs/architecture/mlx-stack.md
+++ b/docs/architecture/mlx-stack.md
@@ -72,7 +72,7 @@ format errors despite correct reasoning. To use non-Qwen models for tool calling
 `auto` or a model-specific parser in the llama-swap config.
 
 **Idle penalty**: After ~1 hour idle, macOS memory compression evicts the model from active
-memory. The next request triggers a full reload, causing 300s+ timeouts through Bifrost.
+memory. The next request triggers a full reload, causing 300s+ timeouts through the proxy.
 Restore with `mlx-default` to return to normal latency.
 
 **MoE vs dense throughput** (M4 Max, 128GB): 122B MoE models achieve ~24 tok/s; dense models

--- a/docs/architecture/secrets-and-injection.md
+++ b/docs/architecture/secrets-and-injection.md
@@ -36,8 +36,8 @@ graph TD
     subgraph P3["Pattern 3: Kubernetes Doppler Operator"]
         DOP["Doppler (cloud)"]
         K8S["K8s Doppler Operator\n(in-cluster)"]
-        SEC["K8s Secrets\n(provider API keys)"]
-        POD["Bifrost / Cribl pods"]
+        SEC["K8s Secrets\n(Cribl credentials)"]
+        POD["Cribl pods"]
         DOP --> K8S --> SEC --> POD
     end
 ```
@@ -83,18 +83,22 @@ variable is exported by checking `env | grep HF_TOKEN` in a Claude session.
 
 ## Pattern 3: Kubernetes Doppler Operator (In-Cluster)
 
-**Used by**: Bifrost AI gateway, Cribl MCP (both in `orbstack-kubernetes` repo)
+**Used by**: Cribl MCP (in `orbstack-kubernetes` repo)
 
 The [Doppler Kubernetes Operator](https://docs.doppler.com/docs/kubernetes-operator)
 syncs secrets from Doppler into native Kubernetes Secrets objects inside the OrbStack
-cluster. The provider API keys (OpenAI, Anthropic, Gemini, OpenRouter) are injected
-directly into the Bifrost and Cribl pods at runtime.
+cluster, injected directly into the Cribl pods at runtime.
 
-**These secrets never reach the MCP client process.** Claude Code connects to Bifrost
-at `http://localhost:30080/mcp` — Bifrost authenticates to upstream providers using its
-own in-cluster credentials. The client only needs network access to :30080.
+**These secrets never reach the MCP client process.** Claude Code connects to Cribl MCP
+at `http://localhost:30030/mcp` — the pod authenticates upstream using its own in-cluster
+credentials. The client only needs network access to :30030.
 
 This is the cleanest pattern: zero credential exposure outside the cluster boundary.
+
+The Bifrost gateway previously used this same in-cluster pattern for its provider API
+keys (OpenAI, Gemini, OpenRouter). It relocated to the Proxmox homelab; its keys now
+follow the homelab's Doppler injection convention (`doppler run -- ansible-playbook …`),
+not the k8s operator.
 
 ## Secrets by Product
 
@@ -104,7 +108,7 @@ This is the cleanest pattern: zero credential exposure outside the cluster bound
 | Splunk MCP | `SPLUNK_MCP_ENDPOINT`, `SPLUNK_MCP_TOKEN` | Doppler subprocess | `ai-ci-automation/prd` Doppler project |
 | HuggingFace MCP | `HF_TOKEN` | Keychain → shell env | macOS Keychain (`huggingface-token`) |
 | GitHub MCP | `GITHUB_PERSONAL_ACCESS_TOKEN` | Keychain → shell env | macOS Keychain |
-| Bifrost | Provider API keys | K8s Doppler Operator | OrbStack cluster |
+| Bifrost | Provider API keys | Homelab Doppler (`doppler run`) | Proxmox homelab (`ansible-proxmox-apps`) |
 | Cribl | Provider credentials | K8s Doppler Operator | OrbStack cluster |
 | OTEL Collector (Galileo exporter) | `GALILEO_API_KEY` | K8s Doppler Operator | OrbStack cluster (`ai-ci-automation/prd`) |
 | WakaTime | `WAKATIME_API_KEY` | Activation-time Doppler fetch | Written to `~/.wakatime.cfg` at `darwin-rebuild switch` |

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -31,8 +31,6 @@ graph TD
         FAB["Fabric\nCLI + REST :8180"]
     end
 
-    HOMELAB["Bifrost multi-provider gateway\n(Proxmox homelab — external)\nbifrost.pve.jacobpevans.com"]
-
     CC -->|stdio MCP| FAB_MCP["fabric-mcp"]
     CC -->|HTTP MCP| CRIBL["Cribl MCP\n:30030"]
     MAE -->|claude subprocess| CC

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -21,10 +21,6 @@ graph TD
         MAE["Maestro\n(scheduled sessions)"]
     end
 
-    subgraph Gateway["AI Gateway — K8s :30080"]
-        BIF["Bifrost\n(multi-provider router)"]
-    end
-
     subgraph LocalInference["Local Inference — Apple Silicon"]
         LS["llama-swap proxy\n:11434"]
         VLLM["vllm-mlx backends\n:11436+"]
@@ -35,34 +31,24 @@ graph TD
         FAB["Fabric\nCLI + REST :8180"]
     end
 
-    subgraph Cloud["Cloud Providers (via Bifrost)"]
-        OR["OpenRouter"]
-        OAI["OpenAI"]
-        ANT["Anthropic"]
-        GGL["Google AI"]
-    end
+    HOMELAB["Bifrost multi-provider gateway\n(Proxmox homelab — external)\nbifrost.pve.jacobpevans.com"]
 
     CC -->|stdio MCP| FAB_MCP["fabric-mcp"]
-    CC -->|HTTP MCP| BIF
     CC -->|HTTP MCP| CRIBL["Cribl MCP\n:30030"]
     MAE -->|claude subprocess| CC
 
     FAB_MCP -->|reads patterns| FAB
-
-    BIF -->|HTTP /v1| LS
-    BIF -->|HTTPS| OR
-    BIF -->|HTTPS| OAI
-    BIF -->|HTTPS| ANT
-    BIF -->|HTTPS| GGL
-
-    OR -->|unified API| OAI
-    OR -->|unified API| ANT
 
     OWU -->|HTTP /v1| LS
     FAB -->|HTTP /v1| LS
 
     LS -->|manages processes| VLLM
 ```
+
+Local nix-ai clients (qwen-code, cecli, Open WebUI, Fabric) call llama-swap
+directly at `:11434` — there is no local gateway hop. Multi-provider cloud
+fan-out lives in the Bifrost gateway, which relocated off this machine's
+OrbStack k8s cluster to the Proxmox homelab (see the homelab IaC repos).
 
 ## Product Responsibility Table
 
@@ -72,7 +58,7 @@ graph TD
 | Antigravity CLI | `modules/antigravity-cli/` | CLI | Google Antigravity assistant | `~/.gemini/antigravity-cli/settings.json` |
 | Codex CLI | `modules/codex/` | CLI | OpenAI coding assistant | `~/.codex/config.toml` |
 | GitHub Copilot CLI | `modules/copilot.nix` | CLI | Trusted folder configuration | `~/.copilot/config.json` |
-| Bifrost | `orbstack-kubernetes` repo | HTTP :30080 | Multi-provider AI gateway | K8s secrets (Doppler Operator) |
+| Bifrost | Proxmox homelab (`ansible-proxmox-apps`, relocating) | HTTPS (Traefik) | Multi-provider AI gateway | Doppler (provider keys) |
 | MLX / llama-swap | `modules/mlx/` | HTTP :11434 | Local Apple Silicon inference | `~/.config/mlx/llama-swap.json` |
 | Fabric | `modules/fabric/` | CLI + HTTP :8180 | AI prompt pattern library | `~/.config/fabric/` |
 | Open WebUI | `modules/open-webui.nix` | HTTP :8080 | Browser UI for MLX | None (queries MLX at runtime) |
@@ -102,7 +88,6 @@ graph LR
 | `time` | stdio (uvx) | None | Official maintained Python server |
 | `aws` | stdio (bunx) | IAM/STS env vars | AWS KB retrieval |
 | `terraform` | stdio (binary) | None | nixpkgs binary |
-| `bifrost` | HTTP :30080 | None (K8s internal) | AI gateway |
 | `cribl` | HTTP :30030 | None (K8s internal) | Log pipeline |
 
 ### Claude-Only MCP Servers
@@ -131,7 +116,6 @@ Enable by overriding `programs.aiMcp.servers.<name>.disabled` and adding the key
 | 8080 | Open WebUI | HTTP | `modules/open-webui.nix` |
 | 8180 | Fabric REST API (opt-in) | HTTP + Swagger UI | `modules/fabric/` |
 | 9379 | LiteRT-LM classifier (Antigravity CLI gemma router, opt-in) | HTTP | `modules/antigravity-cli/` |
-| 30080 | Bifrost AI gateway | HTTP | `orbstack-kubernetes` repo |
 | 30030 | Cribl MCP | HTTP | `orbstack-kubernetes` repo |
 | 30317 | OTEL Collector (gRPC receiver) | gRPC | `orbstack-kubernetes` repo |
 | 4317 | Cribl OTEL ingest | gRPC | `orbstack-kubernetes` repo |

--- a/docs/runbooks/galileo-onboarding.md
+++ b/docs/runbooks/galileo-onboarding.md
@@ -11,8 +11,9 @@ reach Galileo. Check each before assuming the pipeline is live:
 1. `programs.mlx.telemetry.enable = true` in your nix-darwin config (this repo).
 2. `orbstack-kubernetes`: OTEL Collector has `otlphttp/galileo` exporter, routing
    connector, and content denylist processor deployed.
-3. `orbstack-kubernetes`: Bifrost emits OTel spans and maps `X-Trace-Sink` header
-   to `trace.sink` span attribute.
+3. `ansible-proxmox-apps` (homelab): Bifrost emits OTel spans and maps `X-Trace-Sink`
+   header to `trace.sink` span attribute. (Bifrost relocated from `orbstack-kubernetes`
+   to the Proxmox homelab — see [ADR 0003](../adr/0003-galileo-ai-observability.md).)
 4. `nix-home`: `galileo-on` zsh function and `gcurl` wrapper are activated.
 5. Doppler (`ai-ci-automation/prd`): `GALILEO_API_KEY` is set, Doppler Operator
    has synced it to the OTEL Collector pod.
@@ -28,8 +29,8 @@ gcurl http://127.0.0.1:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"default","messages":[{"role":"user","content":"hello"}]}'
 
-# Hit Bifrost with trace header (cloud model):
-gcurl http://127.0.0.1:30080/v1/chat/completions \
+# Hit Bifrost with trace header (cloud model) — now on the Proxmox homelab:
+gcurl https://bifrost.pve.jacobpevans.com/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"${MODEL_ID}","messages":[{"role":"user","content":"hello"}]}'
 

--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -102,9 +102,9 @@
   skillPacks = import ../modules/claude/plugins/packs.nix;
 
   # Role-name → physical mlx-community/* model ID registry.
-  # Exported as a plain attrset so foreign consumers (e.g.
-  # orbstack-kubernetes Bifrost config) can consume it without
-  # importing the home-manager module system. The module at
+  # Exported as a plain attrset so foreign consumers (e.g. the homelab
+  # Bifrost gateway config) can consume it without importing the
+  # home-manager module system. The module at
   # modules/ai-stack/default.nix uses this same file as its option
   # default — one source of truth.
   aiStackModels = import ../lib/ai-stack-models.nix;

--- a/modules/antigravity-cli/options.nix
+++ b/modules/antigravity-cli/options.nix
@@ -185,9 +185,9 @@ in
         See the in-CLI /model dialog or upstream settings.schema.json for
         the current accepted values.
         null leaves Antigravity CLI's own model resolution alone.
-        NOTE: Google-hosted model values execute in Google's cloud. For
-        on-device generation via local MLX inference, configure
-        GOOGLE_GEMINI_BASE_URL to point at the Bifrost genai translator.
+        NOTE: Google-hosted model values execute in Google's cloud. To
+        route generation elsewhere, point GOOGLE_GEMINI_BASE_URL at a
+        Gemini-compatible endpoint (e.g. the homelab Bifrost gateway).
       '';
     };
 

--- a/modules/cecli/README.md
+++ b/modules/cecli/README.md
@@ -60,13 +60,12 @@ closes the next time we bump nixpkgs.
 
 ## Routing
 
-Defaults to local MLX via llama-swap (`http://127.0.0.1:11434/v1`),
+Routes to local MLX via llama-swap (`http://127.0.0.1:11434/v1`),
 no API keys required.
 
 ```nix
 programs.cecli = {
   enable = true;
-  routing = "llama-swap";   # default; alternative: "bifrost"
   model = "openai/default"; # capability-class alias from services.aiStack.models
 };
 ```

--- a/modules/cecli/default.nix
+++ b/modules/cecli/default.nix
@@ -7,10 +7,9 @@
 # point — while shipping bug fixes and new features.
 #
 # Routes through the local MLX stack (llama-swap at
-# http://127.0.0.1:11434/v1) by default so it works with open-source
-# models (Qwen3-Coder, Gemma, etc.) without cloud API keys. Cloud access
-# is opt-in via the `d-cecli` shell alias (Doppler-injected) or by
-# switching programs.cecli.routing to "bifrost".
+# http://127.0.0.1:11434/v1) so it works with open-source models
+# (Qwen3-Coder, Gemma, etc.) without cloud API keys. Cloud access is
+# opt-in via the `d-cecli` shell alias (Doppler-injected).
 #
 # Why a local Nix derivation (not nixpkgs / brew):
 #   - Not packaged in nixpkgs.

--- a/modules/cecli/options.nix
+++ b/modules/cecli/options.nix
@@ -24,21 +24,6 @@ in
   options.programs.cecli = {
     enable = lib.mkEnableOption "cecli (maintained Aider fork) AI pair programming CLI";
 
-    routing = lib.mkOption {
-      type = lib.types.enum [
-        "llama-swap"
-        "bifrost"
-      ];
-      default = "llama-swap";
-      description = ''
-        Inference routing target.
-        - llama-swap: Direct to http://127.0.0.1:11434/v1 (local MLX, default).
-          Model names are openai/<role>; llama-swap resolves via useModelName.
-        - bifrost: Through http://localhost:30080/v1 (multi-provider gateway).
-          Model names gain the mlx-local/ prefix for local MLX routing.
-      '';
-    };
-
     model = lib.mkOption {
       type = lib.types.str;
       default = "openai/default";

--- a/modules/cecli/settings.nix
+++ b/modules/cecli/settings.nix
@@ -22,24 +22,11 @@ let
   cfg = config.programs.cecli;
   homeDir = config.home.homeDirectory;
 
-  # Endpoint selection: llama-swap (default) or Bifrost
-  isBifrost = cfg.routing == "bifrost";
-  endpointBase = if isBifrost then "http://localhost:30080/v1" else "http://127.0.0.1:11434/v1";
+  endpointBase = "http://127.0.0.1:11434/v1";
 
-  # Model name resolution:
-  # llama-swap routing: keep openai/<role> - llama-swap resolves via useModelName.
-  # Bifrost routing: convert to openai/mlx-local/<physical-hf-id> - Bifrost
-  # requires the mlx-local/ prefix to route to the local MLX stack.
+  # Model names are openai/<role>; llama-swap resolves each role to the
+  # physical HF id via useModelName (see services.aiStack.models).
   inherit (config.services.aiStack) models;
-
-  prefixModel =
-    m:
-    let
-      n = lib.removePrefix "openai/" m;
-    in
-    if isBifrost then "openai/mlx-local/" + (models.${n} or n) else m;
-
-  prefixedWeakModel = prefixModel cfg.weakModel;
 
   yamlFormat = pkgs.formats.yaml { };
 
@@ -51,10 +38,10 @@ let
 
   configAttrs = {
     openai-api-base = endpointBase;
-    openai-api-key = "dummy"; # llama-swap/Bifrost authenticate upstream; local hop is open
-    model = prefixModel cfg.model;
-    weak-model = prefixedWeakModel;
-    editor-model = prefixModel cfg.editorModel;
+    openai-api-key = "dummy"; # llama-swap authenticates upstream; local hop is open
+    inherit (cfg) model;
+    weak-model = cfg.weakModel;
+    editor-model = cfg.editorModel;
     auto-commits = cfg.autoCommits;
     dirty-commits = cfg.dirtyCommits;
     attribute-author = cfg.attributeAuthor;
@@ -81,9 +68,7 @@ let
   yamlConf = yamlFormat.generate "cecli-conf.yml" configAttrs;
 
   # Model metadata — cecli uses LiteLLM. Unknown models fall back to GPT
-  # limits which may be wrong. Generate entries for both naming conventions:
-  #   - openai/<role>            used with llama-swap routing
-  #   - openai/mlx-local/<id>    used with Bifrost routing
+  # limits which may be wrong. Generate an entry per openai/<role> alias.
   metadataEntry = {
     max_input_tokens = 32768;
     max_output_tokens = 8192;
@@ -91,23 +76,11 @@ let
     output_cost_per_token = 0;
   };
 
-  roleAliasMetadata = lib.mapAttrs' (
-    role: _: lib.nameValuePair "openai/${role}" metadataEntry
-  ) models;
-
-  physicalIdMetadata = lib.mapAttrs' (
-    _: physicalId: lib.nameValuePair "openai/mlx-local/${physicalId}" metadataEntry
-  ) models;
-
-  modelMetadata = roleAliasMetadata // physicalIdMetadata;
+  modelMetadata = lib.mapAttrs' (role: _: lib.nameValuePair "openai/${role}" metadataEntry) models;
 
   metadataJson = pkgs.writeText "cecli-model-metadata.json" (builtins.toJSON modelMetadata);
 
-  # Per-model edit format and streaming overrides. Entries for:
-  #   - each role alias (llama-swap routing)
-  #   - each physical HF id with mlx-local/ prefix (Bifrost routing)
-  # A catch-all regex entry covers additional openai/mlx-local/* variants
-  # that might appear if the user extends services.aiStack.models later.
+  # Per-model edit format and streaming overrides — one entry per role alias.
   codeRoles = [
     "default"
     "coding"
@@ -124,23 +97,13 @@ let
     in
     {
       inherit name;
-      weak_model_name = prefixedWeakModel;
+      weak_model_name = cfg.weakModel;
       use_repo_map = true;
       streaming = cfg.stream;
     }
     // lib.optionalAttrs (selectedFormat != null) { edit_format = selectedFormat; };
 
-  roleAliasSettings = lib.mapAttrsToList (role: _: makeSettingsEntry "openai/${role}" role) models;
-
-  physicalIdSettings = lib.mapAttrsToList (
-    role: physicalId: makeSettingsEntry "openai/mlx-local/${physicalId}" role
-  ) models;
-
-  # Regex catch-all for any mlx-local/* model not explicitly listed above;
-  # "default" is a codeRole so this entry correctly inherits editFormat.
-  catchAllEntry = makeSettingsEntry "openai/mlx-local/.*" "default";
-
-  modelSettings = roleAliasSettings ++ physicalIdSettings ++ [ catchAllEntry ];
+  modelSettings = lib.mapAttrsToList (role: _: makeSettingsEntry "openai/${role}" role) models;
 
   modelSettingsYaml = yamlFormat.generate "cecli-model-settings.yml" modelSettings;
 

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -250,12 +250,4 @@ in
     type = "http";
     url = "http://localhost:30030/mcp";
   };
-
-  # ================================================================
-  # Bifrost AI Gateway - OrbStack kubernetes monitoring stack
-  # ================================================================
-  bifrost = {
-    type = "http";
-    url = "http://localhost:30080/mcp";
-  };
 }

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -168,7 +168,7 @@ let
   # using a capability-class alias (e.g. `model: "default"`) hit
   #   "The model `default` does not exist."
   # even though llama-swap routed the request correctly. With it, the alias
-  # works end-to-end through the local proxy without needing Bifrost in front.
+  # works end-to-end through the local proxy.
   # Default llama-swap filters applied to every model in the registry.
   # See modules/mlx/options-filters.nix for the schema and reasoning.
   # Filters run at the proxy layer BEFORE the request hits vllm-mlx, so they

--- a/modules/qwen-code/README.md
+++ b/modules/qwen-code/README.md
@@ -10,8 +10,8 @@ OpenAI/Anthropic/Gemini-compatible endpoint. Apache-2.0.
   PATH (only fires on darwin). The actual brew install lives in
   nix-darwin's `homebrew.brews`, sourced from nix-ai's
   `lib.brewFormulae` flake output.
-- A generated `~/.qwen/settings.json` wired to local llama-swap (or
-  Bifrost) with one provider entry per capability-class alias from
+- A generated `~/.qwen/settings.json` wired to local llama-swap with
+  one provider entry per capability-class alias from
   `services.aiStack.models`. Default startup model is the `coding`
   class.
 - Doppler-wrapped `d-qwen` shell alias (declared in
@@ -37,15 +37,12 @@ optional-dep resolution properly.
 
 ## Routing
 
-Defaults to local MLX via llama-swap (`http://127.0.0.1:11434/v1`).
-Switch to Bifrost (`http://localhost:30080/v1`) by setting
-`programs.qwen-code.routing = "bifrost"`.
+Routes to local MLX via llama-swap (`http://127.0.0.1:11434/v1`).
 
 ```nix
 programs.qwen-code = {
   enable = true;
-  routing = "llama-swap";  # default
-  model = "coding";        # capability-class alias
+  model = "coding";  # capability-class alias
 };
 ```
 

--- a/modules/qwen-code/options.nix
+++ b/modules/qwen-code/options.nix
@@ -23,19 +23,6 @@
       '';
     };
 
-    routing = lib.mkOption {
-      type = lib.types.enum [
-        "llama-swap"
-        "bifrost"
-      ];
-      default = "llama-swap";
-      description = ''
-        Inference routing target.
-        - llama-swap: Direct to http://127.0.0.1:11434/v1 (local MLX, default).
-        - bifrost: Through http://localhost:30080/v1 (multi-provider gateway).
-      '';
-    };
-
     model = lib.mkOption {
       type = lib.types.str;
       default = "coding";

--- a/modules/qwen-code/settings.nix
+++ b/modules/qwen-code/settings.nix
@@ -28,32 +28,18 @@ let
   cfg = config.programs.qwen-code;
   inherit (config.services.aiStack) models;
 
-  isBifrost = cfg.routing == "bifrost";
-  endpointBase = if isBifrost then "http://localhost:30080/v1" else "http://127.0.0.1:11434/v1";
-  providerKey = if isBifrost then "bifrost" else "mlx-local-llama-swap";
+  endpointBase = "http://127.0.0.1:11434/v1";
+  providerKey = "mlx-local-llama-swap";
 
-  # llama-swap routes capability-class aliases (default, coding, ...);
-  # Bifrost requires the mlx-local/ prefix on physical IDs. Generate the
-  # provider's model list to match the routing target. The qwen-code
-  # model schema only accepts `name` and `description` — routing is
-  # implicit in the provider's baseUrl, not a per-model field.
-  modelEntries =
-    if isBifrost then
-      lib.mapAttrsToList (role: physical: {
-        name = "mlx-local/${physical}";
-        description = "${role} → ${physical} via Bifrost";
-      }) models
-    else
-      lib.mapAttrsToList (role: physical: {
-        name = role;
-        description = "${role} → ${physical} via llama-swap";
-      }) models;
+  # llama-swap routes capability-class aliases (default, coding, ...). The
+  # qwen-code model schema only accepts `name` and `description` — routing
+  # is implicit in the provider's baseUrl, not a per-model field.
+  modelEntries = lib.mapAttrsToList (role: physical: {
+    name = role;
+    description = "${role} → ${physical} via llama-swap";
+  }) models;
 
-  defaultModelName =
-    let
-      r = cfg.model;
-    in
-    if isBifrost then "mlx-local/${models.${r} or r}" else r;
+  defaultModelName = cfg.model;
 
   baseSettings = {
     modelProviders = [
@@ -61,9 +47,9 @@ let
         name = providerKey;
         protocol = "openai";
         baseUrl = endpointBase;
-        # llama-swap and Bifrost authenticate upstream; the local hop is
-        # open. envKey points at a name that won't be set, so qwen-code
-        # falls through to the literal "dummy" in env below.
+        # llama-swap authenticates upstream; the local hop is open. envKey
+        # points at a name that won't be set, so qwen-code falls through
+        # to the literal "dummy" in env below.
         envKey = "QWEN_LOCAL_DUMMY_KEY";
         models = modelEntries;
       }

--- a/vars/ai-stack.nix
+++ b/vars/ai-stack.nix
@@ -53,13 +53,11 @@
   # migrated from hardcoded literals to registry reads.
   endpoints = {
     mlx_local = "http://localhost:11434";
-    bifrost_local = "http://localhost:30080";
   };
 
   # OrbStack NodePort allocations. Authoritative source for any consumer
   # that needs to know where a service listens.
   nodeports = {
-    bifrost = 30080;
     cribl_mcp = 30030;
     otel_grpc = 30317;
     otel_http = 30318;


### PR DESCRIPTION
## What

Removes every requirement to route through the **Bifrost** multi-provider gateway (OrbStack-k8s, `:30080`), which is being relocated to the Proxmox homelab. nix-ai clients call local MLX (llama-swap `:11434`) directly — as they already did by default.

## Changes

- **qwen-code / cecli**: drop the `routing` option and the `bifrost` branch; collapse settings generation to llama-swap only (removes the `mlx-local/` prefixing and the physical-id/catch-all metadata entries that existed solely for Bifrost).
- **mcp/catalog.nix**: remove the `bifrost` HTTP MCP server.
- **vars/ai-stack.nix**: drop `endpoints.bifrost_local` and `nodeports.bifrost` (localhost:30080 is wrong post-move; no consumers read them).
- **antigravity-cli / flake/lib.nix / mlx**: reword Bifrost-specific comments.
- **docs**: decision tree, architecture map, secrets, ADR 0003 + galileo runbook now describe direct local-MLX access and Bifrost as a homelab gateway (`bifrost.pve.jacobpevans.com`), not a local `:30080` front door.

## Not breaking

No downstream consumer (nix-darwin host configs) sets `programs.{qwen-code,cecli}.routing`, so removing the option does not break evaluation.

## Verification

- `nix flake check` + `nix fmt`: pass. All x86_64-linux regression-check derivations evaluate clean; no snapshot references the removed refs.
- `darwin-rebuild switch --override-input nix-ai <worktree>`: succeeds. Live `~/.qwen/settings.json` and `~/.cecli.conf.yml` now point at `http://127.0.0.1:11434/v1`. `lib.ci.claudeSettingsJson` and the MCP catalog no longer emit `bifrost` (the residual entry in the running session's `~/.claude.json` is live app state that clears on a fresh session).

Part of the Bifrost decouple + relocate effort (sibling PRs: ai-assistant-instructions, claude-code-plugins). k8s teardown + Proxmox redeploy are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)