### PR TITLE
fix(plugins): correct plugin-load docs; pin bump to follow upstream fix

### DIFF
--- a/.claude/rules/plugin-cache-architecture.md
+++ b/.claude/rules/plugin-cache-architecture.md
@@ -75,5 +75,16 @@ Additionally, Claude Code discovers marketplaces via `~/.claude/plugins/known_ma
 (its actual registry), NOT directly from `extraKnownMarketplaces` in `settings.json`. Entries
 propagate from `extraKnownMarketplaces` only when Claude Code can successfully fetch the
 marketplace from the declared GitHub source. Synthetic marketplaces fail this fetch (no upstream
-structure), so the `knownMarketplacesMerge` activation in `modules/default.nix` ensures the
-local `installLocation` is registered directly.
+structure), so the `knownMarketplacesMerge` activation ensures the local `installLocation` is
+registered directly. That activation lives in the `nix-claude-code` flake input
+(`modules/settings.nix`), not in this repo — nix-ai only supplies the marketplace catalog and
+`enabled` set; `nix-claude-code` owns the activation that renders and merges them.
+
+## Runtime Registry Reconciliation
+
+`installed_plugins.json` is a separate Claude-owned runtime registry recording each plugin's
+version and `installPath`. When a marketplace's Nix store path changes, `verify-cache-integrity`
+purges the stale cache dir, which orphans those `installPath`s; the `marketplace-refresh`
+sessionStart hook then has Claude natively reinstall the affected enabled plugins so the registry
+is re-pointed. Both live in `nix-claude-code`. Never edit `installed_plugins.json` from an
+activation script while Claude may be running.

--- a/docs/architecture/config-lifecycle.md
+++ b/docs/architecture/config-lifecycle.md
@@ -66,7 +66,7 @@ All `home.activation` entries and their targets:
 | Activation Name | Source File | Target File | What It Does |
 |----------------|-------------|-------------|-------------|
 | Claude settings merge | `nix-claude-code` flake input (wired via `modules/claude-config.nix`) | `~/.claude.json`, `~/.claude/settings.json` | MCP servers, project trust, permissions, plugins, hooks, model, sandbox |
-| `knownMarketplacesMerge` | `modules/default.nix` | `~/.claude/plugins/known_marketplaces.json` | Synthetic marketplace registry |
+| `knownMarketplacesMerge` | `nix-claude-code` flake input (`modules/settings.nix`) | `~/.claude/plugins/known_marketplaces.json` | Synthetic marketplace registry (installLocation + source) |
 | `mergeAntigravitySettings` | `modules/antigravity-cli/settings.nix` | `~/.gemini/antigravity-cli/settings.json` | MCP servers, policies, folder trust |
 | `codexConfigMerge` | `modules/codex/settings.nix` | `~/.codex/config.toml` | Model, MCP servers, approval policy |
 | `seedLlamaSwapConfig` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Copies Nix-generated seed; preserves runtime models |

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -130,7 +130,7 @@ in
         '';
 
         # browser-use: CLI for browser automation (not in nixpkgs)
-        installBrowserUse = lib.hm.dag.entryAfter [ "writeBoundary" "knownMarketplacesMerge" ] ''
+        installBrowserUse = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           if ! ${lib.getExe pkgs.uv} tool list 2>/dev/null | grep -q "^browser-use"; then
             echo "-> Installing browser-use via uv..."
             $DRY_RUN_CMD ${lib.getExe pkgs.uv} tool install "browser-use==${browserUseVersion}"


### PR DESCRIPTION
Part of resolving "plugins (e.g. `/ship`) not auto-loaded on Claude startup; `/reload-plugins` fixes them but they vanish again."

## Root cause (recap)

`installed_plugins.json` (Claude's runtime registry) drifts from the Nix-declared plugin versions and nothing reconciles it — **55 of 104 enabled plugins** pointed at cache paths that no longer existed, so Claude skipped them at startup. The durable fix lives upstream in `nix-claude-code`:

- **dryvist/nix-claude-code#71** — completes the `marketplace-refresh` sessionStart hook to natively `claude plugin install` the enabled+broken plugins after a store-path change (no new script; native commands in the hook already built for post-rebuild resync).
- **dryvist/nix-claude-code#72** — adds Renovate + refreshes the 6-week-stale `jacobpevans-cc-plugins` input (also fixes the stale skill content served to Codex/Antigravity via the shared `~/.agents/skills` tree).

## This PR (nix-ai)

Docs-only, and corrects a false trail the investigation hit:

- `knownMarketplacesMerge` is attributed to `modules/default.nix` in two docs — it actually lives in the `nix-claude-code` flake input (`modules/settings.nix`). Fixed in `plugin-cache-architecture.md` + `config-lifecycle.md`, plus a note that `installed_plugins.json` is reconciled by the refresh hook.
- Dropped the misleading `"knownMarketplacesMerge"` token from `installBrowserUse`'s `entryAfter` in `modules/default.nix` (browser-use's uv install has no marketplace dependency; the stale coupling made the ref look dangling).

## Follow-up (after upstream merges)

A `chore(deps): bump nix-claude-code` commit will be added here once #71 + #72 merge — that pin bump is what delivers the runtime fix + fresh plugins to the machine. Then: `darwin-rebuild switch`, quit all Claude sessions, rebuild once more (reconciliation defers while Claude runs), and confirm `/ship` loads on a fresh session without `/reload-plugins`.

## Verification

`nix fmt` + `nix flake check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)