### PR TITLE
chore(deps): bump nix-claude-code — deliver plugin auto-load fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -420,11 +420,11 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1779660353,
-        "narHash": "sha256-Wst459BiRSLXaE2PtSpQk1wYMev0uhDlOTmW5ks7ZEo=",
+        "lastModified": 1783096239,
+        "narHash": "sha256-9fK/q7nQRyRxu3GOf+JzhrdwNZ00lcs7YnBUIIZafFE=",
         "owner": "JacobPEvans",
         "repo": "claude-code-plugins",
-        "rev": "36a6a281d5d4d1120c857e212eca6d061ca1c6bc",
+        "rev": "281ab4d7f780e39f53ca2a77b7858f593e6a941e",
         "type": "github"
       },
       "original": {
@@ -538,11 +538,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783047488,
-        "narHash": "sha256-Sj3ad3iiT3M7CrIU1pK5iW4SxFfK0qAUPhUc4MhBLu0=",
+        "lastModified": 1783102056,
+        "narHash": "sha256-1/uX1H4IJPCuZC6ZzgneQVNIoGXbMxNiSRt8pT8n4e0=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "103a191a8937a9476786cd9ec69dcec0f2d6b746",
+        "rev": "27761373c70d735a8c7397cbf1045ef212c1df51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow-up to #1106 (docs) — this is the pin bump that actually delivers the fix to the machine.

- **nix-claude-code** `103a191` → `2776137` (0.4.1): the `marketplace-refresh` hook now natively `claude plugin install`s enabled plugins whose `installPath` was orphaned by the cache purge, so plugins (`/ship` et al.) auto-load on startup instead of needing `/reload-plugins`.
- **jacobpevans-cc-plugins** (transitive) `36a6a28` (2026-05-24) → `281ab4d` (2026-07-03): refreshes plugin/skill content served to Claude, Codex, and Antigravity.

`nix flake check` green.

## After merge (runtime rollout)

`darwin-rebuild switch` → **quit all Claude sessions** → rebuild once more (the reconcile defers while Claude runs) → fresh session should load all previously-broken plugins with no `/reload-plugins`. That rebuild + `nix store gc` also clears the orphaned `~/.agents/skills/self-hosted-runners` symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)