### PR TITLE
fix(agent-skills): prune orphaned skill symlinks on activation

### DIFF
--- a/modules/agent-skills/components.nix
+++ b/modules/agent-skills/components.nix
@@ -50,6 +50,14 @@ in
             fi
           done
 
+          # Prune per-skill symlinks whose store target no longer exists. A skill
+          # removed from the flake input set between generations leaves a dangling
+          # link here: it is a symlink (not a -type d), so the legacy sweep above
+          # skips it, and home-manager's generation diff does not remove it either.
+          find "$root" -mindepth 1 -maxdepth 1 -type l -print0 | while IFS= read -r -d $'\0' link; do
+            [ -e "$link" ] || $DRY_RUN_CMD rm -f "$link"
+          done
+
           $DRY_RUN_CMD rmdir "$root" 2>/dev/null || true
         }
 


### PR DESCRIPTION
## Problem

When a skill is removed from the flake input set between generations (e.g. `self-hosted-runners`, deleted upstream between plugin revs `36a6a28`→`281ab4d`), its per-skill symlink under `~/.agents/skills/<name>` is left **dangling**:

- It is a symlink, **not** a `-type d`, so `cleanup_skill_tree`'s legacy directory sweep skips it entirely.
- home-manager's generation diff does not remove it either.

The stale link then leaks a broken skill into **every** consumer tree — Codex, both Antigravity variants, and Gemini all symlink into `~/.agents/skills`. A `darwin-rebuild switch` + `nix store gc` does **not** clear it (confirmed live).

## Fix

Extend `cleanup_skill_tree` (the existing `cleanupLegacySkillCopies` activation) to prune per-skill symlinks whose store target no longer exists. Additive ~4 lines to the existing inline activation — no new script.

## Validation

- Unit-tested the prune loop: removes dangling links, preserves valid ones.
- `nix flake check` green; `nix fmt` clean.
- Full `darwin-rebuild switch --override-input nix-ai <worktree>`: **0 broken links across all 5 consumer trees, all 157 valid links preserved**, all pointing at the current generation.

Closes the orphan-symlink gap called out in the plugin-auto-load investigation (the contingency the plan pre-authorized: "if it recurs, extend that activation to prune broken `~/.agents/skills/*` symlinks too").

🤖 Generated with [Claude Code](https://claude.com/claude-code)