### PR TITLE
fix(mlx): pin transformers 5.12.0 — 5.13.0 breaks mlx-lm import, fleet-wide outage

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -81,6 +81,14 @@
   mlx = "0.31.2";
   # renovate: datasource=pypi depName=mlx-lm
   mlxLm = "0.31.3";
+  # transformers 5.13.0 (released 2026-07-04) broke mlx-lm 0.31.3's import:
+  # AutoTokenizer.register("NewlineTokenizer", ...) passes a string key and
+  # 5.13.0's register() calls key.__module__ on it -> AttributeError at
+  # module import, killing every vllm-mlx worker on both hosts (fleet-wide
+  # serving outage, 2026-07-04). Pin until mlx-lm registers a class (or
+  # transformers restores string keys); bump together with mlxLm.
+  # renovate: datasource=pypi depName=transformers
+  transformers = "5.12.0";
   # renovate: datasource=pypi depName=lm-eval
   lmEval = "0.4.11";
 

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -34,10 +34,13 @@ let
   # ("There is no Stream(gpu, N) in current thread", nix-ai#751); vllm-mlx
   # 0.4.0 is built against mlx 0.31.2 / mlx-lm 0.31.3 and the crash no longer
   # reproduces under concurrent continuous batching (validated 2026-07-02).
+  # transformers is pinned too: 5.13.0 broke mlx-lm's import at tokenizer
+  # registration (see lib/versions.nix for the incident note).
   mlxPin = "mlx==${versions.mlx}";
   mlxLmPin = "mlx-lm==${versions.mlxLm}";
+  transformersPin = "transformers==${versions.transformers}";
   vllmMlxPkg = pkgs.writeShellScriptBin "vllm-mlx" ''
-    exec ${pkgs.uv}/bin/uvx --from "vllm-mlx==${vllmMlxVersion}" --with "${mlxPin}" --with "${mlxLmPin}" vllm-mlx "$@"
+    exec ${pkgs.uv}/bin/uvx --from "vllm-mlx==${vllmMlxVersion}" --with "${mlxPin}" --with "${mlxLmPin}" --with "${transformersPin}" vllm-mlx "$@"
   '';
 
   # llama-swap proxy package — sits on the API port, manages vllm-mlx child processes.

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -132,9 +132,11 @@ in
           exec ${pkgs.uv}/bin/uvx --from "${vllmMlxPin}" vllm-mlx bench "$@"
         '')
 
-        # mlx-bench-raw — raw MLX prefill + decode (no vllm-mlx overhead)
+        # mlx-bench-raw — raw MLX prefill + decode (no vllm-mlx overhead).
+        # transformers pinned for the same mlx-lm import break as the server
+        # wrapper (lib/versions.nix incident note).
         (pkgs.writeShellScriptBin "mlx-bench-raw" ''
-          exec ${pkgs.uv}/bin/uvx --from "mlx-lm==${mlxLmVersion}" mlx_lm.benchmark "$@"
+          exec ${pkgs.uv}/bin/uvx --from "mlx-lm==${mlxLmVersion}" --with "transformers==${versions.transformers}" mlx_lm.benchmark "$@"
         '')
 
         # mlx-eval — accuracy evaluation against the live vllm-mlx server API


### PR DESCRIPTION
## Summary

**Fleet-wide serving outage (2026-07-04):** transformers 5.13.0 (released today) changed `AutoTokenizer.register()` to call `key.__module__` on its config-class argument. mlx-lm 0.31.3 registers `"NewlineTokenizer"` as a **string**, so `import mlx_lm` raises AttributeError before the server can bind — every vllm-mlx worker on both hosts crash-loops (`upstream command exited prematurely` from llama-swap). transformers was the one unpinned package in the wrapper, so uv re-resolved it under our feet.

- Pin `transformers==5.12.0` in the vllm-mlx server wrapper and `mlx-bench-raw`
- Version recorded in `lib/versions.nix` with a Renovate annotation and incident note; bump together with mlxLm

## Verification

- Reproduced both ways: `import mlx_lm` fails under 5.13.0, clean under 5.12.0
- The exact pinned wrapper command (`uvx --from vllm-mlx==0.4.0 --with mlx==0.31.2 --with mlx-lm==0.31.3 --with transformers==5.12.0 vllm-mlx --help`) resolves and runs
- nix-darwin `darwinConfigurations."jevans-ms"` evals with this branch via `--override-input`

## Rollout

After merge: bump the nix-ai input in dryvist/nix-darwin (deps-update-flake target=jacobpevans) and rebuild both hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyEckmJJqp3ZDxcchRfuYT