### PR TITLE
chore(deps): bump nix-claude-code for marketplace symlink churn fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,11 +538,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783128702,
-        "narHash": "sha256-MaJ5aawGPLRKp/OSgrwmgYg+4fnKxH4irM0uf7dS+Gk=",
+        "lastModified": 1783187475,
+        "narHash": "sha256-Sbmy+fUtUHNiN6MaDK9arKYr5S7Qs2SIesRtKt748kM=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "15e22a72513f9075c1f112927e94368ee2ed9e24",
+        "rev": "c995e68cd1ac294d5f0ce85b39059f5af001b1a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What
`nix flake update nix-claude-code` — bumps the transitive nix-claude-code input from `15e22a7` → `c995e68` (nix-cc main HEAD).

## Why
nix-cc `15e22a7` predates **dryvist/nix-claude-code#78** (stop churning HM-managed marketplace symlinks on every activation). That fix removes the ~26 `[INFO] Removed conflicting directory symlink` churn lines and the `[WARN] Skipping rm -rf` ×3 that appear on every `darwin-rebuild` in consumers (nix-darwin).

This is hop 1 of 2 to propagate the fix: nix-ai bumps nix-cc here → nix-darwin then bumps nix-ai. Flake inputs are branch-tracked, so this needs no release tag or dispatch.

## Test
`flake.lock`-only change; CI flake check validates.