### PR TITLE
feat: warm MLX preload models and split swap tier

### DIFF
--- a/docs/architecture/config-lifecycle.md
+++ b/docs/architecture/config-lifecycle.md
@@ -45,6 +45,8 @@ copy only — the Nix-generated seed stays fixed until the next rebuild.
 they _can_ query live APIs, `llama-swap.json` specifically uses a **seed-and-extend** pattern:
 the activation script copies a Nix-generated seed, and the runtime `mlx-discover` tool handles
 dynamic local-model discovery — so model IDs never have to be baked into the Nix expression.
+The separate `mlx-warmup` LaunchAgent runs after the proxy is ready and faults the
+resident preload list into memory with 1-token requests.
 
 The dominant pattern is **deep-merge**: the activation script overlays Nix-managed keys
 onto the existing mutable file, preserving any keys Nix does not manage (auth tokens,
@@ -70,7 +72,7 @@ All `home.activation` entries and their targets:
 | `mergeAntigravitySettings` | `modules/antigravity-cli/settings.nix` | `~/.gemini/antigravity-cli/settings.json` | MCP servers, policies, folder trust |
 | `codexConfigMerge` | `modules/codex/settings.nix` | `~/.codex/config.toml` | Model, MCP servers, approval policy |
 | `seedLlamaSwapConfig` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Copies Nix-generated seed; preserves runtime models |
-| `discoverMlxModels` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Extends the seed with locally available MLX models |
+| `discoverMlxModels` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Extends the seed with locally available MLX models (swap tier when configured) |
 
 ## Config File Patterns
 
@@ -103,6 +105,7 @@ These tools refresh specific files between rebuilds:
 | Command | Refreshes | Trigger |
 |---------|-----------|---------|
 | `mlx-discover` | `~/.config/mlx/llama-swap.json` | After downloading a new model to `/Volumes/HuggingFace` |
+| `mlx-warmup` | resident model pages | After startup or when manually faulting the preload list |
 | `mlx-switch <model>` | triggers `mlx-discover` if needed | Hot-swap active MLX model without restart |
 
 ## Diagram: Full File Ownership Map

--- a/docs/architecture/mlx-stack.md
+++ b/docs/architecture/mlx-stack.md
@@ -75,12 +75,18 @@ format errors despite correct reasoning. To use non-Qwen models for tool calling
 the worker's `autoUnloadIdleSeconds` failsafe fires at 30 min). The next request pays a
 full reload — seconds for a small MoE, ~60-120s for a 120B model.
 
-**Multi-resident serving**: the defaults keep one model resident (`proxy.groupSwap = true`
-evicts on switch). Server-class hosts with the wired-memory headroom keep several models
-warm by setting `groupSwap = false`, listing each role in `preload`, and disabling
-eviction (`proxy.idleTtl = 0`, `autoUnloadIdleSeconds = 0`); per-model serve flags that
-must differ from the globals ride `modelExtraArgs` (append-only) or `modelFlagOverrides`
-(replaces a global option value, e.g. turning `pagedKvCache` off for one model).
+**Resident vs swap tiers**: the resident registry comes from `services.aiStack.models`
+and the `preload` list. Server-class hosts keep several resident models warm by setting
+`groupSwap = false`, listing each resident role in `preload`, and disabling eviction
+for that tier (`proxy.idleTtl = 0`, `autoUnloadIdleSeconds = 0`). The separate
+`programs.mlx.models` map is the non-resident swap tier: those models are not
+preloaded, can carry their own TTLs and per-model flags, and are loaded only when
+requested. Runtime-discovered HF models are appended to the swap tier when that group
+exists. A small `mlx-warmup` LaunchAgent faults the resident preload list at boot with
+1-token requests so the first user request does not pay the cold-start page-in cost.
+Per-model serve flags that must differ from the globals ride `modelExtraArgs`
+(append-only) or `modelFlagOverrides` (replaces a global option value, e.g. turning
+`pagedKvCache` off for one model).
 
 **MoE vs dense throughput** (M4 Max, 128GB): 122B MoE models achieve ~24 tok/s; dense models
 of similar parameter count (~123B) top out at ~6.6 tok/s. Prefer MoE for throughput-sensitive

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -42,6 +42,9 @@ let
   vllmMlxPkg = pkgs.writeShellScriptBin "vllm-mlx" ''
     exec ${pkgs.uv}/bin/uvx --from "vllm-mlx==${vllmMlxVersion}" --with "${mlxPin}" --with "${mlxLmPin}" --with "${transformersPin}" vllm-mlx "$@"
   '';
+  mlxWarmupPkg = pkgs.writeShellScriptBin "mlx-warmup" ''
+    exec ${pkgs.python3}/bin/python3 ${./scripts/mlx-warmup.py} "$@"
+  '';
 
   # llama-swap proxy package — sits on the API port, manages vllm-mlx child processes.
   # Sourced from nixpkgs-unstable: 25.11-darwin froze it at v165 on 2025-09-22
@@ -199,12 +202,9 @@ let
   ) rolesByPhysical;
 
   # Additional ad-hoc models from cfg.models (existing extension point).
-  # Per-model filters merge on top of the global default so an individual
-  # model can tighten one key without dropping siblings — e.g. setting
-  # cfg.models.foo.filters.setParams.top_p preserves the global
-  # frequency_penalty / presence_penalty defaults. Uses lib.recursiveUpdate
-  # so nested attrsets (setParams, future filter groups) merge key-by-key
-  # rather than wholesale-replacing each other.
+  # These form the non-resident swap tier. They can be loaded on demand
+  # without evicting the resident registry models, and they can carry their
+  # own TTLs/aliases/filters.
   additionalModels = lib.mapAttrs (
     name: modelCfg:
     let
@@ -229,7 +229,9 @@ let
     }
   ) cfg.models;
 
-  allModels = registryModels // additionalModels;
+  residentModels = registryModels;
+  swapModels = additionalModels;
+  allModels = residentModels // swapModels;
 
   llamaSwapConfigAttrs = {
     inherit (cfg.proxy) healthCheckTimeout logLevel logToStdout;
@@ -244,8 +246,19 @@ let
     groups.mlx-models = {
       swap = cfg.proxy.groupSwap;
       exclusive = true;
-      members = builtins.attrNames allModels;
+      persistent = true;
+      members = builtins.attrNames residentModels;
     };
+  }
+  // lib.optionalAttrs (swapModels != { }) {
+    groups.mlx-swap-models = {
+      swap = true;
+      exclusive = false;
+      persistent = false;
+      members = builtins.attrNames swapModels;
+    };
+  }
+  // {
 
     # Preload by role, not physical name. llama-swap resolves "default"
     # via the alias table on the registryModels entry.
@@ -275,6 +288,7 @@ in
     inherit
       cfg
       vllmMlxPkg
+      mlxWarmupPkg
       vllmMlxVersion
       parakeetMlxVersion
       mlxVlmVersion

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -9,18 +9,8 @@ let
   cfg = config.programs.mlx;
   versions = import ../../lib/versions.nix;
 
-  # Version history for vllm-mlx (canonical pin in lib/versions.nix):
-  #   - 0.2.6: stable baseline.
-  #   - 0.2.7: regressed vllm_mlx/utils/tokenizer.py::load_model_with_fallback
-  #     (the success path forgot to return, yielding None implicitly).
-  #   - 0.2.8: fixed that regression but mis-detected Qwen3.5 as MLLM and its
-  #     MLLM continuous-batching path failed parallel text requests.
-  #   - 0.2.9: ships Paged KV Cache + prefix sharing + continuous batching
-  #     (MLLM-detection bug fixed). Loads gemma-4-e4b architectures.
-  #   - 0.3.0: stable baseline after the 0.2.x line.
-  #   - 0.4.0: GPT-OSS/harmony prompt rendering for tool calls (required to
-  #     serve gpt-oss models with working tool calling); parser roster grows
-  #     to 17 tool + 7 reasoning parsers; requires mlx-lm>=0.31.3.
+  # vllm-mlx version history and compatibility notes live in lib/versions.nix.
+  # This module only keeps the pinning and scheduler-specific glue.
   vllmMlxVersion = versions.vllmMlx;
   parakeetMlxVersion = versions.parakeetMlx;
   mlxVlmVersion = versions.mlxVlm;
@@ -30,12 +20,8 @@ let
   # derivation lives here. Also added to home.packages for CLI access.
   #
   # mlx + mlx-lm are pinned together as a lockstep pair (see lib/versions.nix).
-  # History: mlx 0.31.2 originally broke vllm-mlx 0.2.9's scheduler thread
-  # ("There is no Stream(gpu, N) in current thread", nix-ai#751); vllm-mlx
-  # 0.4.0 is built against mlx 0.31.2 / mlx-lm 0.31.3 and the crash no longer
-  # reproduces under concurrent continuous batching (validated 2026-07-02).
-  # transformers is pinned too: 5.13.0 broke mlx-lm's import at tokenizer
-  # registration (see lib/versions.nix for the incident note).
+  # Pin mlx and transformers together with vllm-mlx; see lib/versions.nix for
+  # the compatibility history behind these versions.
   mlxPin = "mlx==${versions.mlx}";
   mlxLmPin = "mlx-lm==${versions.mlxLm}";
   transformersPin = "transformers==${versions.transformers}";

--- a/modules/mlx/discover-models.py
+++ b/modules/mlx/discover-models.py
@@ -231,13 +231,11 @@ def main() -> None:
         sys.exit(0)
 
     current_config.setdefault("models", {}).update(new_models)
-    existing_members = (
-        current_config.get("groups", {}).get("mlx-models", {}).get("members", [])
-    )
+    groups = current_config.setdefault("groups", {})
+    group_name = "mlx-swap-models" if "mlx-swap-models" in groups else "mlx-models"
+    existing_members = groups.get(group_name, {}).get("members", [])
     merged_members = sorted(set(existing_members + new_members))
-    current_config.setdefault("groups", {}).setdefault("mlx-models", {})[
-        "members"
-    ] = merged_members
+    groups.setdefault(group_name, {})["members"] = merged_members
 
     # Write atomically
     config_dir = config_path.parent

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -82,7 +82,7 @@ in
       # One-shot warmup job: wait for the proxy to answer, then fault each
       # preloaded model with a 1-token chat completion so the weights are
       # resident at boot instead of on first user request.
-      user.agents.vllm-mlx-warmup = {
+      agents.vllm-mlx-warmup = {
         enable = true;
         config = {
           Label = "dev.vllm-mlx.warmup";

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -15,6 +15,8 @@ let
   inherit (mlxShared)
     cfg
     launchAgentLabel
+    apiUrl
+    mlxWarmupPkg
     llamaSwapPkg
     llamaSwapConfigFile
     llamaSwapRuntimeConfigPath
@@ -22,57 +24,83 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
-    # ==========================================================================
-    # LaunchAgent for Auto-Start
-    # ==========================================================================
-    # llama-swap proxy listens on the API port and manages vllm-mlx child
-    # processes on ephemeral ports (startPort = 11436+). HardResourceLimits
-    # is omitted — it would only cap the proxy process, not the vllm-mlx
-    # children where the actual memory lives (and macOS does not reliably
-    # enforce RSS rlimits). Per-worker OOM protection is native and inside
-    # each worker: --gpu-memory-utilization (Metal allocation ceiling +
-    # emergency cache clear; programs.mlx.gpuMemoryUtilization) plus
-    # --cache-memory-mb and --auto-unload-idle-seconds (set in the generated
-    # config). programs.mlx.memoryHardLimitGb remains declarative intent only.
-    launchd.agents.vllm-mlx = {
-      enable = true;
-      config = {
-        Label = launchAgentLabel;
-        ProgramArguments = [
-          (lib.getExe llamaSwapPkg)
-          "--config"
-          llamaSwapRuntimeConfigPath
-          "--watch-config"
-          "--listen"
-          "${cfg.host}:${toString cfg.port}"
-        ];
-        RunAtLoad = true;
-        KeepAlive = true;
-        # 2 min throttle — 70GB model loads take 20-60s, prevents rapid crash-restart loops (closes #256)
-        ThrottleInterval = 120;
-        # Interactive by default — Background QoS clamps Metal decode ~8x
-        # (see options-runtime.nix processType). OOM backstop is the RSS
-        # hard limit, not Jetsam eligibility.
-        ProcessType = cfg.processType;
-        # Do not abandon the process group; ensure child vllm-mlx processes
-        # are terminated when launchd stops the proxy.
-        AbandonProcessGroup = false;
-        EnvironmentVariables = {
-          HF_HOME = cfg.huggingFaceHome;
-        }
-        // lib.optionalAttrs cfg.telemetry.enable {
-          # Standard OTel env vars inherited by llama-swap and its vllm-mlx children.
-          # The OTEL Collector at :30317 fans out to Cribl/Splunk and (optionally)
-          # to Galileo — see docs/adr/0003-galileo-ai-observability.md.
-          # Trace emission from vllm-mlx 0.2.9 is best-effort; the collector's
-          # routing connector is the primary gate, not the agent env.
-          OTEL_SERVICE_NAME = "vllm-mlx";
-          OTEL_EXPORTER_OTLP_ENDPOINT = cfg.telemetry.otlpEndpoint;
-          OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
-          OTEL_RESOURCE_ATTRIBUTES = "service.namespace=mlx,deployment.environment=homelab";
+    launchd = {
+      # ==========================================================================
+      # LaunchAgent for Auto-Start
+      # ==========================================================================
+      # llama-swap proxy listens on the API port and manages vllm-mlx child
+      # processes on ephemeral ports (startPort = 11436+). HardResourceLimits
+      # is omitted — it would only cap the proxy process, not the vllm-mlx
+      # children where the actual memory lives (and macOS does not reliably
+      # enforce RSS rlimits). Per-worker OOM protection is native and inside
+      # each worker: --gpu-memory-utilization (Metal allocation ceiling +
+      # emergency cache clear; programs.mlx.gpuMemoryUtilization) plus
+      # --cache-memory-mb and --auto-unload-idle-seconds (set in the generated
+      # config). programs.mlx.memoryHardLimitGb remains declarative intent only.
+      agents.vllm-mlx = {
+        enable = true;
+        config = {
+          Label = launchAgentLabel;
+          ProgramArguments = [
+            (lib.getExe llamaSwapPkg)
+            "--config"
+            llamaSwapRuntimeConfigPath
+            "--watch-config"
+            "--listen"
+            "${cfg.host}:${toString cfg.port}"
+          ];
+          RunAtLoad = true;
+          KeepAlive = true;
+          # 2 min throttle — 70GB model loads take 20-60s, prevents rapid crash-restart loops (closes #256)
+          ThrottleInterval = 120;
+          # Interactive by default — Background QoS clamps Metal decode ~8x
+          # (see options-runtime.nix processType). OOM backstop is the RSS
+          # hard limit, not Jetsam eligibility.
+          ProcessType = cfg.processType;
+          # Do not abandon the process group; ensure child vllm-mlx processes
+          # are terminated when launchd stops the proxy.
+          AbandonProcessGroup = false;
+          EnvironmentVariables = {
+            HF_HOME = cfg.huggingFaceHome;
+          }
+          // lib.optionalAttrs cfg.telemetry.enable {
+            # Standard OTel env vars inherited by llama-swap and its vllm-mlx children.
+            # The OTEL Collector at :30317 fans out to Cribl/Splunk and (optionally)
+            # to Galileo — see docs/adr/0003-galileo-ai-observability.md.
+            # Trace emission from vllm-mlx 0.2.9 is best-effort; the collector's
+            # routing connector is the primary gate, not the agent env.
+            OTEL_SERVICE_NAME = "vllm-mlx";
+            OTEL_EXPORTER_OTLP_ENDPOINT = cfg.telemetry.otlpEndpoint;
+            OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
+            OTEL_RESOURCE_ATTRIBUTES = "service.namespace=mlx,deployment.environment=homelab";
+          };
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log";
         };
-        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log";
-        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log";
+      };
+
+      # One-shot warmup job: wait for the proxy to answer, then fault each
+      # preloaded model with a 1-token chat completion so the weights are
+      # resident at boot instead of on first user request.
+      user.agents.vllm-mlx-warmup = {
+        enable = true;
+        config = {
+          Label = "dev.vllm-mlx.warmup";
+          ProgramArguments = [ (lib.getExe mlxWarmupPkg) ];
+          RunAtLoad = true;
+          KeepAlive = {
+            SuccessfulExit = false;
+          };
+          ThrottleInterval = 120;
+          ProcessType = "Background";
+          EnvironmentVariables = {
+            MLX_API_URL = apiUrl;
+            MLX_PRELOAD_MODELS = lib.concatStringsSep " " cfg.preload;
+            MLX_PRELOAD_MODELS_JSON = builtins.toJSON cfg.preload;
+          };
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.error.log";
+        };
       };
     };
 
@@ -87,6 +115,8 @@ in
         # logfilename                                                                [owner:group]  mode  count  size  when  flags
         ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log        :              644   3      10240 *     J
         ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log              :              644   3      10240 *     J
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.error.log :              644   3      10240 *     J
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.log       :              644   3      10240 *     J
       '';
 
       # ==========================================================================

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -90,7 +90,7 @@
         }
       );
       default = { };
-      description = "Additional models available for on-demand switching via llama-swap proxy. All models (including the default-aliased one) share the uniform proxy.idleTtl unless overridden per-model.";
+      description = "Additional non-resident models available for on-demand switching via llama-swap proxy. These form the swap tier; they are loaded only when requested and can carry their own TTLs, aliases, filters, and serve-flag overrides.";
     };
 
     # modelExtraArgs — extra vllm-mlx serve args for REGISTRY models, keyed by
@@ -149,7 +149,7 @@
     preload = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ "default" ];
-      description = "Models (role aliases or physical ids) llama-swap preloads at startup. Every entry occupies memory concurrently until its idle TTL — size the list against the host's wired-memory budget.";
+      description = "Resident models (role aliases or physical ids) llama-swap preloads at startup. Every entry occupies memory concurrently until its idle TTL — size the list against the host's wired-memory budget. Swap-tier models belong in programs.mlx.models instead.";
     };
 
     proxy = {

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -20,6 +20,7 @@ let
   inherit (mlxShared)
     cfg
     vllmMlxPkg
+    mlxWarmupPkg
     vllmMlxVersion
     parakeetMlxVersion
     mlxVlmVersion
@@ -43,6 +44,8 @@ in
       sessionVariables = {
         MLX_API_URL = apiUrl;
         MLX_DEFAULT_MODEL = cfg.defaultModel;
+        MLX_PRELOAD_MODELS = lib.concatStringsSep " " cfg.preload;
+        MLX_PRELOAD_MODELS_JSON = builtins.toJSON cfg.preload;
         MLX_PORT = toString cfg.port;
         MLX_HOST = cfg.host;
         MLX_HF_HOME = cfg.huggingFaceHome;
@@ -84,6 +87,9 @@ in
           runtimeInputs = [ ];
           text = builtins.readFile ./scripts/mlx-default.sh;
         })
+
+        # mlx-warmup — fault the declared preload list into resident memory
+        mlxWarmupPkg
 
         # llama-swap — proxy binary on PATH for direct invocation and mlx-default
         llamaSwapPkg

--- a/modules/mlx/scripts/mlx-warmup.py
+++ b/modules/mlx/scripts/mlx-warmup.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = []
+# ///
+"""Warm the declared MLX preload list after the proxy comes up.
+
+The LaunchAgent waits for the loopback API to answer, then sends a 1-token
+chat completion to each preloaded model. That forces the weights to fault in
+at boot instead of on the first user request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+TRANSIENT_HTTP_CODES = {408, 429, 500, 502, 503, 504}
+
+
+def parse_models() -> list[str]:
+    """Load the preload list from env, preserving the Nix order."""
+    raw_json = os.environ.get("MLX_PRELOAD_MODELS_JSON")
+    if raw_json:
+        try:
+            models = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(
+                f"ERROR: MLX_PRELOAD_MODELS_JSON is not valid JSON: {exc}"
+            ) from exc
+    else:
+        raw = os.environ.get("MLX_PRELOAD_MODELS", "").strip()
+        models = raw.split() if raw else []
+
+    if not isinstance(models, list):
+        raise SystemExit("ERROR: preload models must be a JSON list or space-separated list")
+
+    cleaned = [model.strip() for model in models if isinstance(model, str) and model.strip()]
+    # Preserve order while removing duplicates.
+    return list(dict.fromkeys(cleaned))
+
+
+def request_json(url: str, payload: dict[str, object], timeout: int) -> dict[str, object]:
+    """POST JSON and return the decoded response."""
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        raw = response.read()
+    if not raw:
+        return {}
+    decoded = json.loads(raw.decode("utf-8"))
+    if not isinstance(decoded, dict):
+        raise RuntimeError(f"Unexpected non-object response from {url}")
+    return decoded
+
+
+def wait_for_api(models_url: str, deadline: float) -> None:
+    """Poll the proxy until /models answers successfully."""
+    while True:
+        try:
+            with urllib.request.urlopen(models_url, timeout=10) as response:
+                if response.status == 200:
+                    return
+        except Exception:
+            pass
+
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"Timed out waiting for {models_url}")
+        time.sleep(2)
+
+
+def warm_model(api_url: str, model: str, deadline: float) -> None:
+    """Send a 1-token completion to fault a model into memory."""
+    chat_url = f"{api_url.rstrip('/')}/chat/completions"
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": "warmup",
+            }
+        ],
+        "max_tokens": 1,
+        "stream": False,
+        "temperature": 0,
+    }
+    last_error: Exception | None = None
+
+    while True:
+        try:
+            response = request_json(chat_url, payload, timeout=20)
+            if "error" in response:
+                raise RuntimeError(f"{model}: {response['error']}")
+            return
+        except urllib.error.HTTPError as exc:
+            if exc.code not in TRANSIENT_HTTP_CODES:
+                raise RuntimeError(f"{model}: HTTP {exc.code}") from exc
+            last_error = exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+            last_error = exc
+        except RuntimeError:
+            raise
+
+        if time.monotonic() >= deadline:
+            if last_error is not None:
+                raise TimeoutError(f"{model}: timed out after repeated failures: {last_error}") from last_error
+            raise TimeoutError(f"{model}: timed out after repeated failures")
+        time.sleep(2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Warm preloaded MLX models")
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=900,
+        help="Maximum time to wait for the proxy and warmup requests (seconds)",
+    )
+    args = parser.parse_args()
+
+    api_url = os.environ.get("MLX_API_URL")
+    if not api_url:
+        print("ERROR: MLX_API_URL not set", file=sys.stderr)
+        return 1
+
+    models = parse_models()
+    if not models:
+        print("No preload models configured; nothing to warm.")
+        return 0
+
+    deadline = time.monotonic() + args.timeout
+    models_url = f"{api_url.rstrip('/')}/models"
+
+    print(f"Waiting for MLX API at {api_url} ...")
+    wait_for_api(models_url, deadline)
+    print(f"API ready; warming {len(models)} model(s): {', '.join(models)}")
+
+    for model in models:
+        model_start = time.monotonic()
+        warm_model(api_url, model, deadline)
+        elapsed = time.monotonic() - model_start
+        print(f"Warmed {model} in {elapsed:.1f}s")
+
+    print("MLX warmup completed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a one-shot MLX warmup LaunchAgent that faults the preload list with 1-token requests after the proxy is ready
- split llama-swap into resident and swap tiers so runtime-discovered models and Qwen3.6 can live off the resident pair
- expose the preload list to the warmup job and add a `mlx-warmup` CLI for manual use
- document the lifecycle and stack contract changes

## Validation
- `nix fmt`
- `nix flake check`

## Notes
- resident models stay on the `preload` list
- swap-tier models now belong in `programs.mlx.models`
