### PR TITLE
feat: enable elements-of-style writing skill plugin

### DIFF
--- a/modules/claude/plugins/04-community.nix
+++ b/modules/claude/plugins/04-community.nix
@@ -89,6 +89,10 @@ _:
     # Core enhancement suite — keep the canonical plugin.
     "superpowers@superpowers-marketplace" = true;
 
+    # Strunk & White writing skills (writing-clearly-and-concisely) — prose
+    # quality for docs, PRs, status reports.
+    "elements-of-style@superpowers-marketplace" = true;
+
     # DISABLED — niche experiments not in active use.
     "superpowers-lab@superpowers-marketplace" = false;
 


### PR DESCRIPTION
## What

Enable the `elements-of-style` plugin from the already-declared `superpowers-marketplace` (Tier 4) in `modules/claude/plugins/04-community.nix`. One-line toggle following the existing `superpowers@superpowers-marketplace` enable pattern.

## Why

`elements-of-style` packages Strunk & White's *The Elements of Style* as agent skills (notably `writing-clearly-and-concisely`), giving Claude Code a prose-quality skill for docs, PRs, and status reports. The marketplace is already a pinned flake input via the `nix-claude-code` catalog, so no new input or catalog change is needed here — the plugin content is runtime-fetched exactly like the already-enabled `superpowers` plugin.

## Validation

- Pre-commit hooks passed: `nixfmt-rfc-style`, `statix`, `deadnix`, trailing-whitespace/EOF.
- Targeted eval of the rendered Claude settings JSON (exercises the full plugin-tier merge) instead of a full `nix flake check` (which pulls the whole MLX stack and is slow):

  ```
  nix eval .#lib.ci.claudeSettingsJson --raw | jq '.enabledPlugins["elements-of-style@superpowers-marketplace"]'
  # => true
  ```

  The new plugin resolves and flows through to `enabledPlugins` as `true`.

## Source

- Plugin repo: https://github.com/obra/the-elements-of-style
- Marketplace (already declared): https://github.com/obra/superpowers-marketplace

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wgkZ9GX9WGWg1TYwfcp4V