### PR TITLE
refactor(lib): extract shared check helpers

### DIFF
--- a/lib/checks/agent-skills.nix
+++ b/lib/checks/agent-skills.nix
@@ -1,6 +1,7 @@
 # Agent Skills module regression tests
 { pkgs, hmConfig }:
 let
+  helpers = import ./helpers.nix { inherit pkgs; };
   cfg = hmConfig.config.programs.agentSkills;
   homeFileNames = builtins.attrNames hmConfig.config.home.file;
   managedSkillEntries = builtins.filter (
@@ -12,55 +13,39 @@ let
 in
 {
   # Verify all expected Agent Skills option paths exist.
-  agent-skills-options-regression =
-    let
-      expectedOptions = [
-        "enable"
-        "fromFlakeInputs"
-        "local"
-      ];
-      actualOptions = builtins.attrNames cfg;
-      missingOptions = builtins.filter (o: !(builtins.elem o actualOptions)) expectedOptions;
-    in
-    assert
-      missingOptions == [ ] || throw "Missing Agent Skills options: ${builtins.toJSON missingOptions}";
-    pkgs.runCommand "check-agent-skills-options-regression" { } ''
-      echo "Agent Skills option regression: ${toString (builtins.length expectedOptions)} options verified"
-      touch $out
-    '';
+  agent-skills-options-regression = helpers.mkOptionsRegression {
+    label = "Agent Skills";
+    checkName = "check-agent-skills-options-regression";
+    inherit cfg;
+    expectedOptions = [
+      "enable"
+      "fromFlakeInputs"
+      "local"
+    ];
+  };
 
   # Verify evaluated config values match expected defaults.
-  agent-skills-defaults-regression =
-    let
-      checks = [
-        {
-          name = "agentSkills.enable";
-          actual = cfg.enable;
-          expected = true;
-        }
-        {
-          name = "agentSkills.fromFlakeInputs.populated";
-          actual = builtins.length cfg.fromFlakeInputs > 0;
-          expected = true;
-        }
-        {
-          name = "agentSkills.local";
-          actual = cfg.local;
-          expected = { };
-        }
-      ];
-      failures = builtins.filter (c: c.actual != c.expected) checks;
-      failureMsg = builtins.concatStringsSep "\n" (
-        map (
-          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
-        ) failures
-      );
-    in
-    assert failures == [ ] || throw "Agent Skills default value regression:\n${failureMsg}";
-    pkgs.runCommand "check-agent-skills-defaults-regression" { } ''
-      echo "Agent Skills defaults regression: ${toString (builtins.length checks)} critical defaults verified"
-      touch $out
-    '';
+  agent-skills-defaults-regression = helpers.mkDefaultsRegression {
+    label = "Agent Skills";
+    checkName = "check-agent-skills-defaults-regression";
+    checks = [
+      {
+        name = "agentSkills.enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "agentSkills.fromFlakeInputs.populated";
+        actual = builtins.length cfg.fromFlakeInputs > 0;
+        expected = true;
+      }
+      {
+        name = "agentSkills.local";
+        actual = cfg.local;
+        expected = { };
+      }
+    ];
+  };
 
   # Validate module output wiring for ~/.agents ownership.
   agent-skills-home-files =
@@ -78,8 +63,5 @@ in
     assert
       missingSkillFiles == [ ]
       || throw "Agent Skills directory entries missing SKILL.md: ${builtins.toJSON missingSkillFiles}";
-    pkgs.runCommand "check-agent-skills-home-files" { } ''
-      echo "Agent Skills home.file wiring: ${toString (builtins.length managedSkillEntries)} managed skill entries"
-      touch $out
-    '';
+    helpers.mkMarker "check-agent-skills-home-files" "Agent Skills home.file wiring: ${toString (builtins.length managedSkillEntries)} managed skill entries";
 }

--- a/lib/checks/ai-stack.nix
+++ b/lib/checks/ai-stack.nix
@@ -4,6 +4,7 @@
 # aggregator passes a placeholder test id so the registry can be materialized.
 { pkgs, testLocalModelId }:
 let
+  helpers = import ./helpers.nix { inherit pkgs; };
   models = import ../ai-stack-models.nix { defaultLocalModelId = testLocalModelId; };
 
   expectedRoles = [
@@ -28,10 +29,7 @@ in
     assert
       actualRoles == expectedRoles
       || throw "lib.aiStackModels role set changed: expected ${builtins.toJSON expectedRoles}, got ${builtins.toJSON actualRoles}";
-    pkgs.runCommand "check-ai-stack-models-keys" { } ''
-      echo "lib.aiStackModels: ${toString (builtins.length expectedRoles)} roles verified"
-      touch $out
-    '';
+    helpers.mkMarker "check-ai-stack-models-keys" "lib.aiStackModels: ${toString (builtins.length expectedRoles)} roles verified";
 
   # Verify all physical IDs are non-empty mlx-community/ strings.
   ai-stack-models-physical-ids =
@@ -49,8 +47,5 @@ in
     assert
       invalidEntries == [ ]
       || throw "lib.aiStackModels physical IDs invalid for roles: ${builtins.toJSON invalidEntries}";
-    pkgs.runCommand "check-ai-stack-models-physical-ids" { } ''
-      echo "lib.aiStackModels: ${toString (builtins.length (builtins.attrNames models))} physical IDs verified as mlx-community/* strings"
-      touch $out
-    '';
+    helpers.mkMarker "check-ai-stack-models-physical-ids" "lib.aiStackModels: ${toString (builtins.length (builtins.attrNames models))} physical IDs verified as mlx-community/* strings";
 }

--- a/lib/checks/antigravity-cli.nix
+++ b/lib/checks/antigravity-cli.nix
@@ -1,153 +1,135 @@
 # Antigravity module regression tests
 { pkgs, hmConfig }:
 let
+  helpers = import ./helpers.nix { inherit pkgs; };
   cfg = hmConfig.config.programs.antigravity-cli;
   homeFileNames = builtins.attrNames hmConfig.config.home.file;
 in
 {
   # Verify all expected Antigravity option paths exist.
-  antigravity-cli-options-regression =
-    let
-      expectedOptions = [
-        "commands"
-        "contextFileNames"
-        "defaultApprovalMode"
-        "defaultModel"
-        "enable"
-        "excludedMcpServers"
-        "extensions"
-        "gemmaModelRouter"
-        "hooks"
-        "sandbox"
-        "sandboxAllowedPaths"
-        "sandboxAllowedPathsMerged"
-        "trustedFolders"
-        "worktrees"
-      ];
-      actualOptions = builtins.attrNames cfg;
-      missingOptions = builtins.filter (o: !(builtins.elem o actualOptions)) expectedOptions;
-    in
-    assert
-      missingOptions == [ ] || throw "Missing Antigravity options: ${builtins.toJSON missingOptions}";
-    pkgs.runCommand "check-antigravity-cli-options-regression" { } ''
-      echo "Antigravity option regression: ${toString (builtins.length expectedOptions)} options verified"
-      touch $out
-    '';
+  antigravity-cli-options-regression = helpers.mkOptionsRegression {
+    label = "Antigravity";
+    checkName = "check-antigravity-cli-options-regression";
+    inherit cfg;
+    expectedOptions = [
+      "commands"
+      "contextFileNames"
+      "defaultApprovalMode"
+      "defaultModel"
+      "enable"
+      "excludedMcpServers"
+      "extensions"
+      "gemmaModelRouter"
+      "hooks"
+      "sandbox"
+      "sandboxAllowedPaths"
+      "sandboxAllowedPathsMerged"
+      "trustedFolders"
+      "worktrees"
+    ];
+  };
 
   # Verify evaluated config values match expected defaults.
-  antigravity-cli-defaults-regression =
-    let
-      checks = [
-        {
-          name = "antigravity-cli.enable";
-          actual = cfg.enable;
-          expected = true;
-        }
-        {
-          name = "antigravity-cli.trustedFolders";
-          actual = cfg.trustedFolders;
-          expected = [ ];
-        }
-        {
-          name = "antigravity-cli.contextFileNames";
-          actual = cfg.contextFileNames;
-          expected = [ "AGENTS.md" ];
-        }
-        {
-          name = "antigravity-cli.excludedMcpServers.length";
-          actual = builtins.length cfg.excludedMcpServers;
-          expected = 11;
-        }
-        {
-          name = "antigravity-cli.extensions";
-          actual = cfg.extensions;
-          expected = { };
-        }
-        {
-          name = "antigravity-cli.hooks.beforeTool";
-          actual = cfg.hooks.beforeTool;
-          expected = null;
-        }
-        {
-          name = "antigravity-cli.hooks.afterTool";
-          actual = cfg.hooks.afterTool;
-          expected = null;
-        }
-        {
-          name = "antigravity-cli.commands.fromFlakeInputs";
-          actual = cfg.commands.fromFlakeInputs;
-          expected = [ ];
-        }
-        {
-          name = "antigravity-cli.commands.local";
-          actual = cfg.commands.local;
-          expected = { };
-        }
-        {
-          name = "antigravity-cli.sandbox.enable";
-          actual = cfg.sandbox.enable;
-          expected = true;
-        }
-        {
-          name = "antigravity-cli.sandbox.profile";
-          actual = cfg.sandbox.profile;
-          expected = null;
-        }
-        {
-          name = "antigravity-cli.sandboxAllowedPaths";
-          actual = cfg.sandboxAllowedPaths;
-          expected = [ ];
-        }
-        {
-          name = "antigravity-cli.defaultModel";
-          actual = cfg.defaultModel;
-          expected = null;
-        }
-        {
-          name = "antigravity-cli.gemmaModelRouter.enable";
-          actual = cfg.gemmaModelRouter.enable;
-          expected = false;
-        }
-        {
-          name = "antigravity-cli.gemmaModelRouter.autoStartServer";
-          actual = cfg.gemmaModelRouter.autoStartServer;
-          expected = false;
-        }
-        {
-          name = "antigravity-cli.gemmaModelRouter.port";
-          actual = cfg.gemmaModelRouter.port;
-          expected = 9379;
-        }
-        {
-          name = "antigravity-cli.gemmaModelRouter.binaryPath";
-          actual = cfg.gemmaModelRouter.binaryPath;
-          expected = "";
-        }
-        {
-          name = "antigravity-cli.gemmaModelRouter.classifierModel";
-          actual = cfg.gemmaModelRouter.classifierModel;
-          expected = "gemma3-1b-gpu-custom";
-        }
-      ];
-      failures = builtins.filter (c: c.actual != c.expected) checks;
-      failureMsg = builtins.concatStringsSep "\n" (
-        map (
-          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
-        ) failures
-      );
-    in
-    assert failures == [ ] || throw "Antigravity default value regression:\n${failureMsg}";
-    pkgs.runCommand "check-antigravity-cli-defaults-regression" { } ''
-      echo "Antigravity defaults regression: ${toString (builtins.length checks)} critical defaults verified"
-      touch $out
-    '';
+  antigravity-cli-defaults-regression = helpers.mkDefaultsRegression {
+    label = "Antigravity";
+    checkName = "check-antigravity-cli-defaults-regression";
+    checks = [
+      {
+        name = "antigravity-cli.enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "antigravity-cli.trustedFolders";
+        actual = cfg.trustedFolders;
+        expected = [ ];
+      }
+      {
+        name = "antigravity-cli.contextFileNames";
+        actual = cfg.contextFileNames;
+        expected = [ "AGENTS.md" ];
+      }
+      {
+        name = "antigravity-cli.excludedMcpServers.length";
+        actual = builtins.length cfg.excludedMcpServers;
+        expected = 11;
+      }
+      {
+        name = "antigravity-cli.extensions";
+        actual = cfg.extensions;
+        expected = { };
+      }
+      {
+        name = "antigravity-cli.hooks.beforeTool";
+        actual = cfg.hooks.beforeTool;
+        expected = null;
+      }
+      {
+        name = "antigravity-cli.hooks.afterTool";
+        actual = cfg.hooks.afterTool;
+        expected = null;
+      }
+      {
+        name = "antigravity-cli.commands.fromFlakeInputs";
+        actual = cfg.commands.fromFlakeInputs;
+        expected = [ ];
+      }
+      {
+        name = "antigravity-cli.commands.local";
+        actual = cfg.commands.local;
+        expected = { };
+      }
+      {
+        name = "antigravity-cli.sandbox.enable";
+        actual = cfg.sandbox.enable;
+        expected = true;
+      }
+      {
+        name = "antigravity-cli.sandbox.profile";
+        actual = cfg.sandbox.profile;
+        expected = null;
+      }
+      {
+        name = "antigravity-cli.sandboxAllowedPaths";
+        actual = cfg.sandboxAllowedPaths;
+        expected = [ ];
+      }
+      {
+        name = "antigravity-cli.defaultModel";
+        actual = cfg.defaultModel;
+        expected = null;
+      }
+      {
+        name = "antigravity-cli.gemmaModelRouter.enable";
+        actual = cfg.gemmaModelRouter.enable;
+        expected = false;
+      }
+      {
+        name = "antigravity-cli.gemmaModelRouter.autoStartServer";
+        actual = cfg.gemmaModelRouter.autoStartServer;
+        expected = false;
+      }
+      {
+        name = "antigravity-cli.gemmaModelRouter.port";
+        actual = cfg.gemmaModelRouter.port;
+        expected = 9379;
+      }
+      {
+        name = "antigravity-cli.gemmaModelRouter.binaryPath";
+        actual = cfg.gemmaModelRouter.binaryPath;
+        expected = "";
+      }
+      {
+        name = "antigravity-cli.gemmaModelRouter.classifierModel";
+        actual = cfg.gemmaModelRouter.classifierModel;
+        expected = "gemma3-1b-gpu-custom";
+      }
+    ];
+  };
 
   # Validate activation package builds (forces settings.json generation).
   antigravity-cli-settings-json = builtins.seq hmConfig.activationPackage (
-    pkgs.runCommand "check-antigravity-cli-settings-json" { } ''
-      echo "Antigravity settings: activation package builds successfully (settings.json generation verified)"
-      touch $out
-    ''
+    helpers.mkMarker "check-antigravity-cli-settings-json" "Antigravity settings: activation package builds successfully (settings.json generation verified)"
   );
 
   # Validate that the evaluated settings always include the `~/git` sandbox
@@ -163,10 +145,7 @@ in
     assert
       hasGitDir
       || throw "Antigravity sandboxAllowedPathsMerged missing ${expected}: ${builtins.toJSON merged}";
-    pkgs.runCommand "check-antigravity-cli-sandbox-default-paths" { } ''
-      echo "Antigravity sandbox default: ${expected} is present in merged settings"
-      touch $out
-    '';
+    helpers.mkMarker "check-antigravity-cli-sandbox-default-paths" "Antigravity sandbox default: ${expected} is present in merged settings";
 
   # Validate the .gemini/antigravity-cli/.keep directory marker is created (proves module loaded).
   antigravity-cli-module-loaded =
@@ -183,10 +162,7 @@ in
     assert
       disallowedAntigravityFiles == [ ]
       || throw "Antigravity must not deploy skills or GEMINI.md: ${builtins.toJSON disallowedAntigravityFiles}";
-    pkgs.runCommand "check-antigravity-cli-module-loaded" { } ''
-      echo "Antigravity module: .keep file present, module loaded successfully"
-      touch $out
-    '';
+    helpers.mkMarker "check-antigravity-cli-module-loaded" "Antigravity module: .keep file present, module loaded successfully";
 
   # Validate Policy Engine TOML is deployed and settings.json uses policyPaths.
   antigravity-cli-policy-engine =
@@ -207,8 +183,5 @@ in
       || throw "No run_shell_command rules found";
     assert
       lib.hasInfix ''commandPrefix = "git"'' policyContent || throw "Missing git commandPrefix rule";
-    pkgs.runCommand "check-antigravity-cli-policy-engine" { } ''
-      echo "Antigravity Policy Engine: TOML structure verified (8 assertions: non-empty, [[rule]], 3 decision types, tool mappings, git rule)"
-      touch $out
-    '';
+    helpers.mkMarker "check-antigravity-cli-policy-engine" "Antigravity Policy Engine: TOML structure verified (8 assertions: non-empty, [[rule]], 3 decision types, tool mappings, git rule)";
 }

--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -7,6 +7,7 @@
 # actually override.
 { pkgs, hmConfig }:
 let
+  helpers = import ./helpers.nix { inherit pkgs; };
   cfg = hmConfig.config.programs.claude;
 in
 {
@@ -88,68 +89,58 @@ in
 
   # Verify evaluated config values match expected values.
   # Tests claude-config.nix overrides against the schema's defaults.
-  defaults-regression =
-    let
-      checks = [
-        {
-          name = "enable";
-          actual = cfg.enable;
-          expected = true;
-        }
-        {
-          name = "alwaysThinkingEnabled";
-          actual = cfg.settings.alwaysThinkingEnabled;
-          expected = true;
-        }
-        {
-          name = "cleanupPeriodDays";
-          actual = cfg.settings.cleanupPeriodDays;
-          expected = 180;
-        }
-        {
-          name = "model";
-          actual = cfg.model;
-          expected = "opusplan";
-        }
-        {
-          # Intentionally unset → null → Claude Code uses the upstream default.
-          name = "effortLevel";
-          actual = cfg.effortLevel;
-          expected = null;
-        }
-        {
-          name = "sandbox.enabled";
-          actual = cfg.settings.sandbox.enabled;
-          expected = false;
-        }
-        {
-          name = "plugins.allowRuntimeInstall";
-          actual = cfg.plugins.allowRuntimeInstall;
-          expected = true;
-        }
-        {
-          name = "remoteControlAtStartup";
-          actual = cfg.remoteControlAtStartup;
-          expected = true;
-        }
-        {
-          name = "apiKeyHelper.enable";
-          actual = cfg.apiKeyHelper.enable;
-          expected = true;
-        }
-      ];
-      failures = builtins.filter (c: c.actual != c.expected) checks;
-      failureMsg = builtins.concatStringsSep "\n" (
-        map (
-          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
-        ) failures
-      );
-    in
-    assert failures == [ ] || throw "Default value regression:\n${failureMsg}";
-    pkgs.runCommand "check-defaults-regression" { } ''
-      echo "Defaults regression: ${toString (builtins.length checks)} critical defaults verified"
-      touch $out
-    '';
+  defaults-regression = helpers.mkDefaultsRegression {
+    label = "Claude";
+    checkName = "check-defaults-regression";
+    checks = [
+      {
+        name = "enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "alwaysThinkingEnabled";
+        actual = cfg.settings.alwaysThinkingEnabled;
+        expected = true;
+      }
+      {
+        name = "cleanupPeriodDays";
+        actual = cfg.settings.cleanupPeriodDays;
+        expected = 180;
+      }
+      {
+        name = "model";
+        actual = cfg.model;
+        expected = "opusplan";
+      }
+      {
+        # Intentionally unset → null → Claude Code uses the upstream default.
+        name = "effortLevel";
+        actual = cfg.effortLevel;
+        expected = null;
+      }
+      {
+        name = "sandbox.enabled";
+        actual = cfg.settings.sandbox.enabled;
+        expected = false;
+      }
+      {
+        name = "plugins.allowRuntimeInstall";
+        actual = cfg.plugins.allowRuntimeInstall;
+        expected = true;
+      }
+      {
+        name = "remoteControlAtStartup";
+        actual = cfg.remoteControlAtStartup;
+        expected = true;
+      }
+      {
+        name = "apiKeyHelper.enable";
+        actual = cfg.apiKeyHelper.enable;
+        expected = true;
+      }
+    ];
+  };
 
   # Validate the maestro-cli script extraction produces correct output.
   # (Kept here for historical reasons — moves to maestro module checks long-term.)
@@ -215,8 +206,5 @@ in
     in
     assert nonEmpty || throw "skill packs must be non-empty attrsets";
     assert allBool || throw "skill pack leaf values must all be booleans";
-    pkgs.runCommand "check-skill-packs" { } ''
-      echo "Skill packs: ${toString (builtins.length packList)} packs verified"
-      touch $out
-    '';
+    helpers.mkMarker "check-skill-packs" "Skill packs: ${toString (builtins.length packList)} packs verified";
 }

--- a/lib/checks/codex.nix
+++ b/lib/checks/codex.nix
@@ -1,131 +1,117 @@
 # Codex module regression tests
 { pkgs, hmConfig }:
 let
+  helpers = import ./helpers.nix { inherit pkgs; };
   cfg = hmConfig.config.programs.codex;
   homeFileNames = builtins.attrNames hmConfig.config.home.file;
 in
 {
   # Verify all expected Codex option paths exist.
-  codex-options-regression =
-    let
-      expectedOptions = [
-        "approvalPolicy"
-        "enable"
-        "excludedMcpServers"
-        "features"
-        "hooks"
-        "model"
-        "modelProvider"
-        "modelReasoningEffort"
-        "modelVerbosity"
-        "planModeReasoningEffort"
-        "projectDocFallbackFilenames"
-        "reviewModel"
-        "serviceTier"
-        "trustedProjectDirs"
-        "webSearch"
-      ];
-      actualOptions = builtins.attrNames cfg;
-      missingOptions = builtins.filter (o: !(builtins.elem o actualOptions)) expectedOptions;
-    in
-    assert missingOptions == [ ] || throw "Missing Codex options: ${builtins.toJSON missingOptions}";
-    pkgs.runCommand "check-codex-options-regression" { } ''
-      echo "Codex option regression: ${toString (builtins.length expectedOptions)} options verified"
-      touch $out
-    '';
+  codex-options-regression = helpers.mkOptionsRegression {
+    label = "Codex";
+    checkName = "check-codex-options-regression";
+    inherit cfg;
+    expectedOptions = [
+      "approvalPolicy"
+      "enable"
+      "excludedMcpServers"
+      "features"
+      "hooks"
+      "model"
+      "modelProvider"
+      "modelReasoningEffort"
+      "modelVerbosity"
+      "planModeReasoningEffort"
+      "projectDocFallbackFilenames"
+      "reviewModel"
+      "serviceTier"
+      "trustedProjectDirs"
+      "webSearch"
+    ];
+  };
 
   # Verify evaluated config values match expected defaults.
-  codex-defaults-regression =
-    let
-      checks = [
-        {
-          name = "codex.enable";
-          actual = cfg.enable;
-          expected = true;
-        }
-        {
-          name = "codex.approvalPolicy";
-          actual = cfg.approvalPolicy;
-          expected = "untrusted";
-        }
-        {
-          name = "codex.features";
-          actual = cfg.features;
-          expected = { };
-        }
-        {
-          name = "codex.model";
-          actual = cfg.model;
-          expected = null;
-        }
-        {
-          name = "codex.modelProvider";
-          actual = cfg.modelProvider;
-          expected = null;
-        }
-        {
-          name = "codex.modelReasoningEffort";
-          actual = cfg.modelReasoningEffort;
-          expected = "medium";
-        }
-        {
-          name = "codex.modelVerbosity";
-          actual = cfg.modelVerbosity;
-          expected = "medium";
-        }
-        {
-          name = "codex.planModeReasoningEffort";
-          actual = cfg.planModeReasoningEffort;
-          expected = "high";
-        }
-        {
-          name = "codex.reviewModel";
-          actual = cfg.reviewModel;
-          expected = null;
-        }
-        {
-          name = "codex.serviceTier";
-          actual = cfg.serviceTier;
-          expected = null;
-        }
-        {
-          name = "codex.webSearch";
-          actual = cfg.webSearch;
-          expected = null;
-        }
-        {
-          name = "codex.excludedMcpServers.length";
-          actual = builtins.length cfg.excludedMcpServers;
-          expected = 11;
-        }
-        {
-          name = "codex.trustedProjectDirs";
-          actual = cfg.trustedProjectDirs;
-          expected = [ ];
-        }
-        {
-          name = "codex.projectDocFallbackFilenames";
-          actual = cfg.projectDocFallbackFilenames;
-          expected = [ "AGENTS.md" ];
-        }
-        {
-          name = "codex.hooks.notification";
-          actual = cfg.hooks.notification;
-          expected = null;
-        }
-      ];
-      failures = builtins.filter (c: c.actual != c.expected) checks;
-      failureMsg = builtins.concatStringsSep "\n" (
-        map (
-          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
-        ) failures
-      );
-    in
-    assert failures == [ ] || throw "Codex default value regression:\n${failureMsg}";
-    pkgs.runCommand "check-codex-defaults-regression" { } ''
-      echo "Codex defaults regression: ${toString (builtins.length checks)} critical defaults verified"
-      touch $out
-    '';
+  codex-defaults-regression = helpers.mkDefaultsRegression {
+    label = "Codex";
+    checkName = "check-codex-defaults-regression";
+    checks = [
+      {
+        name = "codex.enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "codex.approvalPolicy";
+        actual = cfg.approvalPolicy;
+        expected = "untrusted";
+      }
+      {
+        name = "codex.features";
+        actual = cfg.features;
+        expected = { };
+      }
+      {
+        name = "codex.model";
+        actual = cfg.model;
+        expected = null;
+      }
+      {
+        name = "codex.modelProvider";
+        actual = cfg.modelProvider;
+        expected = null;
+      }
+      {
+        name = "codex.modelReasoningEffort";
+        actual = cfg.modelReasoningEffort;
+        expected = "medium";
+      }
+      {
+        name = "codex.modelVerbosity";
+        actual = cfg.modelVerbosity;
+        expected = "medium";
+      }
+      {
+        name = "codex.planModeReasoningEffort";
+        actual = cfg.planModeReasoningEffort;
+        expected = "high";
+      }
+      {
+        name = "codex.reviewModel";
+        actual = cfg.reviewModel;
+        expected = null;
+      }
+      {
+        name = "codex.serviceTier";
+        actual = cfg.serviceTier;
+        expected = null;
+      }
+      {
+        name = "codex.webSearch";
+        actual = cfg.webSearch;
+        expected = null;
+      }
+      {
+        name = "codex.excludedMcpServers.length";
+        actual = builtins.length cfg.excludedMcpServers;
+        expected = 11;
+      }
+      {
+        name = "codex.trustedProjectDirs";
+        actual = cfg.trustedProjectDirs;
+        expected = [ ];
+      }
+      {
+        name = "codex.projectDocFallbackFilenames";
+        actual = cfg.projectDocFallbackFilenames;
+        expected = [ "AGENTS.md" ];
+      }
+      {
+        name = "codex.hooks.notification";
+        actual = cfg.hooks.notification;
+        expected = null;
+      }
+    ];
+  };
 
   # Validate the activation package builds (forces config.toml generation).
   codex-settings-toml = builtins.seq hmConfig.activationPackage (
@@ -135,10 +121,7 @@ in
     assert
       disallowedCodexFiles == [ ]
       || throw "Codex must not deploy tool-specific shared skills or GEMINI.md: ${builtins.toJSON disallowedCodexFiles}";
-    pkgs.runCommand "check-codex-settings-toml" { } ''
-      echo "Codex settings: activation package builds successfully (config.toml generation verified)"
-      touch $out
-    ''
+    helpers.mkMarker "check-codex-settings-toml" "Codex settings: activation package builds successfully (config.toml generation verified)"
   );
 
   # Validate permissions pipeline produces non-empty rules via home.file output.

--- a/lib/checks/fabric.nix
+++ b/lib/checks/fabric.nix
@@ -9,6 +9,7 @@
   src,
 }:
 let
+  helpers = import ./helpers.nix { inherit pkgs; };
   cfg = hmConfig.config.programs.fabric;
 in
 {
@@ -16,7 +17,13 @@ in
   # an option — it is a computed constant in packages.nix (see that file for
   # rationale). This check also asserts patternsDir is NOT in the option set.
   fabric-options-regression =
-    let
+    assert
+      !(builtins.elem "patternsDir" (builtins.attrNames cfg))
+      || throw "patternsDir must NOT be a configurable option (it is a computed constant — see modules/fabric/packages.nix)";
+    helpers.mkOptionsRegression {
+      label = "Fabric";
+      checkName = "check-fabric-options-regression";
+      inherit cfg;
       expectedOptions = [
         "customPatternsDir"
         "defaultModel"
@@ -25,76 +32,55 @@ in
         "host"
         "port"
       ];
-      actualOptions = builtins.attrNames cfg;
-      missingOptions = builtins.filter (o: !(builtins.elem o actualOptions)) expectedOptions;
-      patternsDirIsOption = builtins.elem "patternsDir" actualOptions;
-    in
-    assert missingOptions == [ ] || throw "Missing fabric options: ${builtins.toJSON missingOptions}";
-    assert
-      !patternsDirIsOption
-      || throw "patternsDir must NOT be a configurable option (it is a computed constant — see modules/fabric/packages.nix)";
-    pkgs.runCommand "check-fabric-options-regression" { } ''
-      echo "Fabric option regression: ${toString (builtins.length expectedOptions)} options verified"
-      touch $out
-    '';
+    };
 
   # Verify fabric evaluated config values match expected defaults.
   # Pinning these so accidental drift breaks the build (port collisions, etc.).
-  fabric-defaults-regression =
-    let
-      checks = [
-        {
-          name = "fabric.enable";
-          actual = cfg.enable;
-          expected = true;
-        }
-        {
-          name = "fabric.enableServer";
-          actual = cfg.enableServer;
-          expected = false;
-        }
-        {
-          name = "fabric.host";
-          actual = cfg.host;
-          expected = "127.0.0.1";
-        }
-        {
-          name = "fabric.port";
-          actual = cfg.port;
-          expected = 8180;
-        }
-        {
-          name = "fabric.defaultModel";
-          actual = cfg.defaultModel;
-          expected = "default";
-        }
-        # Environment variables — FABRIC_PATTERNS_DIR is computed from
-        # config.home.homeDirectory + the fixed ".config/fabric/patterns"
-        # relative path (see modules/fabric/packages.nix). This check asserts
-        # the env var stays in sync with the home.file symlink location.
-        {
-          name = "fabric.env.FABRIC_PATTERNS_DIR";
-          actual = hmConfig.config.home.sessionVariables.FABRIC_PATTERNS_DIR;
-          expected = "${hmConfig.config.home.homeDirectory}/.config/fabric/patterns";
-        }
-        {
-          name = "fabric.env.FABRIC_DEFAULT_MODEL";
-          actual = hmConfig.config.home.sessionVariables.FABRIC_DEFAULT_MODEL;
-          expected = cfg.defaultModel;
-        }
-      ];
-      failures = builtins.filter (c: c.actual != c.expected) checks;
-      failureMsg = builtins.concatStringsSep "\n" (
-        map (
-          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
-        ) failures
-      );
-    in
-    assert failures == [ ] || throw "Fabric default value regression:\n${failureMsg}";
-    pkgs.runCommand "check-fabric-defaults-regression" { } ''
-      echo "Fabric defaults regression: ${toString (builtins.length checks)} critical defaults verified"
-      touch $out
-    '';
+  fabric-defaults-regression = helpers.mkDefaultsRegression {
+    label = "Fabric";
+    checkName = "check-fabric-defaults-regression";
+    checks = [
+      {
+        name = "fabric.enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "fabric.enableServer";
+        actual = cfg.enableServer;
+        expected = false;
+      }
+      {
+        name = "fabric.host";
+        actual = cfg.host;
+        expected = "127.0.0.1";
+      }
+      {
+        name = "fabric.port";
+        actual = cfg.port;
+        expected = 8180;
+      }
+      {
+        name = "fabric.defaultModel";
+        actual = cfg.defaultModel;
+        expected = "default";
+      }
+      # Environment variables — FABRIC_PATTERNS_DIR is computed from
+      # config.home.homeDirectory + the fixed ".config/fabric/patterns"
+      # relative path (see modules/fabric/packages.nix). This check asserts
+      # the env var stays in sync with the home.file symlink location.
+      {
+        name = "fabric.env.FABRIC_PATTERNS_DIR";
+        actual = hmConfig.config.home.sessionVariables.FABRIC_PATTERNS_DIR;
+        expected = "${hmConfig.config.home.homeDirectory}/.config/fabric/patterns";
+      }
+      {
+        name = "fabric.env.FABRIC_DEFAULT_MODEL";
+        actual = hmConfig.config.home.sessionVariables.FABRIC_DEFAULT_MODEL;
+        expected = cfg.defaultModel;
+      }
+    ];
+  };
 
   # Validate the fabric LaunchAgent (positive case): when enableServer = true,
   # ProgramArguments must contain --serve and the configured host:port.
@@ -122,10 +108,7 @@ in
     assert hasKeepAlive || throw "Fabric LaunchAgent must have KeepAlive = true";
     assert hasRunAtLoad || throw "Fabric LaunchAgent must have RunAtLoad = true";
     assert hasBackgroundType || throw "Fabric LaunchAgent must have ProcessType = \"Background\"";
-    pkgs.runCommand "check-fabric-launchd" { } ''
-      echo "Fabric LaunchAgent (enableServer=true): --serve --address ${expectedAddress} verified"
-      touch $out
-    '';
+    helpers.mkMarker "check-fabric-launchd" "Fabric LaunchAgent (enableServer=true): --serve --address ${expectedAddress} verified";
 
   # Validate the fabric LaunchAgent (negative case): when enableServer = false
   # (the default), no launchd.agents.fabric entry should exist.
@@ -135,10 +118,7 @@ in
     in
     assert
       !hasAgent || throw "Fabric LaunchAgent must NOT be defined when enableServer = false (default)";
-    pkgs.runCommand "check-fabric-launchd-negative" { } ''
-      echo "Fabric LaunchAgent negative: launchd.agents.fabric correctly absent when enableServer = false"
-      touch $out
-    '';
+    helpers.mkMarker "check-fabric-launchd-negative" "Fabric LaunchAgent negative: launchd.agents.fabric correctly absent when enableServer = false";
 
   # Assert the fabric version in lib/versions.nix matches the version tag of
   # the fabric-src flake input in flake.nix. Renovate's nix manager bumps
@@ -163,10 +143,7 @@ in
     ) "fabric-version-sync: lib/versions.nix has no `fabric` entry";
     assert pkgs.lib.assertMsg (flakeVersion == pinVersion)
       "fabric version drift: flake.nix fabric-src=v${flakeVersion} but lib/versions.nix.fabric=${pinVersion}";
-    pkgs.runCommand "check-fabric-version-sync" { } ''
-      echo "Fabric version sync: flake.nix v${flakeVersion} == lib/versions.nix.fabric ${pinVersion}"
-      touch $out
-    '';
+    helpers.mkMarker "check-fabric-version-sync" "Fabric version sync: flake.nix v${flakeVersion} == lib/versions.nix.fabric ${pinVersion}";
 
   # fabric-marketplace-build moved to nix-claude-code/flake/checks.nix as
   # part of PR3 — the synthetic fabric-patterns marketplace derivation and

--- a/lib/checks/helpers.nix
+++ b/lib/checks/helpers.nix
@@ -1,0 +1,64 @@
+# Shared scaffolding for the regression checks.
+#
+# Every check group repeats the same three shapes: a trivially-building
+# success marker (echo + touch $out), an "option set contains every expected
+# attr" guard, and a "list of {name, actual, expected} all hold" guard. These
+# helpers centralize that boilerplate so the individual check files carry only
+# the data (expected option names, expected default values) they are pinning.
+#
+# Each helper evaluates its assertions before returning the marker derivation,
+# so option/default drift fails `nix flake check` at eval time — same timing
+# as the inline `assert … ; pkgs.runCommand …` form it replaces.
+{ pkgs }:
+let
+  inherit (builtins)
+    attrNames
+    elem
+    filter
+    toJSON
+    length
+    concatStringsSep
+    map
+    ;
+
+  # Success marker: echo a message, touch $out.
+  mkMarker =
+    name: message:
+    pkgs.runCommand name { } ''
+      echo ${pkgs.lib.escapeShellArg message}
+      touch $out
+    '';
+in
+{
+  inherit mkMarker;
+
+  # Guard: `cfg` must contain every attr name in `expectedOptions`.
+  mkOptionsRegression =
+    {
+      label,
+      checkName,
+      cfg,
+      expectedOptions,
+    }:
+    let
+      missing = filter (o: !(elem o (attrNames cfg))) expectedOptions;
+    in
+    assert missing == [ ] || throw "Missing ${label} options: ${toJSON missing}";
+    mkMarker checkName "${label} option regression: ${toString (length expectedOptions)} options verified";
+
+  # Guard: every `{ name, actual, expected }` in `checks` must have actual == expected.
+  mkDefaultsRegression =
+    {
+      label,
+      checkName,
+      checks,
+    }:
+    let
+      failures = filter (c: c.actual != c.expected) checks;
+      failureMsg = concatStringsSep "\n" (
+        map (c: "  ${c.name}: expected ${toJSON c.expected}, got ${toJSON c.actual}") failures
+      );
+    in
+    assert failures == [ ] || throw "${label} default value regression:\n${failureMsg}";
+    mkMarker checkName "${label} defaults regression: ${toString (length checks)} critical defaults verified";
+}

--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -1,204 +1,190 @@
 # MLX module regression tests and LaunchAgent validation
 { pkgs, hmConfig }:
 let
+  helpers = import ./helpers.nix { inherit pkgs; };
   mlxCfg = hmConfig.config.programs.mlx;
 in
 {
   # Verify all expected MLX option paths exist.
   # Flat structure — no nested backend settings (vllm-mlx only since v0.2.6).
-  mlx-options-regression =
-    let
-      expectedOptions = [
-        "autoUnloadIdleSeconds"
-        "cacheMemoryMb"
-        "chunkedPrefillTokens"
-        "completionBatchSize"
-        "continuousBatching"
-        "defaultModel"
-        "enable"
-        "enableAutoToolChoice"
-        "enableMetrics"
-        "enablePrefixCaching"
-        "gpuMemoryUtilization"
-        "host"
-        "huggingFaceHome"
-        "maxTokens"
-        "maxNumSeqs"
-        "memoryHardLimitGb"
-        "models"
-        "pagedKvCache"
-        "port"
-        "prefillBatchSize"
-        "proxy"
-        "reasoningParser"
-        "toolCallParser"
-      ];
-      actualOptions = builtins.attrNames mlxCfg;
-      missingOptions = builtins.filter (o: !(builtins.elem o actualOptions)) expectedOptions;
-    in
-    assert missingOptions == [ ] || throw "Missing MLX options: ${builtins.toJSON missingOptions}";
-    pkgs.runCommand "check-mlx-options-regression" { } ''
-      echo "MLX option regression: ${toString (builtins.length expectedOptions)} options verified"
-      touch $out
-    '';
+  mlx-options-regression = helpers.mkOptionsRegression {
+    label = "MLX";
+    checkName = "check-mlx-options-regression";
+    cfg = mlxCfg;
+    expectedOptions = [
+      "autoUnloadIdleSeconds"
+      "cacheMemoryMb"
+      "chunkedPrefillTokens"
+      "completionBatchSize"
+      "continuousBatching"
+      "defaultModel"
+      "enable"
+      "enableAutoToolChoice"
+      "enableMetrics"
+      "enablePrefixCaching"
+      "gpuMemoryUtilization"
+      "host"
+      "huggingFaceHome"
+      "maxTokens"
+      "maxNumSeqs"
+      "memoryHardLimitGb"
+      "models"
+      "pagedKvCache"
+      "port"
+      "prefillBatchSize"
+      "proxy"
+      "reasoningParser"
+      "toolCallParser"
+    ];
+  };
 
   # Verify MLX evaluated config values match expected defaults.
-  mlx-defaults-regression =
-    let
-      checks = [
-        {
-          name = "mlx.enable";
-          actual = mlxCfg.enable;
-          expected = true;
-        }
-        {
-          # Presence-only check — the actual model id is parameterized via
-          # services.aiStack.defaultLocalModelId and not hardcoded in this
-          # repo. Verifying it's a non-empty string is enough; the consumer
-          # owns the value.
-          name = "mlx.defaultModel-populated";
-          actual = mlxCfg.defaultModel != null && mlxCfg.defaultModel != "";
-          expected = true;
-        }
-        {
-          name = "mlx.port";
-          actual = mlxCfg.port;
-          expected = 11434;
-        }
-        {
-          name = "mlx.host";
-          actual = mlxCfg.host;
-          expected = "127.0.0.1";
-        }
-        {
-          name = "mlx.huggingFaceHome";
-          actual = mlxCfg.huggingFaceHome;
-          expected = "/Volumes/HuggingFace";
-        }
-        {
-          name = "mlx.cacheMemoryMb";
-          actual = mlxCfg.cacheMemoryMb;
-          expected = 8192;
-        }
-        {
-          name = "mlx.gpuMemoryUtilization";
-          actual = mlxCfg.gpuMemoryUtilization;
-          expected = 0.8;
-        }
-        {
-          name = "mlx.autoUnloadIdleSeconds";
-          actual = mlxCfg.autoUnloadIdleSeconds;
-          expected = 1800;
-        }
-        {
-          name = "mlx.enableMetrics";
-          actual = mlxCfg.enableMetrics;
-          expected = true;
-        }
-        {
-          name = "mlx.proxy.idleTtl";
-          actual = mlxCfg.proxy.idleTtl;
-          expected = 900;
-        }
-        {
-          name = "mlx.proxy.concurrencyLimit";
-          actual = mlxCfg.proxy.concurrencyLimit;
-          expected = 2;
-        }
-        {
-          name = "mlx.prefillBatchSize";
-          actual = mlxCfg.prefillBatchSize;
-          expected = null;
-        }
-        {
-          name = "mlx.continuousBatching";
-          actual = mlxCfg.continuousBatching;
-          expected = true;
-        }
-        {
-          name = "mlx.maxNumSeqs";
-          actual = mlxCfg.maxNumSeqs;
-          expected = 4;
-        }
-        {
-          name = "mlx.enablePrefixCaching";
-          actual = mlxCfg.enablePrefixCaching;
-          expected = true;
-        }
-        {
-          name = "mlx.pagedKvCache";
-          actual = mlxCfg.pagedKvCache;
-          expected = true;
-        }
-        {
-          name = "mlx.chunkedPrefillTokens";
-          actual = mlxCfg.chunkedPrefillTokens;
-          expected = null;
-        }
-        {
-          name = "mlx.completionBatchSize";
-          actual = mlxCfg.completionBatchSize;
-          expected = null;
-        }
-        {
-          name = "mlx.maxTokens";
-          actual = mlxCfg.maxTokens;
-          expected = 8192;
-        }
-        {
-          name = "mlx.memoryHardLimitGb";
-          actual = mlxCfg.memoryHardLimitGb;
-          expected = 100;
-        }
-        {
-          name = "mlx.enableAutoToolChoice";
-          actual = mlxCfg.enableAutoToolChoice;
-          expected = true;
-        }
-        {
-          name = "mlx.toolCallParser";
-          actual = mlxCfg.toolCallParser;
-          expected = "hermes";
-        }
-        {
-          name = "mlx.reasoningParser";
-          actual = mlxCfg.reasoningParser;
-          expected = null;
-        }
-        # Environment variables
-        {
-          name = "mlx.env.MLX_DEFAULT_MODEL";
-          actual = hmConfig.config.home.sessionVariables.MLX_DEFAULT_MODEL;
-          expected = mlxCfg.defaultModel;
-        }
-        {
-          name = "mlx.env.MLX_API_URL";
-          actual = hmConfig.config.home.sessionVariables.MLX_API_URL;
-          expected = "http://127.0.0.1:11434/v1";
-        }
-        {
-          name = "mlx.env.MLX_PORT";
-          actual = hmConfig.config.home.sessionVariables.MLX_PORT;
-          expected = "11434";
-        }
-        {
-          name = "mlx.env.MLX_HOST";
-          actual = hmConfig.config.home.sessionVariables.MLX_HOST;
-          expected = "127.0.0.1";
-        }
-      ];
-      failures = builtins.filter (c: c.actual != c.expected) checks;
-      failureMsg = builtins.concatStringsSep "\n" (
-        map (
-          c: "  ${c.name}: expected ${builtins.toJSON c.expected}, got ${builtins.toJSON c.actual}"
-        ) failures
-      );
-    in
-    assert failures == [ ] || throw "MLX default value regression:\n${failureMsg}";
-    pkgs.runCommand "check-mlx-defaults-regression" { } ''
-      echo "MLX defaults regression: ${toString (builtins.length checks)} critical defaults verified"
-      touch $out
-    '';
+  mlx-defaults-regression = helpers.mkDefaultsRegression {
+    label = "MLX";
+    checkName = "check-mlx-defaults-regression";
+    checks = [
+      {
+        name = "mlx.enable";
+        actual = mlxCfg.enable;
+        expected = true;
+      }
+      {
+        # Presence-only check — the actual model id is parameterized via
+        # services.aiStack.defaultLocalModelId and not hardcoded in this
+        # repo. Verifying it's a non-empty string is enough; the consumer
+        # owns the value.
+        name = "mlx.defaultModel-populated";
+        actual = mlxCfg.defaultModel != null && mlxCfg.defaultModel != "";
+        expected = true;
+      }
+      {
+        name = "mlx.port";
+        actual = mlxCfg.port;
+        expected = 11434;
+      }
+      {
+        name = "mlx.host";
+        actual = mlxCfg.host;
+        expected = "127.0.0.1";
+      }
+      {
+        name = "mlx.huggingFaceHome";
+        actual = mlxCfg.huggingFaceHome;
+        expected = "/Volumes/HuggingFace";
+      }
+      {
+        name = "mlx.cacheMemoryMb";
+        actual = mlxCfg.cacheMemoryMb;
+        expected = 8192;
+      }
+      {
+        name = "mlx.gpuMemoryUtilization";
+        actual = mlxCfg.gpuMemoryUtilization;
+        expected = 0.8;
+      }
+      {
+        name = "mlx.autoUnloadIdleSeconds";
+        actual = mlxCfg.autoUnloadIdleSeconds;
+        expected = 1800;
+      }
+      {
+        name = "mlx.enableMetrics";
+        actual = mlxCfg.enableMetrics;
+        expected = true;
+      }
+      {
+        name = "mlx.proxy.idleTtl";
+        actual = mlxCfg.proxy.idleTtl;
+        expected = 900;
+      }
+      {
+        name = "mlx.proxy.concurrencyLimit";
+        actual = mlxCfg.proxy.concurrencyLimit;
+        expected = 2;
+      }
+      {
+        name = "mlx.prefillBatchSize";
+        actual = mlxCfg.prefillBatchSize;
+        expected = null;
+      }
+      {
+        name = "mlx.continuousBatching";
+        actual = mlxCfg.continuousBatching;
+        expected = true;
+      }
+      {
+        name = "mlx.maxNumSeqs";
+        actual = mlxCfg.maxNumSeqs;
+        expected = 4;
+      }
+      {
+        name = "mlx.enablePrefixCaching";
+        actual = mlxCfg.enablePrefixCaching;
+        expected = true;
+      }
+      {
+        name = "mlx.pagedKvCache";
+        actual = mlxCfg.pagedKvCache;
+        expected = true;
+      }
+      {
+        name = "mlx.chunkedPrefillTokens";
+        actual = mlxCfg.chunkedPrefillTokens;
+        expected = null;
+      }
+      {
+        name = "mlx.completionBatchSize";
+        actual = mlxCfg.completionBatchSize;
+        expected = null;
+      }
+      {
+        name = "mlx.maxTokens";
+        actual = mlxCfg.maxTokens;
+        expected = 8192;
+      }
+      {
+        name = "mlx.memoryHardLimitGb";
+        actual = mlxCfg.memoryHardLimitGb;
+        expected = 100;
+      }
+      {
+        name = "mlx.enableAutoToolChoice";
+        actual = mlxCfg.enableAutoToolChoice;
+        expected = true;
+      }
+      {
+        name = "mlx.toolCallParser";
+        actual = mlxCfg.toolCallParser;
+        expected = "hermes";
+      }
+      {
+        name = "mlx.reasoningParser";
+        actual = mlxCfg.reasoningParser;
+        expected = null;
+      }
+      # Environment variables
+      {
+        name = "mlx.env.MLX_DEFAULT_MODEL";
+        actual = hmConfig.config.home.sessionVariables.MLX_DEFAULT_MODEL;
+        expected = mlxCfg.defaultModel;
+      }
+      {
+        name = "mlx.env.MLX_API_URL";
+        actual = hmConfig.config.home.sessionVariables.MLX_API_URL;
+        expected = "http://127.0.0.1:11434/v1";
+      }
+      {
+        name = "mlx.env.MLX_PORT";
+        actual = hmConfig.config.home.sessionVariables.MLX_PORT;
+        expected = "11434";
+      }
+      {
+        name = "mlx.env.MLX_HOST";
+        actual = hmConfig.config.home.sessionVariables.MLX_HOST;
+        expected = "127.0.0.1";
+      }
+    ];
+  };
 
   # Validate MLX LaunchAgent ProgramArguments use llama-swap proxy,
   # and that the generated llama-swap config JSON contains required fields.
@@ -256,10 +242,7 @@ in
       missingRequired == [ ]
       || throw "Missing required llama-swap proxy flags in ProgramArguments: ${builtins.toJSON missingRequired}";
     assert configArgPresent || throw "ProgramArguments has --config but no following path argument";
-    pkgs.runCommand "check-mlx-launchd" { } ''
-      echo "MLX LaunchAgent: llama-swap proxy args verified (--config ${configFileArg} --watch-config --listen present)"
-      touch $out
-    '';
+    helpers.mkMarker "check-mlx-launchd" "MLX LaunchAgent: llama-swap proxy args verified (--config ${configFileArg} --watch-config --listen present)";
 
   # Verify OOM prevention: ProcessType in LaunchAgent.
   # HardResourceLimits is intentionally absent — it would only cap the llama-swap
@@ -277,10 +260,7 @@ in
     assert
       (!(launchdCfg ? HardResourceLimits) || launchdCfg.HardResourceLimits == null)
       || throw "HardResourceLimits must NOT be set on the llama-swap proxy (only constrains proxy, not vllm-mlx children)";
-    pkgs.runCommand "check-mlx-launchd-memory-safety" { } ''
-      echo "MLX LaunchAgent memory safety: ProcessType=Interactive verified; HardResourceLimits correctly absent from proxy"
-      touch $out
-    '';
+    helpers.mkMarker "check-mlx-launchd-memory-safety" "MLX LaunchAgent memory safety: ProcessType=Interactive verified; HardResourceLimits correctly absent from proxy";
 
   # Negative test: verify the banned-flag detection logic actually catches bad flags.
   # Without this, a regex typo in mlx-launchd could silently pass banned flags through.
@@ -337,8 +317,5 @@ in
       || throw "Negative test failed — banned flags NOT detected: ${
         builtins.toJSON (map (tc: tc.bannedFlag) undetected)
       }";
-    pkgs.runCommand "check-mlx-launchd-negative" { } ''
-      echo "MLX LaunchAgent negative: ${toString (builtins.length testCases)} banned flag patterns verified detectable"
-      touch $out
-    '';
+    helpers.mkMarker "check-mlx-launchd-negative" "MLX LaunchAgent negative: ${toString (builtins.length testCases)} banned flag patterns verified detectable";
 }


### PR DESCRIPTION
## What

The flake-check groups under \`lib/checks/*\` repeated the same three shapes:

- a trivially-building **success marker** (\`echo … ; touch \$out\`)
- an **option-set presence guard** (\`expected\` names vs \`attrNames cfg\` → \`assert\` → marker)
- a **defaults guard** (\`{name, actual, expected}\` list → \`failures\`/\`failureMsg\` → \`assert\` → marker)

This extracts \`mkMarker\`, \`mkOptionsRegression\`, and \`mkDefaultsRegression\` into a
new \`lib/checks/helpers.nix\` and rewires the call sites in \`agent-skills\`,
\`ai-stack\`, \`antigravity-cli\`, \`claude\`, \`codex\`, \`fabric\`, and \`mlx\`. Each check
group now carries only the data it pins; the assert/scaffolding boilerplate lives
in one place.

## Behaviour preserved

Assertions remain inside the derivation-producing expression, so option and
default drift still fails \`nix flake check\` at eval time — same timing as the
inline form. No check names, verified values, or guard conditions changed.

## Net

−61 LOC (comments excluded from the intent; this is real scaffolding removed).

## Validation

- Every converted check's \`drvPath\` force-evaluates cleanly (asserts fire, all pass).
- \`nix fmt\`, \`statix check\`, \`deadnix --fail\` all clean on the changed files.
- IFD-dependent checks (e.g. \`*-policy-engine\`, \`*-home-files\`) can only build on the
  x86_64-linux CI runner; verified locally that they block solely on the builder
  system, not on any touched assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdViJykVq9qAS1jsinng4N