### PR TITLE
fix(mlx): keep resident group when swap tier is non-empty

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -229,22 +229,29 @@ let
 
     models = allModels;
 
-    groups.mlx-models = {
-      swap = cfg.proxy.groupSwap;
-      exclusive = true;
-      persistent = true;
-      members = builtins.attrNames residentModels;
+    # Merge the two group definitions INSIDE `groups` (disjoint keys), not via
+    # an outer `//` on the whole config set. `//` is a shallow update: two
+    # sibling `groups.<name>` paths in `a // b` make `b`'s `groups` replace
+    # `a`'s wholesale, so the persistent resident group would vanish whenever
+    # the swap tier is non-empty — collapsing coder/OptiQ/gpt-oss into
+    # llama-swap's implicit swap default and evicting a resident on every
+    # cross-model request.
+    groups = {
+      mlx-models = {
+        swap = cfg.proxy.groupSwap;
+        exclusive = true;
+        persistent = true;
+        members = builtins.attrNames residentModels;
+      };
+    }
+    // lib.optionalAttrs (swapModels != { }) {
+      mlx-swap-models = {
+        swap = true;
+        exclusive = false;
+        persistent = false;
+        members = builtins.attrNames swapModels;
+      };
     };
-  }
-  // lib.optionalAttrs (swapModels != { }) {
-    groups.mlx-swap-models = {
-      swap = true;
-      exclusive = false;
-      persistent = false;
-      members = builtins.attrNames swapModels;
-    };
-  }
-  // {
 
     # Preload by role, not physical name. llama-swap resolves "default"
     # via the alias table on the registryModels entry.


### PR DESCRIPTION
## Root cause

`modules/mlx/default.nix` assembled the llama-swap `groups` with an **outer `//`**:

```nix
llamaSwapConfigAttrs = {
  ...
  groups.mlx-models = { persistent = true; members = attrNames residentModels; };
}
// lib.optionalAttrs (swapModels != { }) {
  groups.mlx-swap-models = { persistent = false; members = attrNames swapModels; };
}
// { hooks.on_startup.preload = cfg.preload; };
```

`//` is a **shallow** attrset update. Both operands define the `groups` attribute, so when `swapModels != {}` the second set's `groups` **replaces** the first's wholesale — the persistent `mlx-models` residents group is dropped from the generated config. Introduced when the single all-models group was split into resident + swap groups (#1127).

With only `mlx-swap-models` emitted, the role-registry residents fall into llama-swap's implicit swap default: requesting one resident **evicts** the others instead of the pair staying co-resident.

## Fix

Merge the two group definitions **inside** `groups` on disjoint keys (`mlx-models` + `mlx-swap-models`), so the `//` combines siblings within `groups` instead of overwriting the whole attribute. Minimal, no option/interface change. When the swap tier is empty, `optionalAttrs` still yields only the residents group.

## Proof — `nix eval` of the real jevans-ms generated config

Evaluated the built `llama-swap-config.json` for `darwinConfigurations.jevans-ms` (residents = coder + OptiQ tool-calling brain + gpt-oss default; swap tier = Qwen3-Next-80B + stock-35B).

**Before (main):** only the swap group survives
```json
{ "group_names": ["mlx-swap-models"] }
```

**After (this branch):** both groups present
```json
{
  "group_names": ["mlx-models", "mlx-swap-models"],
  "mlx-models":      { "persistent": true,  "swap": false, "exclusive": true,
                       "members": ["…Qwen3-Coder-30B…", "…Qwen3.6-35B…OptiQ-4bit", "…gpt-oss-120b…"] },
  "mlx-swap-models": { "persistent": false, "swap": true,  "exclusive": false,
                       "members": ["…Qwen3-Next-80B…Thinking-4bit", "…Qwen3.6-35B-A3B-4bit"] }
}
```

This restores the intended resident/swap split: the residents stay co-resident in a persistent group, the swap tier idle-loads on demand.

## Consumer impact / rebuild order

`nix-darwin` pins this input at a **locked rev** in `flake.lock` (not a branch-follow), so after this merges:
1. Bump `nix-darwin`'s `nix-ai` input to the merged rev (`nix flake update nix-ai`, or the `update-flake-input` dispatch), and merge that lock PR.
2. `darwin-rebuild switch` on jevans-ms regenerates `llama-swap.json` with both groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)