### PR TITLE
chore(renovate): use org renovate-nix preset; drop redundant nix-pins group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,12 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "local>dryvist/.github",
+    "local>dryvist/.github:renovate-nix",
   ],
-  "nix": {
-    "enabled": true,
-  },
   "packageRules": [
     {
       "description": "Group MLX Python packages into a single PR",
@@ -19,25 +15,6 @@
       "matchManagers": ["pep621"],
       "matchFileNames": ["orchestrator/**"],
       "groupName": "orchestrator-packages",
-    },
-    {
-      "description": [
-        "Batch all custom-regex version pins in lib/versions.nix into ONE scheduled,",
-        "auto-merged PR instead of one-PR-per-package. Renovate defaults to one PR per",
-        "dependency; without this, low-priority custom-regex pins (huggingface-hub,",
-        "browser-use, qwen-code, cclint, fabric, ...) each need their own branch/PR slot",
-        "and lose the twice-weekly window race to lock-file maintenance, starving for",
-        "weeks (huggingface-hub stuck at 1.15.0 from 2026-05 to 2026-07, which broke the",
-        "hf CLI). The mlx trio is re-grouped into 'mlx-core' by the rule below (later",
-        "packageRule wins on groupName), preserving its interlock and automerge:false.",
-        "Schedule is inherited from the org preset's Mon/Thu custom.regex rule; majors",
-        "are excluded so they still open individually under the 30-day major-default hold.",
-      ],
-      "matchManagers": ["custom.regex"],
-      "matchFileNames": ["lib/versions.nix"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "nix tool version pins",
-      "automerge": true,
     },
     {
       "description": [


### PR DESCRIPTION
chore(renovate): use org renovate-nix preset; drop redundant nix-pins group

Replace config:recommended + local>dryvist/.github + inline nix.enabled with the shared renovate-nix preset. Drop the "nix tool version pins" rule: the org grouping preset already batches all **/*.nix custom-regex minor/patch pins into one auto-merged PR, so lib/versions.nix is covered. Keeps the mlx-packages, orchestrator-packages, and mlx-core interlock groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA