### PR TITLE
feat(claude): set advisorModel to fable-5

### DIFF
--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -175,7 +175,7 @@ in
     };
 
     settings = {
-      advisorModel = "fable-5";
+      advisorModel = "fable";
       alwaysThinkingEnabled = true;
       cleanupPeriodDays = 180;
       env = import ./claude/settings-env.nix { inherit lib userConfig; };

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -175,6 +175,7 @@ in
     };
 
     settings = {
+      advisorModel = "fable-5";
       alwaysThinkingEnabled = true;
       cleanupPeriodDays = 180;
       env = import ./claude/settings-env.nix { inherit lib userConfig; };


### PR DESCRIPTION
Configures the advisorModel setting to use fable-5.