### PR TITLE
feat: unify agent MCP and skills config

### DIFF
--- a/docs/architecture/config-lifecycle.md
+++ b/docs/architecture/config-lifecycle.md
@@ -34,6 +34,7 @@ activation scripts via Nix store paths baked into the derivation at evaluation t
 - `modules/mlx/default.nix` → `pkgs.writeText "llama-swap-config.json"` (process management config)
 - `modules/claude-config.nix` (+ `nix-claude-code` flake input) → JSON derivation for settings merge
 - `modules/codex/settings.nix` → TOML derivation for config merge
+- `modules/qwen-code/settings.nix` → JSON derivation for config merge
 
 **Constraint**: The MLX model list in `llama-swap.json` is seeded from `programs.mlx.models`
 (declared in Nix). Models discovered at runtime by `mlx-discover` are added to the mutable
@@ -71,6 +72,7 @@ All `home.activation` entries and their targets:
 | `knownMarketplacesMerge` | `nix-claude-code` flake input (`modules/settings.nix`) | `~/.claude/plugins/known_marketplaces.json` | Synthetic marketplace registry (installLocation + source) |
 | `mergeAntigravitySettings` | `modules/antigravity-cli/settings.nix` | `~/.gemini/antigravity-cli/settings.json` | MCP servers, policies, folder trust |
 | `codexConfigMerge` | `modules/codex/settings.nix` | `~/.codex/config.toml` | Model, MCP servers, approval policy |
+| `qwenCodeSettingsMerge` | `modules/qwen-code/settings.nix` | `~/.qwen/settings.json` | Local provider routing, MCP servers |
 | `seedLlamaSwapConfig` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Copies Nix-generated seed; preserves runtime models |
 | `discoverMlxModels` | `modules/mlx/launchd.nix` | `~/.config/mlx/llama-swap.json` | Extends the seed with locally available MLX models (swap tier when configured) |
 
@@ -81,13 +83,13 @@ consuming tool writes to its own config file at runtime.
 
 | Pattern | Mechanism | Used When | Examples |
 |---------|-----------|-----------|---------|
-| **Nix store symlink** | `home.file` | Tool is read-only toward config | Plugin dirs, patterns, playbooks, copilot trusted folders |
-| **Activation deep-merge** | `home.activation` + shell script | Tool writes runtime state to config | `~/.claude.json`, `~/.gemini/antigravity-cli/settings.json`, `~/.codex/config.toml` |
+| **Nix store symlink** | `home.file` | Tool is read-only toward config | Plugin dirs, shared skills, patterns, playbooks, copilot trusted folders |
+| **Activation deep-merge** | `home.activation` + shell script | Tool writes runtime state to config | `~/.claude.json`, `~/.gemini/antigravity-cli/settings.json`, `~/.codex/config.toml`, `~/.qwen/settings.json` |
 | **Activation seed + runtime extension** | `seed-config.py` + `mlx-discover` | Config is both Nix-seeded and runtime-extensible | `~/.config/mlx/llama-swap.json` |
 
-### Why `home.file` Symlinks Break for Claude/Antigravity/Codex
+### Why `home.file` Symlinks Break for Agent Settings
 
-Claude Code, Antigravity, and Codex all write to their config files at runtime:
+Claude Code, Antigravity, Codex, and Qwen all write to their config files at runtime:
 authentication tokens, session state, user preferences set via `claude config set`, etc.
 
 A `home.file` symlink points into `/nix/store/` which is world-readable but **not
@@ -114,7 +116,7 @@ These tools refresh specific files between rebuilds:
 graph TD
     subgraph BuildTime["Build Time — /nix/store/ (immutable)"]
         NS1["llama-swap-config.json derivation"]
-        NS2["claude settings JSON derivation"]
+        NS2["agent settings derivations\nJSON/TOML"]
         NS3["plugin/skill/rule Nix store paths"]
     end
 
@@ -122,17 +124,23 @@ graph TD
         A1["seedLlamaSwapConfig\n→ ~/.config/mlx/llama-swap.json"]
         A2["claudeJsonMerge\n→ ~/.claude.json"]
         A3["claudeSettingsMerge\n→ ~/.claude/settings.json"]
+        A4["codexConfigMerge\n→ ~/.codex/config.toml"]
+        A5["qwenCodeSettingsMerge\n→ ~/.qwen/settings.json"]
     end
 
     subgraph Runtime["Runtime — mutable user files"]
         R1["~/.config/mlx/llama-swap.json\n(mlx-discover extends)"]
         R2["~/.claude.json\n(Claude Code writes session state)"]
         R3["~/.claude/settings.json\n(Claude Code writes preferences)"]
+        R4["~/.codex/config.toml\n(Codex writes runtime state)"]
+        R5["~/.qwen/settings.json\n(Qwen writes runtime state)"]
     end
 
     subgraph Symlinks["home.file Symlinks — read-only"]
         S1["~/.claude/plugins/marketplaces/"]
         S2["~/.claude/commands/, agents/, skills/, rules/"]
+        S5["~/.agents/skills\nshared agent skill source"]
+        S6["~/.codex/skills, ~/.qwen/skills,\n~/.gemini/*/skills"]
         S3["~/.config/fabric/patterns/"]
         S4["~/Maestro/ playbooks"]
     end
@@ -140,8 +148,11 @@ graph TD
     NS1 --> A1 --> R1
     NS2 --> A2 --> R2
     NS2 --> A3 --> R3
+    NS2 --> A4 --> R4
+    NS2 --> A5 --> R5
     NS3 --> S1
     NS3 --> S2
+    NS3 --> S5 --> S6
     NS3 --> S3
     NS3 --> S4
 ```

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -14,6 +14,7 @@ graph TD
         CC["Claude Code"]
         GEM["Antigravity CLI"]
         CDX["Codex CLI"]
+        QWEN["Qwen Code"]
         COP["Copilot"]
     end
 
@@ -58,6 +59,7 @@ Proxmox homelab (see the homelab IaC repos).
 | Claude Code | `modules/claude-config.nix` | Desktop app | Primary AI coding assistant | `~/.claude/settings.json`, `~/.claude.json` |
 | Antigravity CLI | `modules/antigravity-cli/` | CLI | Google Antigravity assistant | `~/.gemini/antigravity-cli/settings.json` |
 | Codex CLI | `modules/codex/` | CLI | OpenAI coding assistant | `~/.codex/config.toml` |
+| Qwen Code | `modules/qwen-code/` | CLI | Local-first coding assistant | `~/.qwen/settings.json` |
 | GitHub Copilot CLI | `modules/copilot.nix` | CLI | Trusted folder configuration | `~/.copilot/config.json` |
 | Bifrost | Proxmox homelab (`ansible-proxmox-apps`, relocating) | HTTPS (Traefik) | Multi-provider AI gateway | Doppler (provider keys) |
 | MLX / llama-swap | `modules/mlx/` | HTTP :11434 | Local Apple Silicon inference | `~/.config/mlx/llama-swap.json` |
@@ -67,8 +69,9 @@ Proxmox homelab (see the homelab IaC repos).
 ## MCP Server Connectivity
 
 The MCP server catalog (`modules/mcp/catalog.nix`) is exposed by the dedicated
-MCP module as `programs.aiMcp.servers`. Claude, Antigravity, and Codex each
-normalize that shared option differently via their own settings modules.
+MCP module as `programs.aiMcp.servers`. The global cross-agent profile is
+`programs.aiMcp.enabledServers`; Claude, Antigravity, Codex, and Qwen each
+normalize that same option differently via their own settings modules.
 
 ```mermaid
 graph LR
@@ -77,35 +80,34 @@ graph LR
     MCPCAT -->|normalized for Claude| CSETTINGS["modules/claude-config.nix\n→ ~/.claude.json"]
     MCPCAT -->|normalized for Antigravity| GSETTINGS["modules/antigravity-cli/settings.nix\n→ ~/.gemini/antigravity-cli/settings.json"]
     MCPCAT -->|normalized for Codex| DSETTINGS["modules/codex/settings.nix\n→ ~/.codex/config.toml"]
+    MCPCAT -->|normalized for Qwen| QSETTINGS["modules/qwen-code/settings.nix\n→ ~/.qwen/settings.json"]
 ```
 
-### Shared MCP Servers (all three CLI tools)
+### Global Cross-Agent MCP Servers
 
 | Server | Transport | Auth | Notes |
 |--------|-----------|------|-------|
-| `everything`, `fetch`, `filesystem`, `git`, `memory` | stdio (bunx) | None | Official Anthropic servers |
-| `sequentialthinking`, `docker` | stdio (bunx) | None | Official Anthropic servers |
+| `apple-events` | stdio (bunx) | macOS TCC prompts | Reminders and Calendar |
+| `codex` | stdio (binary) | Codex auth | OpenAI Codex CLI server |
+| `fabric` | stdio (uvx) | Fabric CLI setup | Pattern execution |
+| `huggingface` | stdio (uvx) | `HF_TOKEN` from Keychain | Hub/model/dataset search |
 | `time` | stdio (uvx) | None | Official maintained Python server |
-| `aws` | stdio (bunx) | IAM/STS env vars | AWS KB retrieval |
-| `terraform` | stdio (binary) | None | nixpkgs binary |
-| `cribl` | HTTP :30030 | None (K8s internal) | Log pipeline |
+| `splunk` | stdio (doppler-mcp + mcp-remote) | Doppler runtime injection | Splunk MCP Server app |
 
-### Claude-Only MCP Servers
+### Plugin-Managed MCP Servers
 
 | Server | Transport | Notes |
 |--------|-----------|-------|
-| `huggingface` | stdio (uvx) | `HF_TOKEN` from Keychain |
-| `fabric` | stdio (uvx) | Pattern execution |
-| `google-workspace` | stdio (doppler-mcp + uvx) | Gmail/Drive/Calendar; requires OAuth |
-| `codex` | stdio (binary) | OpenAI Codex CLI server |
-| `splunk` | stdio (doppler-mcp + mcp-remote) | Defined in `nix-darwin` repo |
 | `context7` | plugin-managed | Lifecycle owned by `context7` plugin |
 
-### Disabled Servers (configured but off)
+### Disabled Or Excluded Catalog Servers
 
-`brave-search`, `cloudflare`, `exa`, `firecrawl`, `github`, `google-maps`, `postgresql`,
-`puppeteer`, `sentry`, `slack`, `sqlite` — all require API keys not currently configured.
-Enable by overriding `programs.aiMcp.servers.<name>.disabled` and adding the key to Doppler.
+`brave-search`, `cloudflare`, `cribl`, `docker`, `everything`, `exa`, `fetch`,
+`filesystem`, `firecrawl`, `git`, `github`, `google-maps`, `google-workspace`,
+`monarch`, `postgresql`, `puppeteer`, `sentry`, `slack`, `sqlite`, `terraform`,
+and `unifi` stay out of the global cross-agent profile by default. Enable by
+removing a global exclusion or overriding `programs.aiMcp.servers.<name>.disabled`
+and adding any required runtime secret injection.
 
 ## Port Allocation
 

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -87,7 +87,7 @@ graph LR
 
 | Server | Transport | Auth | Notes |
 |--------|-----------|------|-------|
-| `apple-events` | stdio (bunx) | macOS TCC prompts | Reminders and Calendar |
+| `apple-events` | stdio (bunx) | macOS TCC prompts | Reminders and Calendar; Darwin-only |
 | `codex` | stdio (binary) | Codex auth | OpenAI Codex CLI server |
 | `fabric` | stdio (uvx) | Fabric CLI setup | Pattern execution |
 | `huggingface` | stdio (uvx) | `HF_TOKEN` from Keychain | Hub/model/dataset search |

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -162,10 +162,15 @@ in
   qwen-code = {
     imports = [
       ../modules/ai-stack
+      ../modules/mcp
+      ../modules/agent-skills
       ../modules/qwen-code
     ];
     _module.args = {
-      inherit ai-assistant-instructions;
+      inherit
+        ai-assistant-instructions
+        marketplaceInputs
+        ;
     };
   };
 

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -102,12 +102,12 @@ in
   };
 
   mcp = {
-    imports = [ ../modules/mcp ];
+    imports = [ ../modules/mcp/module.nix ];
   };
 
   codex = {
     imports = [
-      ../modules/mcp
+      ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/codex
     ];
@@ -122,7 +122,7 @@ in
 
   antigravity-cli = {
     imports = [
-      ../modules/mcp
+      ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/antigravity-cli
     ];
@@ -137,7 +137,7 @@ in
 
   antigravity-ide = {
     imports = [
-      ../modules/mcp
+      ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/antigravity-ide
     ];
@@ -162,7 +162,7 @@ in
   qwen-code = {
     imports = [
       ../modules/ai-stack
-      ../modules/mcp
+      ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/qwen-code
     ];

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -1,5 +1,5 @@
 # Nix quality checks - thin aggregator
-# Individual check groups live in lib/checks/{lint,claude,agent-skills,codex,antigravity-cli,mlx,fabric}.nix
+# Individual check groups live in lib/checks/{lint,claude,agent-skills,codex,antigravity-cli,mcp,mlx,fabric}.nix
 {
   pkgs,
   src,
@@ -50,6 +50,7 @@ in
 // (import ./checks/agent-skills.nix { inherit pkgs hmConfig; })
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })
 // (import ./checks/antigravity-cli.nix { inherit pkgs hmConfig; })
+// (import ./checks/mcp.nix { inherit pkgs hmConfig; })
 // (import ./checks/autonomous-profile.nix { inherit pkgs; })
 // (import ./checks/mlx.nix { inherit pkgs hmConfig; })
 // (import ./checks/fabric.nix {

--- a/lib/checks/agent-skills.nix
+++ b/lib/checks/agent-skills.nix
@@ -65,7 +65,11 @@ in
         n: !(builtins.hasAttr "source" hmConfig.config.home.file.${n})
       ) managedSkillEntries;
       skillFileSources = builtins.filter (
-        n: pkgs.lib.hasSuffix "/SKILL.md" (toString hmConfig.config.home.file.${n}.source)
+        n:
+        let
+          entry = hmConfig.config.home.file.${n};
+        in
+        entry ? source && pkgs.lib.hasSuffix "/SKILL.md" (toString entry.source)
       ) managedSkillEntries;
     in
     assert keepFile != "" || throw "Agent Skills .agents/.keep file is empty (module not loaded)";

--- a/lib/checks/agent-skills.nix
+++ b/lib/checks/agent-skills.nix
@@ -51,8 +51,21 @@ in
   agent-skills-home-files =
     let
       keepFile = hmConfig.config.home.file.".agents/.keep".text;
-      missingSkillFiles = builtins.filter (
-        n: !(builtins.pathExists "${hmConfig.config.home.file.${n}.source}/SKILL.md")
+      sharedSkillLinks = [
+        ".codex/skills"
+        ".gemini/antigravity/skills"
+        ".gemini/antigravity-cli/skills"
+        ".gemini/config/skills"
+        ".qwen/skills"
+      ];
+      missingSharedLinks = builtins.filter (
+        n: !(builtins.hasAttr n hmConfig.config.home.file)
+      ) sharedSkillLinks;
+      missingSkillSources = builtins.filter (
+        n: !(builtins.hasAttr "source" hmConfig.config.home.file.${n})
+      ) managedSkillEntries;
+      skillFileSources = builtins.filter (
+        n: pkgs.lib.hasSuffix "/SKILL.md" (toString hmConfig.config.home.file.${n}.source)
       ) managedSkillEntries;
     in
     assert keepFile != "" || throw "Agent Skills .agents/.keep file is empty (module not loaded)";
@@ -61,7 +74,13 @@ in
       legacySkillFileEntries == [ ]
       || throw "Agent Skills must deploy skill directories, not SKILL.md files: ${builtins.toJSON legacySkillFileEntries}";
     assert
-      missingSkillFiles == [ ]
-      || throw "Agent Skills directory entries missing SKILL.md: ${builtins.toJSON missingSkillFiles}";
+      missingSkillSources == [ ]
+      || throw "Agent Skills directory entries missing source: ${builtins.toJSON missingSkillSources}";
+    assert
+      skillFileSources == [ ]
+      || throw "Agent Skills must source skill directories, not SKILL.md files: ${builtins.toJSON skillFileSources}";
+    assert
+      missingSharedLinks == [ ]
+      || throw "Agent Skills shared links missing: ${builtins.toJSON missingSharedLinks}";
     helpers.mkMarker "check-agent-skills-home-files" "Agent Skills home.file wiring: ${toString (builtins.length managedSkillEntries)} managed skill entries";
 }

--- a/lib/checks/antigravity-cli.nix
+++ b/lib/checks/antigravity-cli.nix
@@ -21,6 +21,7 @@ in
       "extensions"
       "gemmaModelRouter"
       "hooks"
+      "mcpServerNames"
       "sandbox"
       "sandboxAllowedPaths"
       "sandboxAllowedPathsMerged"
@@ -52,7 +53,7 @@ in
       {
         name = "antigravity-cli.excludedMcpServers.length";
         actual = builtins.length cfg.excludedMcpServers;
-        expected = 11;
+        expected = 0;
       }
       {
         name = "antigravity-cli.extensions";

--- a/lib/checks/codex.nix
+++ b/lib/checks/codex.nix
@@ -21,6 +21,7 @@ in
       "modelProvider"
       "modelReasoningEffort"
       "modelVerbosity"
+      "mcpServerNames"
       "planModeReasoningEffort"
       "projectDocFallbackFilenames"
       "reviewModel"
@@ -93,7 +94,7 @@ in
       {
         name = "codex.excludedMcpServers.length";
         actual = builtins.length cfg.excludedMcpServers;
-        expected = 11;
+        expected = 0;
       }
       {
         name = "codex.trustedProjectDirs";

--- a/lib/checks/mcp.nix
+++ b/lib/checks/mcp.nix
@@ -4,13 +4,13 @@ let
   helpers = import ./helpers.nix { inherit pkgs; };
   cfg = hmConfig.config.programs.aiMcp;
   expectedGlobalServers = [
-    "apple-events"
     "codex"
     "fabric"
     "huggingface"
     "splunk"
     "time"
-  ];
+  ]
+  ++ pkgs.lib.optional pkgs.stdenv.isDarwin "apple-events";
   missingGlobalServers = builtins.filter (
     name: !(builtins.elem name cfg.enabledServerNames)
   ) expectedGlobalServers;

--- a/lib/checks/mcp.nix
+++ b/lib/checks/mcp.nix
@@ -1,0 +1,40 @@
+# Shared MCP profile regression tests
+{ pkgs, hmConfig }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+  cfg = hmConfig.config.programs.aiMcp;
+  expectedGlobalServers = [
+    "apple-events"
+    "codex"
+    "fabric"
+    "huggingface"
+    "splunk"
+    "time"
+  ];
+  missingGlobalServers = builtins.filter (
+    name: !(builtins.elem name cfg.enabledServerNames)
+  ) expectedGlobalServers;
+  rendererNames = {
+    claude = builtins.attrNames hmConfig.config.programs.claude.mcpServers;
+    codex = hmConfig.config.programs.codex.mcpServerNames;
+    antigravity-cli = hmConfig.config.programs.antigravity-cli.mcpServerNames;
+    antigravity-ide = hmConfig.config.programs.antigravity-ide.mcpServerNames;
+    qwen-code = hmConfig.config.programs.qwen-code.mcpServerNames;
+  };
+  rendererMismatches = builtins.filter (name: rendererNames.${name} != cfg.enabledServerNames) (
+    builtins.attrNames rendererNames
+  );
+in
+{
+  shared-mcp-global-profile =
+    assert
+      missingGlobalServers == [ ]
+      || throw "Shared MCP profile missing global servers: ${builtins.toJSON missingGlobalServers}; actual=${builtins.toJSON cfg.enabledServerNames}";
+    helpers.mkMarker "check-shared-mcp-global-profile" "Shared MCP profile includes ${toString (builtins.length expectedGlobalServers)} expected global servers";
+
+  shared-mcp-renderer-parity =
+    assert
+      rendererMismatches == [ ]
+      || throw "MCP renderer parity mismatch: ${builtins.toJSON rendererMismatches}; shared=${builtins.toJSON cfg.enabledServerNames}; renderers=${builtins.toJSON rendererNames}";
+    helpers.mkMarker "check-shared-mcp-renderer-parity" "Shared MCP renderer parity verified for Claude, Codex, Antigravity CLI/IDE, and Qwen";
+}

--- a/modules/agent-skills/components.nix
+++ b/modules/agent-skills/components.nix
@@ -64,6 +64,7 @@ in
         cleanup_skill_tree "${homeDir}/.agents/skills"
         cleanup_skill_tree "${homeDir}/.codex/skills"
         cleanup_skill_tree "${homeDir}/.antigravity-cli/skills"
+        cleanup_skill_tree "${homeDir}/.qwen/skills"
       '';
 
       file = {
@@ -76,6 +77,7 @@ in
           config.lib.file.mkOutOfStoreSymlink "${homeDir}/.agents/skills";
         ".gemini/config/skills".source = config.lib.file.mkOutOfStoreSymlink "${homeDir}/.agents/skills";
         ".codex/skills".source = config.lib.file.mkOutOfStoreSymlink "${homeDir}/.agents/skills";
+        ".qwen/skills".source = config.lib.file.mkOutOfStoreSymlink "${homeDir}/.agents/skills";
       }
       // mkSkillFiles cfg.fromFlakeInputs
       // mkLocalSkills cfg.local;

--- a/modules/antigravity-cli/options.nix
+++ b/modules/antigravity-cli/options.nix
@@ -229,20 +229,15 @@ in
     # MCP servers to exclude from shared definitions
     excludedMcpServers = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [
-        "cloudflare"
-        "cribl"
-        "docker"
-        "everything"
-        "exa"
-        "fetch"
-        "filesystem"
-        "firecrawl"
-        "git"
-        "github"
-        "terraform"
-      ];
-      description = "MCP servers to exclude from the shared definitions";
+      default = [ ];
+      description = "Additional MCP servers to exclude from the shared cross-agent profile for Antigravity only.";
+    };
+
+    mcpServerNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Names of MCP servers emitted to Antigravity settings.json.";
     };
   };
 }

--- a/modules/antigravity-cli/settings.nix
+++ b/modules/antigravity-cli/settings.nix
@@ -50,7 +50,7 @@ let
       (
         lib.filterAttrs (
           name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-        ) config.programs.aiMcp.servers
+        ) config.programs.aiMcp.enabledServers
       );
 
   # Policy Engine: generate TOML rules from shared permissions
@@ -136,8 +136,11 @@ in
     # succeeds even when programs.antigravity-cli.enable = false. Values are derived from
     # pure Nix expressions (no activation-time side effects).
     {
-      programs.antigravity-cli.contextFileNames = settings.context.fileName;
-      programs.antigravity-cli.sandboxAllowedPathsMerged = mergedSandboxAllowedPaths;
+      programs.antigravity-cli = {
+        contextFileNames = settings.context.fileName;
+        mcpServerNames = lib.attrNames mcpServers;
+        sandboxAllowedPathsMerged = mergedSandboxAllowedPaths;
+      };
     }
     (lib.mkIf cfg.enable {
       home = {

--- a/modules/antigravity-ide/default.nix
+++ b/modules/antigravity-ide/default.nix
@@ -30,7 +30,7 @@ let
       (
         lib.filterAttrs (
           name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-        ) config.programs.aiMcp.servers
+        ) config.programs.aiMcp.enabledServers
       );
 
   mcpConfig = {
@@ -80,103 +80,103 @@ in
 
     excludedMcpServers = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [
-        "cloudflare"
-        "cribl"
-        "docker"
-        "everything"
-        "exa"
-        "fetch"
-        "filesystem"
-        "firecrawl"
-        "git"
-        "github"
-        "terraform"
-      ];
-      description = "MCP servers to exclude from the shared definitions";
+      default = [ ];
+      description = "Additional MCP servers to exclude from the shared cross-agent profile for Antigravity IDE only.";
+    };
+
+    mcpServerNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Names of MCP servers emitted to Antigravity IDE mcp_config.json.";
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    home = {
-      activation.mergeAntigravityIdeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        # Merge global settings for Antigravity IDE (VS Code-based settings.json)
-        settings_file="${homeDir}/Library/Application Support/Antigravity/User/settings.json"
-        if [ -f "$settings_file" ]; then
+  config = lib.mkMerge [
+    {
+      programs.antigravity-ide.mcpServerNames = lib.attrNames mcpServers;
+    }
+    (lib.mkIf cfg.enable {
+      home = {
+        activation.mergeAntigravityIdeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          # Merge global settings for Antigravity IDE (VS Code-based settings.json)
+          settings_file="${homeDir}/Library/Application Support/Antigravity/User/settings.json"
+          if [ -f "$settings_file" ]; then
+            export PATH="${pkgs.jq}/bin:$PATH"
+            echo "-> Merging global settings for Antigravity IDE..."
+            # Update or add the autoExecutionPolicy setting
+            $DRY_RUN_CMD jq --arg policy "always" '. + {"antigravity.agent.terminal.autoExecutionPolicy": $policy}' "$settings_file" > "$settings_file.tmp" \
+              && $DRY_RUN_CMD mv "$settings_file.tmp" "$settings_file"
+          fi
+
+          # Merge mcp_config.json
           export PATH="${pkgs.jq}/bin:$PATH"
-          echo "-> Merging global settings for Antigravity IDE..."
-          # Update or add the autoExecutionPolicy setting
-          $DRY_RUN_CMD jq --arg policy "always" '. + {"antigravity.agent.terminal.autoExecutionPolicy": $policy}' "$settings_file" > "$settings_file.tmp" \
-            && $DRY_RUN_CMD mv "$settings_file.tmp" "$settings_file"
-        fi
+          $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+            "${mcpConfigJson}" \
+            "${homeDir}/.gemini/config/mcp_config.json"
 
-        # Merge mcp_config.json
-        export PATH="${pkgs.jq}/bin:$PATH"
-        $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
-          "${mcpConfigJson}" \
-          "${homeDir}/.gemini/config/mcp_config.json"
-
-        # Merge globalPermissionGrants in ~/.gemini/config/config.json
-        gemini_config="${homeDir}/.gemini/config/config.json"
-        if [ -f "$gemini_config" ]; then
-          echo "-> Merging global permission grants in ~/.gemini/config/config.json..."
-          $DRY_RUN_CMD jq \
-            --argjson new_grants '[
-              "read_file(${homeDir}/.gemini)",
-              "write_file(${homeDir}/.gemini)",
-              "read_file(${homeDir}/.antigravity)",
-              "write_file(${homeDir}/.antigravity)",
-              "read_file(${homeDir}/.config)",
-              "read_file(${homeDir}/.claude)",
-              "write_file(${homeDir}/.config/ai-stack)"
-            ]' \
-            '.userSettings.globalPermissionGrants.allow = (((.userSettings.globalPermissionGrants.allow // []) + $new_grants | unique) - ["write_file(${homeDir}/.config)", "write_file(${homeDir}/.claude)"])' \
-            "$gemini_config" > "$gemini_config.tmp" \
-            && $DRY_RUN_CMD mv "$gemini_config.tmp" "$gemini_config"
-        else
-          echo "-> Creating ~/.gemini/config/config.json with global permission grants..."
-          $DRY_RUN_CMD mkdir -p "$(dirname "$gemini_config")"
-          $DRY_RUN_CMD jq -n \
-            --argjson new_grants '[
-              "read_file(${homeDir}/.gemini)",
-              "write_file(${homeDir}/.gemini)",
-              "read_file(${homeDir}/.antigravity)",
-              "write_file(${homeDir}/.antigravity)",
-              "read_file(${homeDir}/.config)",
-              "read_file(${homeDir}/.claude)",
-              "write_file(${homeDir}/.config/ai-stack)"
-            ]' \
-            '{userSettings: {globalPermissionGrants: {allow: $new_grants}}}' > "$gemini_config"
-        fi
-
-        # Update all project config JSON files under ~/.gemini/config/projects/
-        projects_dir="${homeDir}/.gemini/config/projects"
-        if [ -d "$projects_dir" ]; then
-          echo "-> Elevating permissions for all Antigravity projects..."
-          # Iterate over all json files in ~/.gemini/config/projects/
-          find "$projects_dir" -name "*.json" -print0 | while IFS= read -r -d $'\0' project_file; do
-            # We want to merge the new settings and allowed command list
-            # We construct a jq script to update settings and permissionGrants.permissionGrants.allow
-            # We combine and deduplicate them to be safe
+          # Merge globalPermissionGrants in ~/.gemini/config/config.json
+          gemini_config="${homeDir}/.gemini/config/config.json"
+          if [ -f "$gemini_config" ]; then
+            echo "-> Merging global permission grants in ~/.gemini/config/config.json..."
             $DRY_RUN_CMD jq \
-              --arg fileAccessPolicy "${cfg.fileAccessPolicy}" \
-              --arg internetPolicy "${cfg.internetPolicy}" \
-              --arg autoExecutionPolicy "${cfg.autoExecutionPolicy}" \
-              --arg artifactReviewMode "${cfg.artifactReviewMode}" \
-              --argjson allowedCommands '${allowedCommandsJson}' \
-              '
-              .settings.fileAccessPolicy = $fileAccessPolicy |
-              .settings.internetPolicy = $internetPolicy |
-              .settings.autoExecutionPolicy = $autoExecutionPolicy |
-              .settings.artifactReviewMode = $artifactReviewMode |
-              (.permissionGrants.permissionGrants.allow // []) as $existing_allow |
-              .permissionGrants.permissionGrants.allow = ($existing_allow + $allowedCommands | unique)
-              ' \
-              "$project_file" > "$project_file.tmp" \
-              && $DRY_RUN_CMD mv "$project_file.tmp" "$project_file"
-          done
-        fi
-      '';
-    };
-  };
+              --argjson new_grants '[
+                "read_file(${homeDir}/.gemini)",
+                "write_file(${homeDir}/.gemini)",
+                "read_file(${homeDir}/.antigravity)",
+                "write_file(${homeDir}/.antigravity)",
+                "read_file(${homeDir}/.config)",
+                "read_file(${homeDir}/.claude)",
+                "write_file(${homeDir}/.config/ai-stack)"
+              ]' \
+              '.userSettings.globalPermissionGrants.allow = (((.userSettings.globalPermissionGrants.allow // []) + $new_grants | unique) - ["write_file(${homeDir}/.config)", "write_file(${homeDir}/.claude)"])' \
+              "$gemini_config" > "$gemini_config.tmp" \
+              && $DRY_RUN_CMD mv "$gemini_config.tmp" "$gemini_config"
+          else
+            echo "-> Creating ~/.gemini/config/config.json with global permission grants..."
+            $DRY_RUN_CMD mkdir -p "$(dirname "$gemini_config")"
+            $DRY_RUN_CMD jq -n \
+              --argjson new_grants '[
+                "read_file(${homeDir}/.gemini)",
+                "write_file(${homeDir}/.gemini)",
+                "read_file(${homeDir}/.antigravity)",
+                "write_file(${homeDir}/.antigravity)",
+                "read_file(${homeDir}/.config)",
+                "read_file(${homeDir}/.claude)",
+                "write_file(${homeDir}/.config/ai-stack)"
+              ]' \
+              '{userSettings: {globalPermissionGrants: {allow: $new_grants}}}' > "$gemini_config"
+          fi
+
+          # Update all project config JSON files under ~/.gemini/config/projects/
+          projects_dir="${homeDir}/.gemini/config/projects"
+          if [ -d "$projects_dir" ]; then
+            echo "-> Elevating permissions for all Antigravity projects..."
+            # Iterate over all json files in ~/.gemini/config/projects/
+            find "$projects_dir" -name "*.json" -print0 | while IFS= read -r -d $'\0' project_file; do
+              # We want to merge the new settings and allowed command list
+              # We construct a jq script to update settings and permissionGrants.permissionGrants.allow
+              # We combine and deduplicate them to be safe
+              $DRY_RUN_CMD jq \
+                --arg fileAccessPolicy "${cfg.fileAccessPolicy}" \
+                --arg internetPolicy "${cfg.internetPolicy}" \
+                --arg autoExecutionPolicy "${cfg.autoExecutionPolicy}" \
+                --arg artifactReviewMode "${cfg.artifactReviewMode}" \
+                --argjson allowedCommands '${allowedCommandsJson}' \
+                '
+                .settings.fileAccessPolicy = $fileAccessPolicy |
+                .settings.internetPolicy = $internetPolicy |
+                .settings.autoExecutionPolicy = $autoExecutionPolicy |
+                .settings.artifactReviewMode = $artifactReviewMode |
+                (.permissionGrants.permissionGrants.allow // []) as $existing_allow |
+                .permissionGrants.permissionGrants.allow = ($existing_allow + $allowedCommands | unique)
+                ' \
+                "$project_file" > "$project_file.tmp" \
+                && $DRY_RUN_CMD mv "$project_file.tmp" "$project_file"
+            done
+          fi
+        '';
+      };
+    })
+  ];
 }

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -214,41 +214,7 @@ in
 
     # MCP Servers - deployed to ~/.claude.json via home.activation.
     # Shared definitions are owned by modules/mcp and rendered per-client here.
-    # Per-host overrides (disables + splunk) were previously in
-    # nix-darwin/hosts/macbook-m4/home.nix; moved here as part of the
-    # nix-claude-code migration so Claude config lives in nix-ai.
-    mcpServers =
-      let
-        fromCatalog = lib.mapAttrs (_: normalizeClaudeMcpServer) config.programs.aiMcp.servers;
-        # Disable MCP servers that duplicate built-in tools, are demo/test,
-        # or are project-specific. Definitions stay (for type validation);
-        # disabled = true excludes them from ~/.claude.json. Project-specific
-        # servers re-enable per-project via .mcp.json.
-        disabledServers = lib.genAttrs [
-          "everything" # Demo/test — not useful in production
-          "filesystem" # Duplicates built-in Read/Write/Glob/Edit tools
-          "fetch" # Duplicates built-in WebFetch tool
-          "git" # Duplicates built-in git via Bash(git:*)
-          "github" # Duplicates github@claude-plugins-official plugin
-          "cribl" # Project-specific — re-enable per-project
-          "terraform" # Project-specific — re-enable per-project
-          "cloudflare" # Not actively used — disable until needed
-          "exa" # Not actively used — disable until needed
-          "firecrawl" # Not actively used — disable until needed
-          "docker" # Not actively used — disable until needed
-        ] (name: (fromCatalog.${name} or { }) // { disabled = true; });
-      in
-      fromCatalog
-      // disabledServers
-      // {
-        # Splunk MCP via doppler-mcp wrapper (TLS bypass for self-signed cert
-        # is scoped inside splunk-mcp-connect, not here, to avoid leaking
-        # NODE_TLS_REJECT_UNAUTHORIZED to doppler-mcp).
-        splunk = {
-          command = "doppler-mcp";
-          args = [ "splunk-mcp-connect" ];
-        };
-      };
+    mcpServers = lib.mapAttrs (_: normalizeClaudeMcpServer) config.programs.aiMcp.enabledServers;
 
     statusline = {
       enable = true;

--- a/modules/codex/options.nix
+++ b/modules/codex/options.nix
@@ -120,20 +120,15 @@ in
     # MCP servers to exclude from shared definitions
     excludedMcpServers = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [
-        "cloudflare"
-        "cribl"
-        "docker"
-        "everything"
-        "exa"
-        "fetch"
-        "filesystem"
-        "firecrawl"
-        "git"
-        "github"
-        "terraform"
-      ];
-      description = "MCP servers to exclude from the shared definitions";
+      default = [ ];
+      description = "Additional MCP servers to exclude from the shared cross-agent profile for Codex only.";
+    };
+
+    mcpServerNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Names of MCP servers emitted to Codex config.toml.";
     };
   };
 }

--- a/modules/codex/settings.nix
+++ b/modules/codex/settings.nix
@@ -77,7 +77,7 @@ let
   mcpServers = lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeMcpServer server)) (
     lib.filterAttrs (
       name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-    ) config.programs.aiMcp.servers
+    ) config.programs.aiMcp.enabledServers
   );
 
   optionalValue = key: value: lib.optionalAttrs (value != null) { ${key} = value; };
@@ -121,7 +121,12 @@ in
   config = lib.mkMerge [
     # Read-only introspection option set unconditionally so module evaluation
     # succeeds even when programs.codex.enable = false.
-    { programs.codex.projectDocFallbackFilenames = configAttrs.project_doc_fallback_filenames; }
+    {
+      programs.codex = {
+        projectDocFallbackFilenames = configAttrs.project_doc_fallback_filenames;
+        mcpServerNames = lib.attrNames mcpServers;
+      };
+    }
     (lib.mkIf cfg.enable {
       home = {
         activation.codexConfigMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''

--- a/modules/common/render-autonomous.nix
+++ b/modules/common/render-autonomous.nix
@@ -27,7 +27,7 @@ let
   formatters = import ./formatters.nix { inherit lib; };
   inherit (profiles.autonomous) residualDeny;
 
-  # The one permission set all three tools inherit from.
+  # The one permission set all autonomous renderers inherit from.
   residualDenyPermissions = {
     allow = [ ];
     ask = [ ];

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -92,7 +92,6 @@ in
     ./antigravity-cli
     ./fabric
     ./maestro
-    ./mcp
     ./mcp/module.nix
     ./mlx
     ./qwen-code

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -6,6 +6,10 @@ The default cross-agent profile is `programs.aiMcp.enabledServers`. Claude,
 Codex, Antigravity, and Qwen consume that one option and render it into their
 own configuration formats during every `darwin-rebuild switch`.
 
+Standalone consumers should import `modules/mcp/module.nix`, not
+`modules/mcp/default.nix`; the runtime module includes the shared option catalog
+and installs helper binaries such as `doppler-mcp` and `splunk-mcp-connect`.
+
 **Nix is the sole manager of user-scoped MCP servers.** Any entries added manually
 through client CLIs may be overwritten on the next rebuild.
 
@@ -56,6 +60,8 @@ the cross-agent profile when either:
 
 - `programs.aiMcp.servers.<name>.disabled = true`
 - `<name>` is listed in `programs.aiMcp.excludedServers`
+- the server is platform-specific and incompatible with the current host
+  (`apple-events` is Darwin-only)
 
 To disable a server everywhere, prefer the shared profile:
 

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -2,8 +2,9 @@
 
 MCP server definitions are owned by the `modules/mcp` Home Manager module. The
 shared catalog lives in `catalog.nix` and is exposed as `programs.aiMcp.servers`.
-Claude, Codex, and Antigravity consume that option and render it into their own
-configuration formats during every `darwin-rebuild switch`.
+The default cross-agent profile is `programs.aiMcp.enabledServers`. Claude,
+Codex, Antigravity, and Qwen consume that one option and render it into their
+own configuration formats during every `darwin-rebuild switch`.
 
 **Nix is the sole manager of user-scoped MCP servers.** Any entries added manually
 through client CLIs may be overwritten on the next rebuild.
@@ -48,18 +49,37 @@ my-server = {
 };
 ```
 
-## Enabling / Disabling Servers
+## Global Profile / Per-Agent Exclusions
 
-All servers are enabled by default (`disabled = false` is the module system
-default). To disable a server, set `disabled = true`:
+The catalog is intentionally wider than the default profile. Servers stay out of
+the cross-agent profile when either:
+
+- `programs.aiMcp.servers.<name>.disabled = true`
+- `<name>` is listed in `programs.aiMcp.excludedServers`
+
+To disable a server everywhere, prefer the shared profile:
 
 ```nix
-programs.aiMcp.servers.postgresql.disabled = true;
+programs.aiMcp.excludedServers = [ "postgresql" ];
 ```
 
-To enable a disabled server without editing `catalog.nix`, override via the
-module system. Because the catalog uses plain assignments (priority 100), the
-override must use `lib.mkForce` to win the merge:
+To keep a server in the shared profile but omit it from one renderer, use that
+agent's `excludedMcpServers` option:
+
+```nix
+programs.codex.excludedMcpServers = [ "postgresql" ];
+programs.antigravity-cli.excludedMcpServers = [ "postgresql" ];
+programs.antigravity-ide.excludedMcpServers = [ "postgresql" ];
+programs.qwen-code.excludedMcpServers = [ "postgresql" ];
+```
+
+Use per-agent exclusions only for client incompatibility. Routine policy belongs
+in `programs.aiMcp.excludedServers` so Claude, Codex, Antigravity, Qwen, and
+future clients stay aligned.
+
+To enable a catalog-disabled server without editing `catalog.nix`, override via
+the module system. Because the catalog uses plain assignments (priority 100),
+the override must use `lib.mkForce` to win the merge:
 
 ```nix
 programs.aiMcp.servers.postgresql.disabled = lib.mkForce false;
@@ -166,20 +186,30 @@ Both tools are `uvx` wrappers defined in `ai-tools.nix` — no separate installa
    - Remote SSE/HTTP endpoint → inline attribute set with `type` and `url`
    - Plugin-managed → do NOT add here; let the plugin manage it
 
-2. New servers are enabled by default. Add `// { disabled = true; }` to start disabled.
+2. New servers are enabled by default unless `disabled = true` or listed in
+   `programs.aiMcp.excludedServers`.
 
 3. Run `darwin-rebuild switch --flake .` to deploy.
 
-4. Verify: `cat ~/.claude.json | jq .mcpServers`
+4. Verify rendered server names:
+
+```bash
+jq '.mcpServers | keys' ~/.claude.json
+rg '^\[mcp_servers\.' ~/.codex/config.toml
+jq '.mcpServers | keys' ~/.gemini/antigravity-cli/settings.json
+jq '.mcpServers | keys' ~/.gemini/config/mcp_config.json
+jq '.mcpServers | keys' ~/.qwen/settings.json
+```
 
 ## Troubleshooting
 
-### Server not appearing in Claude Code
+### Server not appearing in an agent
 
-1. Check `disabled` is not set to `true` in `programs.aiMcp.servers`
-2. Run `darwin-rebuild switch --flake .`
-3. Restart Claude Code
-4. Check `~/.claude.json` contains the server: `jq .mcpServers ~/.claude.json`
+1. Check it is in `programs.aiMcp.enabledServerNames`
+2. Check it is not listed in that agent's `excludedMcpServers`
+3. Run `darwin-rebuild switch --flake .`
+4. Restart the agent
+5. Check the rendered config contains the server
 
 ### SSE server shows connection error
 

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -134,6 +134,13 @@ in
     ];
   };
 
+  # Splunk MCP via Doppler secret injection. The helper reads
+  # SPLUNK_MCP_ENDPOINT/SPLUNK_MCP_TOKEN from Doppler at process launch.
+  splunk = {
+    command = "doppler-mcp";
+    args = [ "splunk-mcp-connect" ];
+  };
+
   # ================================================================
   # Obsidian - Integrated via Claude Code Plugin (not MCP)
   # ================================================================

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -2,7 +2,12 @@
 #
 # This module is the single declarative source for MCP server definitions.
 # Client modules translate programs.aiMcp.servers into their own config format.
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   mcpServerModule = lib.types.submodule {
@@ -137,7 +142,10 @@ in
 
   config.programs.aiMcp = {
     enabledServers = lib.filterAttrs (
-      name: server: !(server.disabled or false) && !(lib.elem name config.programs.aiMcp.excludedServers)
+      name: server:
+      !(server.disabled or false)
+      && !(lib.elem name config.programs.aiMcp.excludedServers)
+      && !(name == "apple-events" && !pkgs.stdenv.isDarwin)
     ) config.programs.aiMcp.servers;
     enabledServerNames = lib.attrNames config.programs.aiMcp.enabledServers;
   };

--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -2,7 +2,7 @@
 #
 # This module is the single declarative source for MCP server definitions.
 # Client modules translate programs.aiMcp.servers into their own config format.
-{ lib, ... }:
+{ config, lib, ... }:
 
 let
   mcpServerModule = lib.types.submodule {
@@ -101,5 +101,44 @@ in
       default = import ./catalog.nix;
       description = "Shared MCP server definitions consumed by AI client modules.";
     };
+
+    excludedServers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "cloudflare"
+        "cribl"
+        "docker"
+        "everything"
+        "exa"
+        "fetch"
+        "filesystem"
+        "firecrawl"
+        "git"
+        "github"
+        "terraform"
+      ];
+      description = "MCP servers excluded from the global cross-agent MCP profile.";
+    };
+
+    enabledServers = lib.mkOption {
+      type = lib.types.attrsOf mcpServerModule;
+      readOnly = true;
+      internal = true;
+      description = "Shared MCP servers enabled after applying global exclusions and disabled flags.";
+    };
+
+    enabledServerNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Names of shared MCP servers enabled after applying global exclusions and disabled flags.";
+    };
+  };
+
+  config.programs.aiMcp = {
+    enabledServers = lib.filterAttrs (
+      name: server: !(server.disabled or false) && !(lib.elem name config.programs.aiMcp.excludedServers)
+    ) config.programs.aiMcp.servers;
+    enabledServerNames = lib.attrNames config.programs.aiMcp.enabledServers;
   };
 }

--- a/modules/mcp/module.nix
+++ b/modules/mcp/module.nix
@@ -20,6 +20,8 @@ let
   cfg = config.programs.mcpRuntime;
 in
 {
+  imports = [ ./default.nix ];
+
   # Namespace note: home-manager 25.11+ ships `programs.mcp` (Claude Desktop
   # MCP integration). We use `programs.mcpRuntime` to avoid the collision —
   # this module is about Doppler/Splunk MCP runtime wrappers, not the

--- a/modules/qwen-code/README.md
+++ b/modules/qwen-code/README.md
@@ -14,6 +14,12 @@ OpenAI/Anthropic/Gemini-compatible endpoint. Apache-2.0.
   one provider entry per capability-class alias from
   `services.aiStack.models`. Default startup model is the `coding`
   class.
+- MCP servers rendered from the shared `programs.aiMcp.enabledServers`
+  profile, with `programs.qwen-code.excludedMcpServers` reserved for
+  Qwen-only compatibility gaps.
+- Shared skills linked from `~/.agents/skills` into `~/.qwen/skills`,
+  matching Codex and Antigravity rather than maintaining a separate
+  skill tree.
 - Doppler-wrapped `d-qwen` shell alias (declared in
   `modules/ai-aliases.zsh`) for sessions that need cloud-provider keys
   (Dashscope, OpenRouter, OpenAI, etc.).

--- a/modules/qwen-code/options.nix
+++ b/modules/qwen-code/options.nix
@@ -43,5 +43,18 @@
         without forking the module.
       '';
     };
+
+    excludedMcpServers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional MCP servers to exclude from the shared cross-agent profile for Qwen Code only.";
+    };
+
+    mcpServerNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Names of MCP servers emitted to Qwen settings.json.";
+    };
   };
 }

--- a/modules/qwen-code/settings.nix
+++ b/modules/qwen-code/settings.nix
@@ -26,6 +26,7 @@
 
 let
   cfg = config.programs.qwen-code;
+  homeDir = config.home.homeDirectory;
   inherit (config.services.aiStack) models resolvedLlmEndpoint llmEndpoint;
 
   # Endpoint + API-key source both follow services.aiStack.llmEndpoint. Local
@@ -48,7 +49,35 @@ let
 
   defaultModelName = cfg.model;
 
+  normalizeMcpServer =
+    server:
+    if server.url != null then
+      lib.filterAttrs (_name: value: value != null && value != [ ] && value != { }) (
+        {
+          inherit (server) headers timeout;
+        }
+        // (if server.type == "sse" then { inherit (server) url; } else { httpUrl = server.url; })
+      )
+    else
+      lib.filterAttrs (_name: value: value != null && value != [ ] && value != { }) {
+        inherit (server)
+          command
+          args
+          env
+          cwd
+          timeout
+          ;
+      };
+
+  mcpServers = lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeMcpServer server)) (
+    lib.filterAttrs (
+      name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
+    ) config.programs.aiMcp.enabledServers
+  );
+
   baseSettings = {
+    inherit mcpServers;
+
     modelProviders = [
       {
         name = providerKey;
@@ -85,12 +114,25 @@ let
   settingsJson = pkgs.writeText "qwen-settings.json" (builtins.toJSON finalSettings);
 in
 {
-  config = lib.mkIf cfg.enable {
-    home.file.".qwen/settings.json".source = settingsJson;
-    # History dir keep-file; qwen-code writes session state here.
-    home.file.".qwen/.history-keep" = {
-      target = ".qwen/history/.keep";
-      text = "# Managed by Nix - programs.qwen-code\n";
-    };
-  };
+  config = lib.mkMerge [
+    {
+      programs.qwen-code.mcpServerNames = lib.attrNames mcpServers;
+    }
+    (lib.mkIf cfg.enable {
+      home = {
+        activation.qwenCodeSettingsMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          export PATH="${pkgs.jq}/bin:$PATH"
+          $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+            "${settingsJson}" \
+            "${homeDir}/.qwen/settings.json"
+        '';
+
+        # History dir keep-file; qwen-code writes session state here.
+        file.".qwen/.history-keep" = {
+          target = ".qwen/history/.keep";
+          text = "# Managed by Nix - programs.qwen-code\n";
+        };
+      };
+    })
+  ];
 }


### PR DESCRIPTION
## Summary
- add a shared `programs.aiMcp.enabledServers` profile and render it into Claude, Codex, Antigravity CLI/IDE, and Qwen
- move Splunk MCP into the shared catalog and make `modules/mcp/module.nix` the self-contained import for both MCP definitions and runtime wrappers
- add Qwen MCP rendering, writable settings merge, and shared `~/.agents/skills` linkage
- make macOS-only `apple-events` Darwin-gated and add regression checks for shared MCP membership, renderer parity, and shared skill links

## Changes
- Codex, Claude, Antigravity CLI/IDE, and Qwen now consume the same shared MCP enabled profile instead of copied per-agent default exclusions.
- Standalone agent Home Manager modules import the MCP runtime module so `doppler-mcp` and `splunk-mcp-connect` are available when Splunk MCP is enabled.
- Qwen settings are activation-merged into a writable config and Qwen skills point at the shared agent skill tree.
- The agent-skills check no longer forces incompatible derivation builds or crashes on missing `source` fields.
- Architecture and MCP docs now describe the shared profile, platform gating, and runtime import boundary.

## Test Plan
- `nix fmt`
- `git diff --check`
- `nix flake check --print-build-logs`
- `nix eval .#checks.x86_64-linux.shared-mcp-global-profile.name --raw`
- `nix eval .#checks.x86_64-linux.shared-mcp-renderer-parity.name --raw`
- `nix eval .#checks.x86_64-linux.agent-skills-home-files.name --raw`
- `nix eval .#checks.x86_64-linux.codex-defaults-regression.name --raw`
- `nix eval .#checks.x86_64-linux.antigravity-cli-defaults-regression.name --raw`