### PR TITLE
chore(deps): bump nix-claude-code to v0.7.0 for advisorModel option

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,11 +538,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783271602,
-        "narHash": "sha256-OiWFfUJ+tQhwfXxUnsdxY9E2xQd2NAOg0quSkMZ1sdg=",
+        "lastModified": 1783622041,
+        "narHash": "sha256-oMQlhF5SggRfw4eKf5gfkUWQ3CXkFx7WDpKeDRGw9ns=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "e058e7451002e90c49ed12e51dcdf4ab0cfc6492",
+        "rev": "fc63a8bfdca7842569206952660818d1471b9e93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps the `nix-claude-code` input to **v0.7.0** (`fc63a8b`), which adds the typed
`advisorModel` settings option. nix-ai already sets `advisorModel = "fable"`
(`modules/claude-config.nix`); the prior pin (2026-07-05) predated the option, so
this carries the release through to consumers (nix-darwin).

## Changes

- `flake.lock`: `nix-claude-code` `e058e74` (07-05) → `fc63a8b` (v0.7.0, 07-09).

## Test Plan

- `nix flake check` green.
- `.#lib.ci.claudeSettingsJson` still evaluates cleanly against the new pin.