### PR TITLE
fix(fabric): build fabric-ai via proxyVendor to fix inconsistent vendoring

### DIFF
--- a/modules/fabric/package.nix
+++ b/modules/fabric/package.nix
@@ -33,8 +33,15 @@ buildGoModule rec {
 
   src = fabric-src;
 
+  # Fetch modules via the Go proxy into a module cache rather than materializing
+  # a vendor/ tree. Fabric's go.mod (go 1.25.1) produces a vendor/modules.txt
+  # whose `## explicit` markers are rejected as inconsistent by the newer Go
+  # toolchain during the build; proxyVendor sidesteps the vendor consistency
+  # check by building against the module cache instead.
+  proxyVendor = true;
+
   # Discover via: nix build .#fabric-ai 2>&1 | grep 'got:'
-  vendorHash = "sha256-DfI0SYMX1wfJ8V0tFYpjzCgqhR7H/0J1p5R3aNcrXTw=";
+  vendorHash = "sha256-fqIClsGuK24jOqSpdfc2j+S9pRkMewrNr6ld6a71Qtk=";
 
   # Build only the main fabric binary from cmd/fabric. Skip cmd/code2context,
   # cmd/generate_changelog, cmd/to_pdf — we only need the primary CLI.


### PR DESCRIPTION
## Summary

`fabric-ai` fails to build on `main` after the `fabric-src` bump in #1145,
breaking `darwin-rebuild` for consumers (e.g. nix-darwin). fabric-src 1.4.455
declares `go 1.25.1`; buildGoModule's generated `vendor/modules.txt` has
`## explicit` markers the Go 1.26 toolchain rejects during the build phase:

```
go: inconsistent vendoring in .../source:
  github.com/anthropics/anthropic-sdk-go@v1.37.0: is explicitly required in
  go.mod, but not marked as explicit in vendor/modules.txt
```

CI never caught it because the `fabric-ai` package build is skipped in
`nix flake check`.

## Fix

Set `proxyVendor = true` so the build uses a Go module-proxy cache instead of a
materialized vendor tree, sidestepping the vendor-consistency check, and
regenerate `vendorHash` accordingly.

## Test Plan

- `nix build .#fabric-ai` succeeds; `result/bin/fabric --version` → `v1.4.455`.
- `nix flake check` green (including the fabric-version-sync regression check).

## Follow-up (not in this PR)

CI skips the fabric-ai build, which is why #1145's breakage went unnoticed.
Consider building `fabric-ai` in CI to catch this class of regression.