### PR TITLE
fix(versions): block transformers 5.13.0 regression, bump mlx 0.32.0

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -76,19 +76,24 @@
   # no longer reproduces — validated 2026-07-02 on jevans-mbp with three
   # concurrent completions against Qwen3-30B-A3B-Instruct-2507-4bit under
   # continuous batching + paged KV cache: zero errors. Keep mlx and mlx-lm
-  # pinned as a pair; they move in lockstep.
+  # pinned as a pair; they move in lockstep. mlx 0.32.0 with mlx-lm 0.31.3
+  # (satisfies its mlx>=0.31.2) import-validated 2026-07-09 alongside
+  # vllm-mlx 0.4.0 + transformers 5.12.0.
   # renovate: datasource=pypi depName=mlx
-  mlx = "0.31.2";
+  mlx = "0.32.0";
   # renovate: datasource=pypi depName=mlx-lm
   mlxLm = "0.31.3";
   # transformers 5.13.0 (released 2026-07-04) broke mlx-lm 0.31.3's import:
   # AutoTokenizer.register("NewlineTokenizer", ...) passes a string key and
   # 5.13.0's register() calls key.__module__ on it -> AttributeError at
   # module import, killing every vllm-mlx worker on both hosts (fleet-wide
-  # serving outage, 2026-07-04). Pin until mlx-lm registers a class (or
-  # transformers restores string keys); bump together with mlxLm.
+  # serving outage, 2026-07-04). Renovate re-bumped it to 5.13.0 in #1144
+  # anyway; the break re-confirmed by import test 2026-07-09, so this pin is
+  # re-reverted and renovate.json5 now blocks 5.13.0 via allowedVersions.
+  # Bump together with mlxLm once mlx-lm registers a class (or transformers
+  # restores string keys).
   # renovate: datasource=pypi depName=transformers
-  transformers = "5.13.0";
+  transformers = "5.12.0";
   # renovate: datasource=pypi depName=lm-eval
   lmEval = "0.4.12";
 

--- a/mlx-server/pyproject.toml
+++ b/mlx-server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Apple MLX local inference server environment"
 requires-python = ">=3.14"
 dependencies = [
-  "mlx>=0.31.2,<0.31.3",
+  "mlx>=0.32.0,<0.32.1",
   "mlx-lm>=0.31.3,<0.31.4",
   "huggingface-hub>=0.30.2",
 ]

--- a/renovate.json5
+++ b/renovate.json5
@@ -41,5 +41,18 @@
       "groupName": "mlx-core",
       "groupSlug": "mlx-core",
     },
+    {
+      "description": [
+        "transformers 5.13.0 breaks mlx-lm 0.31.3 at import (register() calls",
+        "key.__module__ on the string key mlx-lm passes -> AttributeError),",
+        "killing every vllm-mlx worker (fleet-wide serving outage 2026-07-04,",
+        "re-confirmed by import test 2026-07-09 after #1144 re-landed it).",
+        "Allow anything except that exact release; drop this rule when mlx-lm",
+        "registers a class or transformers restores string keys.",
+      ],
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": ["transformers"],
+      "allowedVersions": "!/^5\\.13\\.0$/",
+    },
   ],
 }


### PR DESCRIPTION
## Why

Renovate #1144 re-landed **transformers 5.13.0**, the exact release documented in `lib/versions.nix` as causing the 2026-07-04 fleet-wide serving outage (mlx-lm 0.31.3 import dies with `AttributeError: 'str' object has no attribute '__module__'`). Re-confirmed broken by a clean-venv import test on 2026-07-09. Both serving hosts are only alive because they have not rebuilt since — the next `darwin-rebuild` would have taken down every vllm-mlx worker.

## What

- `transformers` 5.13.0 → **5.12.0** (re-revert), comment updated with the re-confirmation.
- `renovate.json5`: add the `allowedVersions: "!/^5\\.13\\.0$/"` rule for transformers — the mlx-core rule's comment already referenced "allowedVersions rules below" that were never written. Future 5.13.1+ can still flow.
- `mlx` 0.31.2 → **0.32.0** (latest, 2026-07-07): satisfies mlx-lm 0.31.3's `mlx>=0.31.2`; full combo (mlx 0.32.0 + mlx-lm 0.31.3 + vllm-mlx 0.4.0 + transformers 5.12.0) import-validated in a clean venv.

## Verification

- `nix flake check --no-build` passes.
- Clean-venv proof: transformers 5.13.0 + mlx-lm 0.31.3 → import AttributeError; 5.12.0 combo → imports + mx eval OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr