### PR TITLE
fix(fabric): pin nix-claude-code's fabric-src to ours to stop version skew

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -280,22 +280,6 @@
         "type": "github"
       }
     },
-    "fabric-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1777933126,
-        "narHash": "sha256-2O/g0DC0ptxzEzXA1NYZWfdnUeIVFuLWNyw1uct2XyM=",
-        "owner": "danielmiessler",
-        "repo": "fabric",
-        "rev": "6a9b55a096361d368368fa8119f7dd3b8bf2673b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "danielmiessler",
-        "repo": "fabric",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -518,7 +502,9 @@
         "claude-plugins-official": "claude-plugins-official",
         "claude-skills": "claude-skills",
         "dryvist-github": "dryvist-github",
-        "fabric-src": "fabric-src_2",
+        "fabric-src": [
+          "fabric-src"
+        ],
         "flake-parts": "flake-parts",
         "home-manager": [
           "home-manager"

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,12 @@
         home-manager.follows = "home-manager";
         ai-assistant-instructions.follows = "ai-assistant-instructions";
         claude-code-plugins.follows = "claude-code-plugins";
+        # nix-claude-code injects fabric-src as the module arg that our
+        # fabric-ai package consumes in the composed home config. Pin it to
+        # our own fabric-src so the built source matches lib/versions.nix
+        # (and the vendorHash); otherwise nix-claude-code's independently
+        # pinned fabric-src drifts and the fabric-ai build fails.
+        fabric-src.follows = "fabric-src";
       };
     };
 


### PR DESCRIPTION
## Summary

Consumers of nix-ai (e.g. nix-darwin) fail to build `fabric-ai` because
nix-claude-code injects **its own** `fabric-src` as the module arg our
`fabric-ai` package consumes in the composed home config
(`flake/home-manager-modules.nix`). nix-claude-code's independently-pinned
`fabric-src` (v1.4.452) drifted from our `lib/versions.nix` (v1.4.455) and our
own `fabric-src`, so the build used a source that mismatched the version label
and vendorHash → "no such file or directory" on module zips.

This only bites consumers: nix-ai's own `nix flake check` / standalone
`.#fabric-ai` use our `fabric-src` and pass, which is why it wasn't caught here
(and #1156's proxyVendor fix, while correct, didn't address this second copy).

## Fix

Add `fabric-src.follows = "fabric-src"` to the `nix-claude-code` input so the
injected source always equals ours. Deduplicates the two `fabric-src` nodes.

## Test Plan

- `nix flake lock` collapses `fabric-src`/`fabric-src_2` to a single node (a420eaf6).
- `sudo darwin-rebuild build` of the consuming host **succeeds** (was failing on
  fabric-ai) with `--override-input nix-ai <this branch>`.
- `nix flake check` green.