### PR TITLE
ci: widen CI-Gate-completion doctor trigger to include develop

### DIFF
--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["CI Gate"]
     types: [completed]
-    branches: [main]
+    branches: [main, develop]
 if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' }}
 ---
 


### PR DESCRIPTION
## What

Ahead of the git-flow-next pilot flip, widens `ci-doctor.md`'s (gh-aw agentic CI triage source) `workflow_run` branch filter — which listens for "CI Gate" completions — from `[main]` to `[main, develop]`.

## Why

A CI Gate failure on a develop-targeted PR should still trigger the auto-doctor flow once `develop` is the default branch, not just failures on `main`.

## Scope notes

This repo needed only this one edit:

- `ai-ci.yml`'s `workflow_run` trigger already has no `branches` filter at all, so it already covers `develop`.
- `ci-gate.yml`'s `pull_request` trigger has no `branches` restriction, so PR-time checks already run against develop-targeted PRs unchanged.
- `dispatch-to-nix-darwin.yml` (push-triggered downstream flake.lock dispatch) and `release-please.yml` are intentionally `main`-only — both are tied to the released state, not `develop`.
- `fix-renovate-hashes.yml` triggers on `renovate/**` push, unrelated to main/develop.
- `release-please-config.json` / `.release-please-manifest.json` / `release-please.yml` verified present and following the org-standard pattern — no gap.
- Other gh-aw `.md`/`.lock.yml` pairs (`daily-malicious-code-scan`, `link-checker`, `sub-issue-closer`, `repo-health-audit`) are schedule/workflow_dispatch only — no changes needed.

## Known gap — `ci-doctor.lock.yml` not regenerated

Same caveat as the sibling pilot-repo PRs: the only `gh aw` CLI available locally is a "dev" build newer than this repo's pinned version. Compiling with it silently upgrades the entire toolchain (schema version, action SHAs, container images) as a side effect of what should be a one-line trigger change — out of scope here. **Follow-up needed:** regenerate `ci-doctor.lock.yml` with the pinned toolchain so only the `branches` list changes.

## Open PRs targeting main (not retargeted here, per instructions — retarget happens at flip time)

- #1160, #1158, #1157, #1154 (JacobPEvans-personal)
- #1151, #1150 (renovate — will auto-retarget after the default-branch change per Renovate's own behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ