### PR TITLE
feat(ai-tools): add entire CLI

### DIFF
--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -39,7 +39,7 @@
 # ============================================================================
 #
 # NIXPKGS PACKAGES (from nixpkgs, available on stable 25.11):
-#   github-mcp-server, terraform-mcp-server, whisper-cpp, openai-whisper
+#   github-mcp-server, terraform-mcp-server, whisper-cpp, openai-whisper, entire
 #
 # HOMEBREW PACKAGES (from modules/darwin/homebrew.nix):
 #   codex: OpenAI Codex CLI (moved from nixpkgs to match claude/gemini pattern)
@@ -131,6 +131,13 @@ in
     # or the researcher agent workflow.
     # Source: https://github.com/yt-dlp/yt-dlp
     yt-dlp
+
+    # ==========================================================================
+    # entire — captures AI agent sessions alongside git commits
+    # ==========================================================================
+    # Records AI coding sessions and ties them to the commits they produced.
+    # Source: https://github.com/entireio/cli
+    entire
 
     # ==========================================================================
     # GitHub Copilot CLI


### PR DESCRIPTION
## Summary

Adds the `entire` CLI (a nixpkgs package that captures AI agent sessions
alongside git commits) to the home-manager AI dev tools list in
`modules/ai-tools.nix`.

## Placement note

The original request targeted nix-darwin `environment.systemPackages` "next to
git and gh", but:

- There is no `gh` in that list (it lives in nix-home).
- `entire` is an AI/dev CLI, and both repos' separation guidelines route AI
  tools to nix-ai (this repo), not nix-darwin system bootstrapping packages.

So it lands here alongside the other nixpkgs AI tools (`github-mcp-server`,
`whisper-cpp`, etc.).

## Validation

- `nix flake check` passes.
- Confirmed `entire` resolves against the repo's pinned stable nixpkgs and is
  present in the evaluated `ai-tools` package list.
- pre-commit hooks (nixfmt, statix, deadnix) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)