### PR TITLE
ci(fabric): build fabric-ai in nix flake check to catch vendorHash drift

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,14 +150,25 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          ${system} = import ./lib/checks.nix {
-            inherit
-              pkgs
-              home-manager
-              ;
-            src = ./.;
-            aiModule = self.homeManagerModules.default;
-          };
+          ${system} =
+            (import ./lib/checks.nix {
+              inherit
+                pkgs
+                home-manager
+                ;
+              src = ./.;
+              aiModule = self.homeManagerModules.default;
+            })
+            // {
+              # `nix flake check` only *evaluates* packages.<system> (reports
+              # "build skipped") — it never compiles them, so a stale fabric
+              # vendorHash after a fabric-src bump passes CI unnoticed (this
+              # happened twice: #1145, fixed by #1156/#1159). Aliasing the package
+              # as a check forces the Go build — and its vendorHash verification —
+              # to actually run. Scoped to the CI system (x86_64-linux) like every
+              # other check so a single linux runner covers it.
+              fabric-ai-build = self.packages.${system}.fabric-ai;
+            };
         };
 
       # Expose custom packages for nix-update automation


### PR DESCRIPTION
## Problem

`nix flake check` only **evaluates** `packages.<system>` (it reports `build skipped`) — it never compiles them. So a stale fabric-ai `vendorHash` after a `fabric-src` bump passes CI unnoticed: the Go build, where the vendor hash is verified, is never run. This landed on `main` twice (#1145, fixed by #1156 and #1159).

## Fix

Alias the fabric-ai package as a check:

```nix
checks.x86_64-linux.fabric-ai-build = self.packages.x86_64-linux.fabric-ai;
```

`nix flake check` **builds** checks (unlike packages), so this forces the Go build and its `vendorHash` verification to run. Scoped to the CI system (`x86_64-linux`) like every other check, so a single linux runner covers it — no extra build matrix.

## Verification (local, fail-then-pass)

Via a temporary `aarch64-darwin`-keyed alias so `nix flake check` runs on this darwin machine:

- **Blind spot confirmed:** with a deliberately-broken `vendorHash`, the *unpatched* `nix flake check` reports `✅ packages.aarch64-darwin.fabric-ai (build skipped)` and **passes**.
- **Correct `vendorHash`** → `✅ checks.<system>.fabric-ai-build` builds and passes.
- **Broken `vendorHash`** → `nix flake check` **fails**:
  ```
  error: hash mismatch in fixed-output derivation '…-fabric-ai-1.4.455-go-modules.drv':
           specified: sha256-AAAA…
              got:    sha256-fqIClsGuK24jOqSpdfc2j+S9pRkMewrNr6ld6a71Qtk=
  ```
- Confirmed `checks.x86_64-linux.fabric-ai-build.drvPath` == `packages.x86_64-linux.fabric-ai.drvPath` (the check *is* the package build).

The temporary darwin alias was removed; the committed change is the single CI-scoped check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)