### PR TITLE
feat(mlx): cluster module — two-Mac JACCL pipeline-parallel brain

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -64,6 +64,17 @@ let
       };
     }
   ];
+
+  # Fourth evaluation exercising programs.mlx.nightCluster as the coordinator
+  # (lib/checks/mlx-night.nix): rank env contract, watcher wiring, prefetch.
+  hmConfigNight = mkHmConfig [
+    {
+      programs.mlx.nightCluster = {
+        enable = true;
+        role = "coordinator";
+      };
+    }
+  ];
 in
 (import ./checks/lint.nix { inherit pkgs src; })
 // (import ./checks/ai-stack.nix { inherit pkgs testLocalModelId; })
@@ -75,6 +86,7 @@ in
 // (import ./checks/autonomous-profile.nix { inherit pkgs; })
 // (import ./checks/mlx.nix { inherit pkgs hmConfig; })
 // (import ./checks/mlx-catalog.nix { inherit pkgs hmConfigCatalog; })
+// (import ./checks/mlx-night.nix { inherit pkgs hmConfigNight; })
 // (import ./checks/fabric.nix {
   inherit
     pkgs

--- a/lib/checks/lint.nix
+++ b/lib/checks/lint.nix
@@ -53,6 +53,9 @@
   # lib/checks/* is excluded since it names the pattern itself, and
   # modules/mlx/catalog-data.nix is excluded because it IS the physical-id
   # SSOT (the validated model catalog every other reference resolves through).
+  # modules/mlx/night-cluster.nix is the same kind of SSOT for the night
+  # brain: a different engine (mlx-lm, not vllm-mlx) with exactly one model,
+  # so the day catalog's role registry never references it.
   no-hardcoded-model-id = pkgs.runCommand "check-no-hardcoded-model-id" { } ''
     cd ${src}
     bad=$(grep -rnoE 'mlx-community/[A-Za-z0-9][^[:space:]"]*' \
@@ -60,6 +63,7 @@
       --exclude-dir=.git --exclude-dir=result --exclude-dir=.direnv . \
       | grep -vE 'lib/checks' \
       | grep -vE 'modules/mlx/catalog-data\.nix' \
+      | grep -vE 'modules/mlx/night-cluster\.nix' \
       | grep -vE 'mlx-community/test-model' || true)
     if [ -n "$bad" ]; then
       echo "ERROR: hardcoded physical MLX model id(s) found — use an ai-stack capability role instead:" >&2

--- a/lib/checks/mlx-night.nix
+++ b/lib/checks/mlx-night.nix
@@ -1,0 +1,52 @@
+# Night-cluster compile regression tests (programs.mlx.nightCluster -> launchd agents)
+{ pkgs, hmConfigNight }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+in
+{
+  # Coordinator fixture: rank/watcher/prefetch agents must compile with the
+  # distributed env contract and the --pipeline serving mode baked in.
+  mlx-night =
+    let
+      agents = hmConfigNight.config.launchd.agents;
+      rank = agents.mlx-night-rank.config;
+      watcher = agents.mlx-night-watcher.config;
+      rankEnv = rank.EnvironmentVariables;
+      watcherEnv = watcher.EnvironmentVariables;
+      rankCmd = builtins.concatStringsSep " " rank.ProgramArguments;
+    in
+    assert
+      rankEnv.MLX_RANK == "0" || throw "night: coordinator must be rank 0, got ${rankEnv.MLX_RANK}";
+    assert
+      rankEnv.MLX_JACCL_COORDINATOR == "192.168.208.1:11441"
+      || throw "night: JACCL rendezvous must point at the coordinator link ip:port, got ${rankEnv.MLX_JACCL_COORDINATOR}";
+    assert
+      rankEnv.MLX_METAL_FAST_SYNCH == "1"
+      || throw "night: MLX_METAL_FAST_SYNCH=1 missing from the rank env";
+    assert
+      builtins.match ".*mlx_lm[.]server.*" rankCmd != null
+      && builtins.match ".*--pipeline.*" rankCmd != null
+      || throw "night: rank command must serve via mlx_lm.server --pipeline";
+    assert
+      builtins.match ".*GLM-4[.]7-4bit.*" rankCmd != null
+      || throw "night: default night model (GLM-4.7-4bit) not in the rank command";
+    assert
+      rank.RunAtLoad == false && rank.KeepAlive == false
+      || throw "night: the rank must be started only by the link watcher";
+    assert
+      rank.ProcessType == "Interactive"
+      || throw "night: rank must run Interactive QoS (Background clamps Metal decode)";
+    assert
+      watcher.StartInterval == 30 && watcher.RunAtLoad == true
+      || throw "night: watcher must tick every 30s from load";
+    assert
+      watcherEnv.NIGHT_PEER_IP == "192.168.208.2"
+      || throw "night: coordinator watcher must ping the worker link ip, got ${watcherEnv.NIGHT_PEER_IP}";
+    assert
+      watcherEnv.NIGHT_DAY_PROXY == "http://127.0.0.1:11434"
+      || throw "night: watcher must quiesce the day proxy on its configured port";
+    assert
+      agents ? mlx-night-prefetch && agents.mlx-night-prefetch.config.KeepAlive.SuccessfulExit == false
+      || throw "night: prefetch agent must retry until the download completes";
+    helpers.mkMarker "check-mlx-night" "MLX night cluster: rank env contract, --pipeline serving, watcher wiring, and prefetch retry verified";
+}

--- a/lib/checks/mlx-night.nix
+++ b/lib/checks/mlx-night.nix
@@ -13,7 +13,7 @@ in
       watcher = agents.mlx-night-watcher.config;
       rankEnv = rank.EnvironmentVariables;
       watcherEnv = watcher.EnvironmentVariables;
-      rankCmd = builtins.concatStringsSep " " rank.ProgramArguments;
+      rankArgs = rank.ProgramArguments;
     in
     assert
       rankEnv.MLX_RANK == "0" || throw "night: coordinator must be rank 0, got ${rankEnv.MLX_RANK}";
@@ -24,12 +24,11 @@ in
       rankEnv.MLX_METAL_FAST_SYNCH == "1"
       || throw "night: MLX_METAL_FAST_SYNCH=1 missing from the rank env";
     assert
-      builtins.match ".*mlx_lm[.]server.*" rankCmd != null
-      && builtins.match ".*--pipeline.*" rankCmd != null
-      || throw "night: rank command must serve via mlx_lm.server --pipeline";
+      builtins.elem "mlx_lm.server" rankArgs && builtins.elem "--pipeline" rankArgs
+      || throw "night: rank ProgramArguments must serve via mlx_lm.server --pipeline";
     assert
-      builtins.match ".*GLM-4[.]7-4bit.*" rankCmd != null
-      || throw "night: default night model (GLM-4.7-4bit) not in the rank command";
+      builtins.elem "mlx-community/GLM-4.7-4bit" rankArgs
+      || throw "night: default night model (GLM-4.7-4bit) not in the rank ProgramArguments";
     assert
       rank.RunAtLoad == false && rank.KeepAlive == false
       || throw "night: the rank must be started only by the link watcher";

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -194,6 +194,7 @@ in
     ./options-runtime.nix
     ./packages.nix
     ./launchd.nix
+    ./night-cluster.nix
   ];
 
   # Pass shared bindings to sub-modules via _module.args

--- a/modules/mlx/night-cluster.nix
+++ b/modules/mlx/night-cluster.nix
@@ -1,0 +1,284 @@
+#
+# MLX Module — Night Cluster (two-Mac JACCL distributed brain)
+#
+# Overnight, one Thunderbolt 5 cable turns two Macs into a single MLX
+# pipeline-parallel cluster serving a frontier-class model that neither
+# machine can hold alone. Each host runs its own rank from launchd (no SSH
+# orchestration): a link watcher detects the cable, quiesces day serving,
+# and starts the rank; unplugging reverses it unattended.
+#
+# Serving stack is first-party mlx-lm: `mlx_lm.server --pipeline` on every
+# rank — rank 0 (coordinator) binds the OpenAI-compatible HTTP endpoint,
+# all ranks participate in generation. Distributed init is driven by the
+# documented environment contract (MLX_RANK / MLX_JACCL_COORDINATOR /
+# MLX_IBV_DEVICES) instead of `mlx.launch`, which keeps each host
+# self-contained under launchd. --pipeline is required: the pinned mlx-lm
+# release ships PipelineMixin for glm4_moe but not tensor-parallel shard().
+#
+# RDMA prerequisites (documented in the runbook, not automatable here):
+# `rdma_ctl enable` from macOS Recovery on BOTH Macs, Thunderbolt bridge
+# membership disabled for the RDMA link, and manual link IPs assigned once
+# via networksetup. Verify devices with `ibv_devices`.
+#
+{
+  config,
+  lib,
+  pkgs,
+  mlxShared,
+  ...
+}:
+let
+  inherit (mlxShared) cfg;
+  ncfg = cfg.nightCluster;
+  versions = import ../../lib/versions.nix;
+
+  rankLabel = "dev.mlx-night.rank";
+  watcherLabel = "dev.mlx-night.watcher";
+  logDir = "${config.home.homeDirectory}/Library/Logs/mlx-night";
+  stateFile = "${config.home.homeDirectory}/Library/Application Support/mlx-night/link-state";
+
+  isCoordinator = ncfg.role == "coordinator";
+  peerIp = if isCoordinator then ncfg.linkIps.worker else ncfg.linkIps.coordinator;
+
+  # MLX_IBV_DEVICES matrix: entry [i][j] names the RDMA device node i uses to
+  # reach node j (null on the diagonal). UNVALIDATED until first plug-in —
+  # confirm the device name against `ibv_devices` / `mlx.distributed_config`
+  # on plug night and override rdmaDevice if the cable landed on another port.
+  ibvDevicesFile = pkgs.writeText "mlx-night-ibv-devices.json" (
+    builtins.toJSON [
+      [
+        null
+        ncfg.rdmaDevice
+      ]
+      [
+        ncfg.rdmaDevice
+        null
+      ]
+    ]
+  );
+
+  # Inlined as ProgramArguments (no wrapper script) so lib/checks/mlx-night.nix
+  # can assert the exact serving invocation in pure eval.
+  nightRankArgs = [
+    "${pkgs.uv}/bin/uvx"
+    "--from"
+    "mlx-lm==${versions.mlxLm}"
+    "--with"
+    "transformers==${versions.transformers}"
+    "mlx_lm.server"
+    "--model"
+    ncfg.model
+    "--pipeline"
+    "--host"
+    "127.0.0.1"
+    "--port"
+    (toString ncfg.httpPort)
+  ]
+  ++ ncfg.extraServerArgs;
+
+  nightWatcherPkg = pkgs.writeShellApplication {
+    name = "mlx-night-link-watcher";
+    runtimeInputs = [ pkgs.curl ];
+    text = builtins.readFile ./scripts/night-link-watcher.sh;
+  };
+in
+{
+  options.programs.mlx.nightCluster = {
+    enable = lib.mkEnableOption "two-Mac JACCL night cluster (mlx-lm pipeline-parallel serving)";
+
+    role = lib.mkOption {
+      type = lib.types.enum [
+        "coordinator"
+        "worker"
+      ];
+      description = "coordinator = rank 0, binds the night HTTP endpoint; worker = rank 1.";
+    };
+
+    model = lib.mkOption {
+      type = lib.types.str;
+      default = "mlx-community/GLM-4.7-4bit";
+      description = ''
+        HuggingFace id of the night brain. Must use an architecture with
+        distributed support in the pinned mlx-lm (glm4_moe: pipeline).
+        198 GB weights split across both ranks via --pipeline.
+      '';
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 11440;
+      description = "Night endpoint port on the coordinator (loopback; exposed via the host's gateway).";
+    };
+
+    rendezvousPort = lib.mkOption {
+      type = lib.types.port;
+      default = 11441;
+      description = "JACCL coordinator rendezvous port (MLX_JACCL_COORDINATOR).";
+    };
+
+    linkIps = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = {
+        # Synthetic point-to-point net for the Thunderbolt cable itself —
+        # module-defined defaults, not site topology. Assigned once per Mac
+        # via networksetup (runbook step); override only on subnet clash.
+        coordinator = "192.168.208.1";
+        worker = "192.168.208.2";
+      };
+      description = "Link addresses of the two ends of the Thunderbolt cable.";
+    };
+
+    rdmaDevice = lib.mkOption {
+      type = lib.types.str;
+      default = "rdma_en2";
+      description = "RDMA device name for the Thunderbolt link (see `ibv_devices`; port-dependent).";
+    };
+
+    extraServerArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra mlx_lm.server args for the night rank.";
+    };
+
+    prefetch = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Idempotently download the night model at agent load (retries until complete).";
+    };
+
+    quiesceCommand = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Worker-side hook run at link-up before the rank starts (e.g. the night-quiesce allowlist sweep).";
+    };
+
+    restoreCommand = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Worker-side hook run at link-down after the rank stops.";
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && ncfg.enable) {
+    assertions = [
+      {
+        assertion = ncfg.httpPort != cfg.port && ncfg.rendezvousPort != cfg.port;
+        message = "programs.mlx.nightCluster: night ports must not clash with the day proxy port.";
+      }
+    ];
+
+    launchd.agents = {
+      # The rank itself. Started/stopped exclusively by the link watcher —
+      # RunAtLoad=false + KeepAlive=false means unplugged mornings and
+      # rebuilds leave it idle. Interactive QoS: Background clamps Metal
+      # decode throughput (same lesson as the day server agent).
+      mlx-night-rank = {
+        enable = true;
+        config = {
+          Label = rankLabel;
+          ProgramArguments = nightRankArgs;
+          RunAtLoad = false;
+          KeepAlive = false;
+          ThrottleInterval = 60;
+          ProcessType = "Interactive";
+          AbandonProcessGroup = false;
+          EnvironmentVariables = {
+            HF_HOME = cfg.huggingFaceHome;
+            MLX_RANK = if isCoordinator then "0" else "1";
+            MLX_JACCL_COORDINATOR = "${ncfg.linkIps.coordinator}:${toString ncfg.rendezvousPort}";
+            MLX_IBV_DEVICES = "${ibvDevicesFile}";
+            # Faster GPU/CPU synchronization for distributed decode.
+            MLX_METAL_FAST_SYNCH = "1";
+          };
+          StandardOutPath = "${logDir}/night-rank.log";
+          StandardErrorPath = "${logDir}/night-rank.error.log";
+        };
+      };
+
+      # Link watcher: one state-machine tick per interval (see the script for
+      # the transition table).
+      mlx-night-watcher = {
+        enable = true;
+        config = {
+          Label = watcherLabel;
+          ProgramArguments = [ (lib.getExe nightWatcherPkg) ];
+          RunAtLoad = true;
+          StartInterval = 30;
+          ProcessType = "Background";
+          EnvironmentVariables = {
+            NIGHT_ROLE = ncfg.role;
+            NIGHT_PEER_IP = peerIp;
+            NIGHT_RANK_LABEL = rankLabel;
+            NIGHT_WARMUP_LABEL = "dev.vllm-mlx.warmup";
+            NIGHT_DAY_PROXY = "http://127.0.0.1:${toString cfg.port}";
+            NIGHT_STATE_FILE = stateFile;
+          }
+          // lib.optionalAttrs (ncfg.quiesceCommand != null) {
+            NIGHT_QUIESCE_CMD = ncfg.quiesceCommand;
+          }
+          // lib.optionalAttrs (ncfg.restoreCommand != null) {
+            NIGHT_RESTORE_CMD = ncfg.restoreCommand;
+          };
+          StandardOutPath = "${logDir}/night-watcher.log";
+          StandardErrorPath = "${logDir}/night-watcher.error.log";
+        };
+      };
+    }
+    // lib.optionalAttrs ncfg.prefetch {
+      # One-shot idempotent prefetch; KeepAlive-until-success retries partial
+      # downloads (198 GB) across failures, throttled by launchd.
+      mlx-night-prefetch = {
+        enable = true;
+        config = {
+          Label = "dev.mlx-night.prefetch";
+          ProgramArguments = [
+            "${pkgs.uv}/bin/uvx"
+            "--from"
+            "huggingface-hub==${versions.huggingfaceHub}"
+            "hf"
+            "download"
+            ncfg.model
+          ];
+          RunAtLoad = true;
+          KeepAlive = {
+            SuccessfulExit = false;
+          };
+          ThrottleInterval = 300;
+          ProcessType = "Background";
+          EnvironmentVariables = {
+            HF_HOME = cfg.huggingFaceHome;
+          };
+          StandardOutPath = "${logDir}/night-prefetch.log";
+          StandardErrorPath = "${logDir}/night-prefetch.error.log";
+        };
+      };
+    }
+    // {
+      # Bounded night logs, rotated hourly (offset from the day rotation).
+      mlx-night-logrotate = {
+        enable = true;
+        config = {
+          Label = "dev.mlx-night.logrotate";
+          ProgramArguments = [
+            "/usr/sbin/newsyslog"
+            "-f"
+            "${config.home.homeDirectory}/.config/newsyslog.d/mlx-night.conf"
+          ];
+          StartCalendarInterval = [ { Minute = 30; } ];
+        };
+      };
+    };
+
+    # newsyslog config consumed by mlx-night-logrotate (same pattern as the
+    # day server's vllm-mlx.conf).
+    home.file.".config/newsyslog.d/mlx-night.conf".text = ''
+      # logfilename                                  [owner:group]  mode  count  size  when  flags
+      ${logDir}/night-rank.log                       :              644   3      10240 *     J
+      ${logDir}/night-rank.error.log                 :              644   3      10240 *     J
+      ${logDir}/night-watcher.log                    :              644   3      10240 *     J
+      ${logDir}/night-watcher.error.log              :              644   3      10240 *     J
+      ${logDir}/night-prefetch.log                   :              644   3      10240 *     J
+      ${logDir}/night-prefetch.error.log             :              644   3      10240 *     J
+    '';
+  };
+}

--- a/modules/mlx/scripts/night-link-watcher.sh
+++ b/modules/mlx/scripts/night-link-watcher.sh
@@ -1,0 +1,59 @@
+# Night-cluster link watcher — one state-machine tick per launchd interval.
+#
+# Detects the Thunderbolt point-to-point link by pinging the peer's link
+# address, then converges the night rank to match:
+#   link down -> up : quiesce day serving, start the night rank
+#   link up   -> up : ensure the rank is still running (crash recovery)
+#   link up -> down : stop the rank, restore day serving
+#
+# Consumed environment (set declaratively by the launchd agent):
+#   NIGHT_ROLE         coordinator | worker
+#   NIGHT_PEER_IP      link address of the other Mac
+#   NIGHT_RANK_LABEL   launchd label of the night rank agent
+#   NIGHT_WARMUP_LABEL launchd label of the day-serving warmup one-shot
+#   NIGHT_DAY_PROXY    day llama-swap base URL (coordinator only)
+#   NIGHT_STATE_FILE   where the last observed link state is kept
+#   NIGHT_QUIESCE_CMD  optional worker-side quiesce hook (run via sh -c)
+#   NIGHT_RESTORE_CMD  optional worker-side restore hook (run via sh -c)
+
+mkdir -p "$(dirname "$NIGHT_STATE_FILE")"
+prev="down"
+[ -f "$NIGHT_STATE_FILE" ] && prev="$(cat "$NIGHT_STATE_FILE")"
+
+if /sbin/ping -c 1 -t 2 -q "$NIGHT_PEER_IP" > /dev/null 2>&1; then
+  cur="up"
+else
+  cur="down"
+fi
+
+uid="$(id -u)"
+
+if [ "$cur" = "up" ]; then
+  if [ "$prev" = "down" ]; then
+    echo "night-link: down -> up ($NIGHT_ROLE); quiescing day serving"
+    if [ "$NIGHT_ROLE" = "coordinator" ]; then
+      # Unload every day model; the day proxy itself stays up so the morning
+      # restore only needs a re-warm, not a proxy restart.
+      curl -fsS -m 60 -X POST "$NIGHT_DAY_PROXY/api/models/unload" || true
+    elif [ -n "${NIGHT_QUIESCE_CMD:-}" ]; then
+      sh -c "$NIGHT_QUIESCE_CMD" || true
+    fi
+  fi
+  # Converge every tick while the link is up: restarts a crashed rank without
+  # re-running the quiesce. launchd's ThrottleInterval bounds crash loops.
+  if ! launchctl print "gui/$uid/$NIGHT_RANK_LABEL" 2>/dev/null | grep -q "state = running"; then
+    echo "night-link: rank not running; kickstarting"
+    launchctl kickstart "gui/$uid/$NIGHT_RANK_LABEL" || true
+  fi
+elif [ "$prev" = "up" ]; then
+  echo "night-link: up -> down ($NIGHT_ROLE); restoring day serving"
+  launchctl kill SIGTERM "gui/$uid/$NIGHT_RANK_LABEL" 2> /dev/null || true
+  if [ "$NIGHT_ROLE" = "coordinator" ]; then
+    # Re-warm the declared preload list through the existing warmup one-shot.
+    launchctl kickstart -k "gui/$uid/$NIGHT_WARMUP_LABEL" || true
+  elif [ -n "${NIGHT_RESTORE_CMD:-}" ]; then
+    sh -c "$NIGHT_RESTORE_CMD" || true
+  fi
+fi
+
+printf '%s\n' "$cur" > "$NIGHT_STATE_FILE"


### PR DESCRIPTION
## Summary

Adds the `programs.mlx` cluster option set — the nix-ai half of the cluster design: one Thunderbolt 5 cable turns the two M4 Max/128GB Macs into a single 256GB inference cluster running a frontier-class model neither can hold alone, with unattended fallback to today's day fabric on unplug.

- **Serving**: first-party `mlx_lm.server --pipeline` on both ranks (rank 0 = coordinator, binds the OpenAI-compatible endpoint on loopback; the host repo fronts it with the existing bearer-authed gateway). Distributed init via the documented env contract (`MLX_RANK`/`MLX_JACCL_COORDINATOR`/`MLX_IBV_DEVICES` + `MLX_METAL_FAST_SYNCH=1`) so each Mac starts its own rank from launchd — no `mlx.launch` SSH orchestration, no third-party server.
- **Link watcher** (30s tick, the link-watcher script under `scripts/`): link-up → quiesce day serving (`POST /api/models/unload` on the day proxy; optional worker-side quiesce hook) → start rank; while up → restart a crashed rank (throttled); link-down → stop rank → re-warm day residents via the existing warmup one-shot. Surprise-yank and graceful shutdown converge on one code path.
- **Prefetch**: one-shot launchd agent, `hf download` with retry-until-success (KeepAlive.SuccessfulExit=false) for the 198GB weights.
- **Check**: a dedicated mlx cluster check under `lib/checks/` locks the env contract, `--pipeline` invocation, watcher wiring, and prefetch retry.

## Design notes / deviations from the approved plan

- **Cluster model is GLM-4.7-4bit, not Qwen3-235B/GLM-4.6**: at the pinned mlx-lm, `glm4_moe` is the only frontier-class (>128GB) architecture with distributed support (`PipelineMixin`). `qwen3_moe` has none (upstream PR ml-explore/mlx-lm#1138 stale since April); `qwen3_5_moe` likewise. GLM-4.7 (352.8B / 198GB 4-bit) supersedes the plan's GLM-4.6 same-arch.
- **`--pipeline` (pipeline parallelism), not tensor parallelism**: `shard()` for glm4_moe exists on mlx-lm main but is not in the pinned 0.31.3 release. PP suits a 2-node point-to-point link; revisit TP on the next mlx-lm bump.
- **No dedicated catalog class**: the cluster brain is served by a different engine (mlx-lm, not vllm-mlx), has exactly one model, and shares no compiled flag surface with the day catalog — a catalog class would entangle the vllm compile path for zero deduplication.
- **Link addresses are module-default synthetic point-to-point IPs** (overridable options), deliberately not site topology; hosts commit only their role.

## Verification

- `nix eval` of the new mlx cluster check's `.name` → green; full checks attrset enumerates (41 checks, no regressions).
- Watcher script builds under `writeShellApplication` (shellcheck clean).
- `uvx --from mlx-lm==0.31.3 --with transformers==5.12.1`: `glm4_moe` PipelineMixin confirmed, `mlx_lm.server --help` shows `--pipeline`; server import OK.
- RDMA prerequisites (Recovery-mode `rdma_ctl enable`, link IP assignment, `ibv_devices` device-name confirmation) are runbook steps in the host repo — the `MLX_IBV_DEVICES` matrix ships as a best-guess template flagged UNVALIDATED until first plug-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLeWAhEN9MsTchNU4n1nGY
