### PR TITLE
fix(catalog): 512-token paged blocks for Qwen3-Next-80B — 256 still trips the ceiling

### DIFF
--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -44,5 +44,8 @@ in
       builtins.match ".*enable_thinking.*" (builtins.concatStringsSep " " c.models.${next80}.extraArgs)
       == null
       || throw "catalog: 80B (always-thinking variant) must not carry an enable_thinking kwarg";
+    assert
+      c.modelFlagOverrides.${next80}.pagedCacheBlockSize == 512
+      || throw "catalog: 80B must run 512-token paged blocks — 256 still tripped the Metal buffer-count ceiling under 2-way large-phase load (2026-07-10)";
     helpers.mkMarker "check-mlx-catalog" "MLX catalog: resident/swap compile, bounded tweak, ttl fan-out, and host-override precedence verified";
 }

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -38,8 +38,10 @@ let
   # under 2x ~50K-token concurrency + a 16K-token generation on 2026-07-09
   # even with the MLX_BUFFER_CACHE_LIMIT cap — 512 halves the per-token block
   # count again (worst case ~98K buffers at maxNumSeqs 8 x 65K window, deep
-  # under the ceiling). Swap tier stays 256: its 32K request cap keeps block
-  # counts low, and 512 is unvalidated there.
+  # under the ceiling). Small swap models keep 256 (their 32K request cap
+  # keeps block counts low); the 80B large brain runs 512 after 256 tripped
+  # the ceiling four times under 2-way large-phase load on 2026-07-10 (see
+  # its entry).
   block256 = {
     pagedCacheBlockSize = 256;
   };

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -132,18 +132,22 @@ in
   # LARGE rotation brain. Always-thinking variant (no chat-template switch).
   # Small cache keeps the on-demand swap-in under the memory trip (derivation
   # in mlx-benchmarks docs/RUNBOOK.md). prefixCaching off — unsupported for
-  # the qwen3_next hybrid-attention family. block256 on the full-attention
+  # the qwen3_next hybrid-attention family. block512 on the full-attention
   # layers: the engine-default 64 tripped the Metal buffer-count ceiling
-  # mid-digest at step 250880 on 2026-07-10 (active=67GB, running=2) — the
-  # hybrid's recurrent layers carry no KV blocks, so the paged block size
-  # only shapes its full-attention layers.
+  # mid-digest at step 250880 (active=67GB, running=2), and 256 STILL tripped
+  # it four times in the 2026-07-10 11:25-12:00 UTC large window (active
+  # ≈47.8GB, running=2 waiting=1, steps ~14K, 320s+ generations — crash,
+  # llama-swap reload on next request, crash again). The hybrid's recurrent
+  # layers carry no KV blocks, so the paged block size only shapes its
+  # full-attention layers; 512 halves the per-token buffer count again and is
+  # the same sizing the residents validated under 2x long-context concurrency.
   qwen3-next-80b = {
     model = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
     weightGb = 42.0;
     args = qwenMoeGeneralParser ++ agentTimeout;
     classes = {
       swap.flags =
-        block256
+        block512
         // swapFlags
         // {
           cacheMemoryMb = 4096;


### PR DESCRIPTION
## Summary

Block-256 on the 80B (**#1172**) was validated single-stream but is NOT sufficient under real large-phase load: today 11:25–12:00 UTC the block-256 worker hit `[metal::malloc] Resource limit (499000) exceeded` **four times** (crash → llama-swap reload on next request → crash), at active≈47.8GB, running=2 waiting=1, steps ~14K, 320s+ generations — serving Hermes traffic in production.

Moves the 80B swap profile to `block512` (the sizing the residents validated under 2× long-context concurrency; the hybrid's recurrent layers carry no KV blocks so this only shapes full-attention layers), and adds the previously-missing catalog regression assertion locking the 80B at 512.

## Evidence

`vllm-mlx.log` on the serving host: four `Loading model: …Next-80B…` cycles (lines 223062/223421/223832/224716) interleaved with four error pairs (224519/225108/226852/227680), all after the block-256 config went live and before the 12:00 UTC optimized flip unloaded it.

## Verification

- `nix eval .#checks.x86_64-linux.mlx-catalog.name` green with the new 512 assertion.
- Post-merge: bump nix-darwin, rebuild the serving host **before tonight's 00:00 UTC large flip**, then re-run the concurrency harness + a long 80B request expecting zero resource-limit lines, and hold the digest zero-warning bar on tonight's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLeWAhEN9MsTchNU4n1nGY