### PR TITLE
fix(marketplaces): inherit local directory source for fabric-patterns

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783622041,
-        "narHash": "sha256-oMQlhF5SggRfw4eKf5gfkUWQ3CXkFx7WDpKeDRGw9ns=",
+        "lastModified": 1783656288,
+        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "fc63a8bfdca7842569206952660818d1471b9e93",
+        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
         "type": "github"
       },
       "original": {

--- a/modules/claude/marketplaces.nix
+++ b/modules/claude/marketplaces.nix
@@ -69,11 +69,11 @@ base
     };
     flakeInput = jacobpevansMarketplace;
   };
-  "fabric-patterns" = {
-    source = {
-      type = "github";
-      url = "danielmiessler/fabric";
-    };
+  # Inherit the catalog source (nix-claude-code marks fabric-patterns
+  # source.type = "local" → a Claude `directory` source, so Claude reads the
+  # synthetic marketplace in place instead of re-cloning raw upstream and
+  # clobbering it). Only override flakeInput, matching browser-use/cribl above.
+  "fabric-patterns" = (base."fabric-patterns" or { }) // {
     flakeInput = fabricMarketplace;
   };
   # karpathy-skills lives in nix-ai (input + tier file).


### PR DESCRIPTION
## What

The inline `fabric-patterns` entry in `modules/claude/marketplaces.nix` redefined `source.type = "github"`, shadowing nix-claude-code catalog [PR #95](https://github.com/dryvist/nix-claude-code/pull/95) which marks the three synthetic marketplaces `source.type = "local"` (emitted as a Claude `directory` source Claude reads in place instead of re-cloning raw upstream over the Nix-synthesized content).

This switches `fabric-patterns` to the same inherit-from-catalog pattern already used by `browser-use-skills` and `vct-cribl-pack-validator-skills`, and bumps the `nix-claude-code` input to carry the catalog fix.

## Why

Synthetic marketplaces have no upstream `.claude-plugin/marketplace.json`; a `github` source makes Claude clone raw upstream over the Nix content on every `darwin-rebuild switch`, breaking plugin load. `browser-use`/`cribl` already inherit the local source; `fabric-patterns` was the last one still pinned to `github`.

## Verification

- `nix eval` confirms `fabric-patterns.source` now resolves to `{ type = "local"; url = "danielmiessler/fabric"; }`.
- `nix flake check` passes (fabric-ai build covered on the x86_64-linux CI runner per #1171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)