### PR TITLE
feat(mcp): add vikunja MCP server to the catalog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ GITHUB_PERSONAL_ACCESS_TOKEN=ghp___REPLACE_ME__
 # source: Keychain or Doppler.
 CONTEXT7_API_KEY=ctx7___REPLACE_ME__
 
+# vikunja MCP (task management, docs-starlight#141). FAILS to start without both.
+# [required] instance API base, ending in /api/v1.  source: no-password store.
+VIKUNJA_URL=https://vikunja.example.com/api/v1
+# [required] tk_ API token minted in the Vikunja UI (per-agent).  source: Doppler/Keychain.
+VIKUNJA_API_TOKEN=__REPLACE_ME__vikunja_api_token
+
 # unifi MCP ships DISABLED (LAN-only — enable deliberately). When enabled, the
 # server FAILS to start without UNIFI_API_KEY + UNIFI_LOCAL_HOST.
 # [required-if-enabled] API key from unifi.ui.com.  source: Doppler/Keychain.

--- a/.env.example
+++ b/.env.example
@@ -39,10 +39,11 @@ GITHUB_PERSONAL_ACCESS_TOKEN=ghp___REPLACE_ME__
 # source: Keychain or Doppler.
 CONTEXT7_API_KEY=ctx7___REPLACE_ME__
 
-# vikunja MCP (task management, docs-starlight#141). FAILS to start without both.
-# [required] instance API base, ending in /api/v1.  source: no-password store.
+# vikunja MCP ships DISABLED (task management, docs-starlight#141). When enabled,
+# the server FAILS to start without both VIKUNJA_URL and VIKUNJA_API_TOKEN.
+# [required-if-enabled] instance API base, ending in /api/v1.  source: no-password store.
 VIKUNJA_URL=https://vikunja.example.com/api/v1
-# [required] tk_ API token minted in the Vikunja UI (per-agent).  source: Doppler/Keychain.
+# [required-if-enabled] tk_ API token minted in the Vikunja UI (per-agent).  source: Doppler/Keychain.
 VIKUNJA_API_TOKEN=__REPLACE_ME__vikunja_api_token
 
 # unifi MCP ships DISABLED (LAN-only — enable deliberately). When enabled, the

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -49,6 +49,8 @@
   mcpSlack = "2025.4.25";
   # renovate: datasource=npm depName=mcp-server-apple-events
   mcpAppleEvents = "1.4.0";
+  # renovate: datasource=npm depName=@democratize-technology/vikunja-mcp
+  vikunjaMcp = "0.2.0";
 
   # MCP servers (pypi)
   # renovate: datasource=pypi depName=mcp-server-time

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -223,7 +223,11 @@ in
   # breakers — built for autonomous agents. Requires (inject at runtime — see
   # .env.example): VIKUNJA_URL (instance API base, ends in /api/v1) and
   # VIKUNJA_API_TOKEN (a tk_ token minted in the Vikunja UI, per-agent).
-  vikunja = bunx [ "@democratize-technology/vikunja-mcp@${vikunjaMcpVersion}" ];
+  # Ships disabled — like unifi, it fails to start without its credentials, so a
+  # consumer enables it deliberately once the per-agent token is wired.
+  vikunja = bunx [ "@democratize-technology/vikunja-mcp@${vikunjaMcpVersion}" ] // {
+    disabled = true;
+  };
 
   # ================================================================
   # UniFi Network - local UniFi gateway/controller management

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -37,6 +37,7 @@ let
   fabricMcpVersion = versions.fabricMcp;
   gwsMcpVersion = versions.gwsMcp;
   unifiMcpServerVersion = versions.unifiMcpServer;
+  vikunjaMcpVersion = versions.vikunjaMcp;
 in
 {
   # ================================================================
@@ -211,6 +212,18 @@ in
   sentry = bunx [ "@modelcontextprotocol/server-sentry" ] // {
     disabled = true;
   }; # archived
+
+  # ================================================================
+  # Vikunja - self-hosted task management (docs-starlight#141)
+  # ================================================================
+  # Source: https://github.com/democratize-technology/vikunja-mcp (npm:
+  # @democratize-technology/vikunja-mcp). Chosen over the newer one-author
+  # forks: most contributors/stars by far and the widest tool surface (task/
+  # project/label CRUD, batch import, webhooks) with rate limiting + circuit
+  # breakers — built for autonomous agents. Requires (inject at runtime — see
+  # .env.example): VIKUNJA_URL (instance API base, ends in /api/v1) and
+  # VIKUNJA_API_TOKEN (a tk_ token minted in the Vikunja UI, per-agent).
+  vikunja = bunx [ "@democratize-technology/vikunja-mcp@${vikunjaMcpVersion}" ];
 
   # ================================================================
   # UniFi Network - local UniFi gateway/controller management


### PR DESCRIPTION
Adds `vikunja` to the shared MCP catalog: `@democratize-technology/vikunja-mcp` pinned in `lib/versions.nix` with the standard Renovate npm annotation, plus the `VIKUNJA_URL`/`VIKUNJA_API_TOKEN` env contract in `.env.example`.

Package selection (per docs-starlight#141): most contributors and stars of the 6 npm candidates by a wide margin, richest tool surface (task/project/label CRUD, batch import, webhooks), and agent-oriented hardening (rate limiting, circuit-breaker retries, Zod input validation). The more recently published alternatives are one-author forks; one has no visible source repository.

Verification: `nix eval` on the catalog renders the entry correctly.

Refs dryvist/docs-starlight#141

🤖 Generated with [Claude Code](https://claude.com/claude-code)