### PR TITLE
fix(mlx): warm residents via warmup agent, drop broken llama-swap preload hook

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -39,6 +39,7 @@ let
 
   apiUrl = "http://${cfg.host}:${toString cfg.port}/v1";
   launchAgentLabel = "dev.vllm-mlx.server";
+  warmupAgentLabel = "dev.vllm-mlx.warmup";
 
   # Shared per-backend env; the buffer-cache cap must ride the env
   # (MLX_BUFFER_CACHE_LIMIT) — rationale in options-cache.nix.
@@ -66,9 +67,12 @@ let
 
   # One entry per unique physical model. Every model — including the entry
   # owning the "default" alias — inherits the uniform proxy idle TTL.
-  # The default model is still preloaded on startup via hooks.on_startup.preload
-  # below, so the first request never pays a cold-start cost; after proxy.idleTtl
-  # of idle it unloads and the next request reloads it (~15-30 s).
+  # Preloading is done by the warmup LaunchAgent (mlx-warmup.py reading
+  # MLX_PRELOAD_MODELS_JSON), NOT llama-swap's hooks.on_startup.preload:
+  # that hook's request shape 404s against vllm-mlx (#1175), so llama-swap
+  # would start the worker, fail the preload, and stop it — residents cold.
+  # After proxy.idleTtl of idle a model unloads and the next request reloads
+  # it (~15-30 s).
   #
   # useModelName makes llama-swap rewrite the OpenAI-compatible request body's
   # `model` field to the physical model id before forwarding to vllm-mlx.
@@ -171,10 +175,6 @@ let
         members = builtins.attrNames swapModels;
       };
     };
-
-    # Preload by role, not physical name. llama-swap resolves "default"
-    # via the alias table on the registryModels entry.
-    hooks.on_startup.preload = cfg.preload;
   };
 
   # Use pkgs.writeText (not builtins.toFile) because content references store paths
@@ -208,6 +208,7 @@ in
       mlxVlmVersion
       apiUrl
       launchAgentLabel
+      warmupAgentLabel
       llamaSwapPkg
       llamaSwapConfigFile
       llamaSwapConfigAttrs

--- a/modules/mlx/discover-models.py
+++ b/modules/mlx/discover-models.py
@@ -118,17 +118,19 @@ def main() -> None:
 
     # Extract default model and command template.
     # `preload` may reference a role alias (e.g. "default") rather than a
-    # physical model id, since `hooks.on_startup.preload = ["default"]`
-    # and llama-swap resolves the alias at lookup time. When that's the
-    # case, walk the aliases tables to find the physical entry, then
-    # update default_model so the cmd_template substitution below targets
-    # the right `serve <model>` token.
-    preload = (
-        current_config.get("hooks", {}).get("on_startup", {}).get("preload", [])
-    )
+    # physical model id; llama-swap resolves the alias at lookup time. When
+    # that's the case, walk the aliases tables to find the physical entry,
+    # then update default_model so the cmd_template substitution below
+    # targets the right `serve <model>` token. Sourced from
+    # MLX_PRELOAD_MODELS_JSON (the warmup agent's list) — the config no
+    # longer carries hooks.on_startup.preload (its request shape 404s
+    # vllm-mlx, #1175).
+    preload = json.loads(os.environ.get("MLX_PRELOAD_MODELS_JSON", "[]"))
     if not preload:
         print(
-            "ERROR: Could not determine default model from config", file=sys.stderr
+            "ERROR: Could not determine default model from "
+            "MLX_PRELOAD_MODELS_JSON",
+            file=sys.stderr,
         )
         sys.exit(1)
     default_model = preload[0]

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -15,6 +15,7 @@ let
   inherit (mlxShared)
     cfg
     launchAgentLabel
+    warmupAgentLabel
     apiUrl
     mlxWarmupPkg
     llamaSwapPkg
@@ -81,11 +82,14 @@ in
 
       # One-shot warmup job: wait for the proxy to answer, then fault each
       # preloaded model with a 1-token chat completion so the weights are
-      # resident at boot instead of on first user request.
+      # resident at boot instead of on first user request. Also kickstarted
+      # by mlx-default.sh after every proxy restart (via MLX_WARMUP_LABEL) —
+      # this is the ONLY preload path; llama-swap's hooks.on_startup.preload
+      # is deliberately not emitted (its request shape 404s vllm-mlx, #1175).
       agents.vllm-mlx-warmup = {
         enable = true;
         config = {
-          Label = "dev.vllm-mlx.warmup";
+          Label = warmupAgentLabel;
           ProgramArguments = [ (lib.getExe mlxWarmupPkg) ];
           RunAtLoad = true;
           KeepAlive = {
@@ -136,6 +140,7 @@ in
         export MLX_HF_HOME="${cfg.huggingFaceHome}"
         export MLX_LLAMA_SWAP_CONFIG="${llamaSwapRuntimeConfigPath}"
         export MLX_LLAMA_SWAP_BASE_CONFIG="${llamaSwapConfigFile}"
+        export MLX_PRELOAD_MODELS_JSON=${lib.escapeShellArg (builtins.toJSON cfg.preload)}
         run ${pkgs.python3}/bin/python3 "${./discover-models.py}" --quiet
       '';
     };

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -141,15 +141,18 @@
       description = "Per-physical-model overrides of programs.mlx serve options (e.g. pagedKvCache, enablePrefixCaching), merged over the global values when building that model's vllm-mlx command.";
     };
 
-    # preload — llama-swap hooks.on_startup.preload entries. Role names (or
-    # physical ids) loaded at proxy startup so the first request never pays a
-    # cold start. Multi-resident hosts list every role they keep warm, e.g.
+    # preload — models the warmup agent (mlx-warmup.py, via
+    # MLX_PRELOAD_MODELS_JSON) faults in after every proxy (re)start, so the
+    # first request never pays a cold start. Deliberately NOT emitted as
+    # llama-swap hooks.on_startup.preload — that hook's request shape 404s
+    # vllm-mlx and llama-swap stops the worker on preload failure (#1175).
+    # Multi-resident hosts list every role they keep warm, e.g.
     # [ "default" "coding" ]; each extra entry costs its full weight footprint
     # until the idle TTL evicts it.
     preload = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ "default" ];
-      description = "Resident models (role aliases or physical ids) llama-swap preloads at startup. Every entry occupies memory concurrently until its idle TTL — size the list against the host's wired-memory budget. Swap-tier models belong in programs.mlx.models instead.";
+      description = "Resident models (role aliases or physical ids) the warmup agent loads after proxy start. Every entry occupies memory concurrently until its idle TTL — size the list against the host's wired-memory budget. Swap-tier models belong in programs.mlx.models instead.";
     };
 
     proxy = {

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -26,6 +26,7 @@ let
     mlxVlmVersion
     apiUrl
     launchAgentLabel
+    warmupAgentLabel
     llamaSwapPkg
     llamaSwapConfigFile
     llamaSwapRuntimeConfigPath
@@ -50,6 +51,7 @@ in
         MLX_HOST = cfg.host;
         MLX_HF_HOME = cfg.huggingFaceHome;
         MLX_LAUNCHD_LABEL = launchAgentLabel;
+        MLX_WARMUP_LABEL = warmupAgentLabel;
         MLX_LLAMA_SWAP_CONFIG = llamaSwapRuntimeConfigPath;
         MLX_LLAMA_SWAP_BASE_CONFIG = "${llamaSwapConfigFile}";
       };
@@ -208,8 +210,11 @@ in
           text = builtins.readFile ./scripts/mlx-models.sh;
         })
 
-        # mlx-discover — auto-discover downloaded models and register with llama-swap
+        # mlx-discover — auto-discover downloaded models and register with llama-swap.
+        # MLX_PRELOAD_MODELS_JSON is baked in (not taken from the shell) so the
+        # wrapper works from any env, matching the activation hook.
         (pkgs.writeShellScriptBin "mlx-discover" ''
+          export MLX_PRELOAD_MODELS_JSON=${lib.escapeShellArg (builtins.toJSON cfg.preload)}
           exec ${pkgs.python3}/bin/python3 "${./discover-models.py}" "$@"
         '')
 

--- a/modules/mlx/scripts/mlx-default.sh
+++ b/modules/mlx/scripts/mlx-default.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Restart llama-swap proxy (preloads default model).
+# Restart llama-swap proxy, then re-run the warmup agent so residents are
+# faulted back in (mlx-warmup.py waits for the proxy before warming).
 # Usage: mlx-default
 
 launchctl kickstart -k "gui/$(id -u)/${MLX_LAUNCHD_LABEL:?}"
+launchctl kickstart -k "gui/$(id -u)/${MLX_WARMUP_LABEL:?}"
 echo "Default model restored."


### PR DESCRIPTION
## Problem

llama-swap's `hooks.on_startup.preload` request shape 404s against vllm-mlx (same upstream mismatch `useModelName` works around). On every proxy start llama-swap launched the worker, health-check passed, the preload request 404'd, and the worker was gracefully stopped — residents cold after restarts and rotation flips. The reliable warm path (`mlx-warmup.py`, 1-token chat completion per `MLX_PRELOAD_MODELS_JSON` entry) only ran `RunAtLoad`, never on proxy restarts.

## Fix

- `mlx-default.sh` kickstarts the warmup agent right after the proxy kickstart (the warmup script already polls the API until ready, so no race)
- `MLX_WARMUP_LABEL` / `warmupAgentLabel` plumbed through `mlxShared` (DRY with the existing hardcoded label)
- stop emitting `hooks.on_startup.preload` into the llama-swap config — kills the 404 start/stop churn
- `discover-models.py` reads the default model from `MLX_PRELOAD_MODELS_JSON` instead of the dropped config key; the env var is exported explicitly in the activation hook and the `mlx-discover` wrapper (neither sees home-manager sessionVariables)

Grep-verified: warmup + discover-models were the only readers of `on_startup.preload`; no group/registry seeding depends on it.

## Verification

After rebuild: restart proxy via `mlx-default` → `/running` shows all residents `ready`; zero preload-404s in the llama-swap log.

fixes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaGpLAzZMKYa6QE5PHSKCu