### PR TITLE
chore(deps): bump nix-claude-code for marketplace-refresh retry fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783656288,
-        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
+        "lastModified": 1783699561,
+        "narHash": "sha256-Oc681A3Au311QturqPVhvwTCBsg8XEIITJy2iVJwyVI=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
+        "rev": "cc523447193a24bc32c623d4ece8dc0118b8c64b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls nix-claude-code [cc52344 / #99](https://github.com/dryvist/nix-claude-code/pull/99): `marketplace-refresh.sh` now re-queues its `.nix-refresh-needed` marker when a post-rebuild plugin reinstall leaves an enabled plugin unresolved (or the re-scan itself errors), instead of clearing the marker on `marketplace update` success and stranding the plugin with no retry.

Makes post-`darwin-rebuild switch` plugin recovery self-correcting across sessions.

`nix flake check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)