### PR TITLE
fix(mcp): assign catalog in config so per-server overrides merge

### DIFF
--- a/modules/mcp/default.nix
+++ b/modules/mcp/default.nix
@@ -103,8 +103,17 @@ in
   options.programs.aiMcp = {
     servers = lib.mkOption {
       type = lib.types.attrsOf mcpServerModule;
-      default = import ./catalog.nix;
-      description = "Shared MCP server definitions consumed by AI client modules.";
+      default = { };
+      description = ''
+        Shared MCP server definitions consumed by AI client modules. The shared
+        catalog is assigned below in `config` (a plain priority-100 definition)
+        rather than as this option's `default`, because an option default does
+        NOT merge with a partial definition: a consumer setting
+        `programs.aiMcp.servers.<name>.disabled = lib.mkForce false` would
+        otherwise discard the whole catalog and keep only that one entry. As a
+        config-level assignment the catalog merges per-server, so hosts can
+        override an individual server with `lib.mkForce`.
+      '';
     };
 
     excludedServers = lib.mkOption {
@@ -141,6 +150,9 @@ in
   };
 
   config.programs.aiMcp = {
+    # Plain (priority-100) assignment so per-server host overrides merge — see
+    # the `servers` option description above.
+    servers = import ./catalog.nix;
     enabledServers = lib.filterAttrs (
       name: server:
       !(server.disabled or false)


### PR DESCRIPTION
## Problem

The shared MCP catalog was wired as the `programs.aiMcp.servers` option **default** (`default = import ./catalog.nix`). In the module system an option's `default` is only used when the option has **zero** definitions — it does **not** merge with a partial definition.

So the enable pattern the README documents:

```nix
programs.aiMcp.servers.<name>.disabled = lib.mkForce false;
```

silently **discarded the entire catalog** and kept only that one entry — which then had a `null` command and tripped the stdio `command must be set` assertion. No host had ever exercised the pattern, so the defect stayed latent.

## Fix

Move the catalog to a plain config-level assignment (priority 100), exactly as the README already describes ("the catalog uses plain assignments (priority 100)"). Consumer overrides now merge per-server, so a host can enable a catalog-disabled server with `lib.mkForce` without dropping the rest of the catalog.

## Verification

With this fix + a host override `programs.aiMcp.servers.vikunja.disabled = lib.mkForce false`:

```
enabledServerNames = [ "apple-events" "codex" "fabric" "huggingface" "splunk" "time" "vikunja" ]
```

(the full default profile **plus** vikunja). Before the fix the same override yielded just `[ "vikunja" ]`. `darwin-rebuild build` for jevans-mbp completes; the stdio assertion is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)