### PR TITLE
chore(deps): bump nix-claude-code (settings.json marketplace merge fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783699561,
-        "narHash": "sha256-Oc681A3Au311QturqPVhvwTCBsg8XEIITJy2iVJwyVI=",
+        "lastModified": 1783723192,
+        "narHash": "sha256-xclX8LzvWAmNWSFEisfaJWUg3f2emUJMUZ/zGlJQZMs=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "cc523447193a24bc32c623d4ece8dc0118b8c64b",
+        "rev": "d63a213af4f2c90ce3d576a2aab0c3a3ff2e4b12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pulls dryvist/nix-claude-code#101 into nix-ai's lock.

That fix makes the home-manager settings.json merge strip `extraKnownMarketplaces` before the deep merge (like `mcpServers` already is), so a stale `repo` sibling left on a `directory`-source marketplace by a prior shape change no longer survives and no longer fails Claude Code's settings schema validation on rebuild.

This is the middle link of the chain nix-claude-code → nix-ai → nix-darwin needed to land the fix on the Macs.

Closes #1186