### PR TITLE
feat(mlx): cluster-rank runtime RDMA device detection

### DIFF
--- a/lib/checks/mlx-night.nix
+++ b/lib/checks/mlx-night.nix
@@ -24,11 +24,20 @@ in
       rankEnv.MLX_METAL_FAST_SYNCH == "1"
       || throw "night: MLX_METAL_FAST_SYNCH=1 missing from the rank env";
     assert
+      rankEnv.NIGHT_OWN_IP == "192.168.208.1"
+      || throw "night: coordinator rank must carry its own link ip for device detection, got ${rankEnv.NIGHT_OWN_IP}";
+    assert
       builtins.elem "mlx_lm.server" rankArgs && builtins.elem "--pipeline" rankArgs
       || throw "night: rank ProgramArguments must serve via mlx_lm.server --pipeline";
     assert
       builtins.elem "mlx-community/GLM-4.7-4bit" rankArgs
       || throw "night: default night model (GLM-4.7-4bit) not in the rank ProgramArguments";
+    assert
+      pkgs.lib.hasInfix "mlx-night-rank-launch" (builtins.head rankArgs)
+      || throw "night: rank ProgramArguments must run through the device-detecting launcher";
+    assert
+      !(rankEnv ? MLX_IBV_DEVICES)
+      || throw "night: MLX_IBV_DEVICES must be launcher-generated at runtime, not baked into the plist";
     assert
       rank.RunAtLoad == false && rank.KeepAlive == false
       || throw "night: the rank must be started only by the link watcher";

--- a/modules/mlx/night-cluster.nix
+++ b/modules/mlx/night-cluster.nix
@@ -15,10 +15,13 @@
 # self-contained under launchd. --pipeline is required: the pinned mlx-lm
 # release ships PipelineMixin for glm4_moe but not tensor-parallel shard().
 #
-# RDMA prerequisites (documented in the runbook, not automatable here):
-# `rdma_ctl enable` from macOS Recovery on BOTH Macs, Thunderbolt bridge
-# membership disabled for the RDMA link, and manual link IPs assigned once
-# via networksetup. Verify devices with `ibv_devices`.
+# RDMA prerequisites: `rdma_ctl enable` on BOTH Macs (one-time). Bridge
+# detach and link-address assignment are automatic — the nix-darwin
+# night-link-prep daemon converges the role address onto whichever port the
+# cable is in, and the rank launcher below derives the RDMA device from that
+# interface at start. Moving the cable requires no config change anywhere.
+# JACCL rendezvous is IPv4-only (verified 2026-07-11: every IPv6 form fails
+# to parse), which is why the link keeps synthetic IPv4 addresses.
 #
 {
   config,
@@ -40,26 +43,17 @@ let
   isCoordinator = ncfg.role == "coordinator";
   peerIp = if isCoordinator then ncfg.linkIps.worker else ncfg.linkIps.coordinator;
 
-  # MLX_IBV_DEVICES matrix: entry [i][j] names the RDMA device node i uses to
-  # reach node j (null on the diagonal). UNVALIDATED until first plug-in —
-  # confirm the device name against `ibv_devices` / `mlx.distributed_config`
-  # on plug night and override rdmaDevice if the cable landed on another port.
-  ibvDevicesFile = pkgs.writeText "mlx-night-ibv-devices.json" (
-    builtins.toJSON [
-      [
-        null
-        ncfg.rdmaDevice
-      ]
-      [
-        ncfg.rdmaDevice
-        null
-      ]
-    ]
-  );
+  # Runtime launcher: detects the interface carrying this host's link
+  # address, writes the MLX_IBV_DEVICES matrix for its RDMA device, then
+  # execs the rank command (its argv). Keeps the serving invocation visible
+  # in ProgramArguments so lib/checks/mlx-night.nix still asserts it.
+  rankLaunchPkg = pkgs.writeShellApplication {
+    name = "mlx-night-rank-launch";
+    text = builtins.readFile ./scripts/night-rank-launch.sh;
+  };
 
-  # Inlined as ProgramArguments (no wrapper script) so lib/checks/mlx-night.nix
-  # can assert the exact serving invocation in pure eval.
   nightRankArgs = [
+    (lib.getExe rankLaunchPkg)
     "${pkgs.uv}/bin/uvx"
     "--from"
     "mlx-lm==${versions.mlxLm}"
@@ -128,12 +122,6 @@ in
       description = "Link addresses of the two ends of the Thunderbolt cable.";
     };
 
-    rdmaDevice = lib.mkOption {
-      type = lib.types.str;
-      default = "rdma_en2";
-      description = "RDMA device name for the Thunderbolt link (see `ibv_devices`; port-dependent).";
-    };
-
     extraServerArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -186,7 +174,9 @@ in
             HF_HOME = cfg.huggingFaceHome;
             MLX_RANK = if isCoordinator then "0" else "1";
             MLX_JACCL_COORDINATOR = "${ncfg.linkIps.coordinator}:${toString ncfg.rendezvousPort}";
-            MLX_IBV_DEVICES = "${ibvDevicesFile}";
+            # MLX_IBV_DEVICES is generated at start by the rank launcher from
+            # the detected interface.
+            NIGHT_OWN_IP = if isCoordinator then ncfg.linkIps.coordinator else ncfg.linkIps.worker;
             # Faster GPU/CPU synchronization for distributed decode.
             MLX_METAL_FAST_SYNCH = "1";
           };

--- a/modules/mlx/scripts/night-rank-launch.sh
+++ b/modules/mlx/scripts/night-rank-launch.sh
@@ -22,7 +22,9 @@ if [ -z "$iface" ]; then
   exit 1
 fi
 
-ibv_file="${TMPDIR:-/tmp}/mlx-night-ibv-devices.json"
+# mktemp, not a predictable path: /tmp/<fixed-name> is symlink-attackable
+# (CWE-377) and the rank runs long enough for the file to matter.
+ibv_file="$(mktemp "${TMPDIR:-/tmp}/mlx-night-ibv-XXXXXX.json")"
 printf '[[null,"rdma_%s"],["rdma_%s",null]]' "$iface" "$iface" > "$ibv_file"
 export MLX_IBV_DEVICES="$ibv_file"
 echo "night-rank: iface=$iface rdma_device=rdma_$iface"

--- a/modules/mlx/scripts/night-rank-launch.sh
+++ b/modules/mlx/scripts/night-rank-launch.sh
@@ -1,0 +1,30 @@
+# Night-rank launcher — runtime RDMA device detection, then exec the rank.
+#
+# The nix-darwin night-link-prep daemon converges this host's link address
+# onto whichever Thunderbolt port the cable is in. This wrapper finds that
+# interface, derives the RDMA device from it, writes the MLX_IBV_DEVICES
+# matrix, and execs the real rank command (its own argv). Moving the cable
+# needs no config change on this side either.
+#
+# Consumed environment (set declaratively by the launchd agent):
+#   NIGHT_OWN_IP   this host's link address
+
+iface=""
+for cand in $(/sbin/ifconfig -l); do
+  if /sbin/ifconfig "$cand" 2>/dev/null | grep -q "inet $NIGHT_OWN_IP "; then
+    iface="$cand"
+    break
+  fi
+done
+
+if [ -z "$iface" ]; then
+  echo "night-rank: link address $NIGHT_OWN_IP not on any interface; is the cable in?" >&2
+  exit 1
+fi
+
+ibv_file="${TMPDIR:-/tmp}/mlx-night-ibv-devices.json"
+printf '[[null,"rdma_%s"],["rdma_%s",null]]' "$iface" "$iface" > "$ibv_file"
+export MLX_IBV_DEVICES="$ibv_file"
+echo "night-rank: iface=$iface rdma_device=rdma_$iface"
+
+exec "$@"


### PR DESCRIPTION
## What

The cluster rank now starts through a launcher that finds the interface carrying this host's link address, derives the RDMA device from it, and generates `MLX_IBV_DEVICES` at start. The static `rdmaDevice` option is removed.

Pairs with the nix-darwin link-prep PR (dryvist/nix-darwin#1656; root daemon that converges the role link address onto whichever port the cable is in). Together: moving the Thunderbolt cable never requires a config change.

## Why

The cable moved ports today and the old static pinning (interface + device names in two repos) would have needed a multi-repo edit. Runtime detection removes the whole class of drift.

**JACCL rendezvous is IPv4-only** — verified live: every IPv6 form, including `[::1]:11441`, fails with "Can't parse address". So the link keeps the synthetic IPv4 `linkIps` defaults (module-defined, not site topology) instead of the link-local design.

## Verification

- `nix flake check` pass; `nix eval` of the mlx cluster check evaluates all new assertions (launcher wraps rank, the launcher's own-IP env wired, no static `MLX_IBV_DEVICES`).
- Live link verified end-to-end today: converge daemon assigned both role IPs to the cabled ports, bidirectional ping ~0.5 ms.
