### PR TITLE
feat(mlx): cluster link-local rework — zero written IP, runtime discovery

### DIFF
--- a/lib/checks/mlx-night.nix
+++ b/lib/checks/mlx-night.nix
@@ -18,8 +18,17 @@ in
     assert
       rankEnv.MLX_RANK == "0" || throw "night: coordinator must be rank 0, got ${rankEnv.MLX_RANK}";
     assert
-      rankEnv.MLX_JACCL_COORDINATOR == "192.168.208.1:11441"
-      || throw "night: JACCL rendezvous must point at the coordinator link ip:port, got ${rankEnv.MLX_JACCL_COORDINATOR}";
+      !(rankEnv ? MLX_JACCL_COORDINATOR)
+      || throw "night: the JACCL rendezvous address is runtime-computed by the launcher, never baked into the env";
+    assert
+      rankEnv.NIGHT_LINK_DISCOVERY == "link-local" && rankEnv.NIGHT_ROLE == "coordinator"
+      || throw "night: launcher inputs wrong (link discovery must default to link-local; role must reach the launcher)";
+    assert
+      rankEnv.NIGHT_RENDEZVOUS_PORT == "11441"
+      || throw "night: rendezvous port must reach the launcher env";
+    assert
+      builtins.match ".*mlx-night-rank-launcher.*" (builtins.head rankArgs) != null
+      || throw "night: rank ProgramArguments must start with the link-discovery launcher";
     assert
       rankEnv.MLX_METAL_FAST_SYNCH == "1"
       || throw "night: MLX_METAL_FAST_SYNCH=1 missing from the rank env";
@@ -39,8 +48,8 @@ in
       watcher.StartInterval == 30 && watcher.RunAtLoad == true
       || throw "night: watcher must tick every 30s from load";
     assert
-      watcherEnv.NIGHT_PEER_IP == "192.168.208.2"
-      || throw "night: coordinator watcher must ping the worker link ip, got ${watcherEnv.NIGHT_PEER_IP}";
+      !(watcherEnv ? NIGHT_PEER_IP) && watcherEnv.NIGHT_LINK_DISCOVERY == "link-local"
+      || throw "night: watcher must use link-local peer discovery (no baked peer ip) by default";
     assert
       watcherEnv.NIGHT_DAY_PROXY == "http://127.0.0.1:11434"
       || throw "night: watcher must quiesce the day proxy on its configured port";

--- a/modules/mlx/night-cluster.nix
+++ b/modules/mlx/night-cluster.nix
@@ -16,19 +16,11 @@
 # release ships PipelineMixin for glm4_moe but not tensor-parallel shard().
 #
 # Link identity is ZERO-CONFIG: the cabled Thunderbolt port is auto-detected
-# at runtime, and the interface's automatic IPv6 link-local (fe80::) is the
-# address — no IP is written in any repo, so moving the cable to another
-# port needs no edit anywhere. The rank launcher discovers the peer via
-# all-nodes multicast (ff02::1 -> ndp) and derives the ibv device as
-# rdma_<iface>. GATE (unvalidated until a supervised cluster night): JACCL
-# accepting a scoped link-local rendezvous address; if it rejects it, flip
-# `linkDiscovery = "static"` (role-derived synthetic IPs, the documented
-# fallback — nix-darwin `system.rdmaLink.staticAddress` pins them).
-#
-# RDMA prerequisites (documented in the runbook, not automatable here):
-# `rdma_ctl enable` from macOS Recovery on BOTH Macs; nix-darwin's
-# `system.rdmaLink` detaches the cabled port from the Thunderbolt bridge at
-# activation. Verify devices with `ibv_devices`.
+# at runtime and its automatic IPv6 link-local (fe80::) is the address — no
+# IP is written in any repo (see the linkDiscovery option for the JACCL gate
+# + static fallback). RDMA prerequisites: `rdma_ctl enable` from Recovery on
+# BOTH Macs; nix-darwin `system.rdmaLink` detaches the cabled port from the
+# Thunderbolt bridge at activation. Verify devices with `ibv_devices`.
 #
 {
   config,
@@ -74,12 +66,14 @@ let
   nightWatcherPkg = pkgs.writeShellApplication {
     name = "mlx-night-link-watcher";
     runtimeInputs = [ pkgs.curl ];
-    text = builtins.readFile ./scripts/night-link-lib.sh + builtins.readFile ./scripts/night-link-watcher.sh;
+    text =
+      builtins.readFile ./scripts/night-link-lib.sh + builtins.readFile ./scripts/night-link-watcher.sh;
   };
 
   nightRankLauncherPkg = pkgs.writeShellApplication {
     name = "mlx-night-rank-launcher";
-    text = builtins.readFile ./scripts/night-link-lib.sh + builtins.readFile ./scripts/night-rank-launcher.sh;
+    text =
+      builtins.readFile ./scripts/night-link-lib.sh + builtins.readFile ./scripts/night-rank-launcher.sh;
   };
 in
 {
@@ -123,14 +117,11 @@ in
       ];
       default = "link-local";
       description = ''
-        How the two ends of the Thunderbolt cable address each other.
-        "link-local" (default): zero written IP — the cabled port is
-        auto-detected and its automatic IPv6 fe80:: is the identity; the peer
-        is discovered via all-nodes multicast. GATE: JACCL accepting a scoped
-        link-local rendezvous address is unvalidated until a supervised
-        cluster night. "static": the documented fallback — role-derived
-        synthetic IPs from `staticLinkIps` (pin them per host with
-        nix-darwin `system.rdmaLink.staticAddress`).
+        "link-local" (default): zero written IP — auto-detected port, IPv6
+        fe80:: identity, peer via all-nodes multicast. GATE: JACCL accepting
+        a scoped link-local rendezvous is unvalidated until a supervised
+        cluster night. "static": the fallback — role-derived synthetic IPs
+        from staticLinkIps (pin per host via rdmaLink.staticAddress).
       '';
     };
 

--- a/modules/mlx/night-cluster.nix
+++ b/modules/mlx/night-cluster.nix
@@ -15,10 +15,20 @@
 # self-contained under launchd. --pipeline is required: the pinned mlx-lm
 # release ships PipelineMixin for glm4_moe but not tensor-parallel shard().
 #
+# Link identity is ZERO-CONFIG: the cabled Thunderbolt port is auto-detected
+# at runtime, and the interface's automatic IPv6 link-local (fe80::) is the
+# address — no IP is written in any repo, so moving the cable to another
+# port needs no edit anywhere. The rank launcher discovers the peer via
+# all-nodes multicast (ff02::1 -> ndp) and derives the ibv device as
+# rdma_<iface>. GATE (unvalidated until a supervised cluster night): JACCL
+# accepting a scoped link-local rendezvous address; if it rejects it, flip
+# `linkDiscovery = "static"` (role-derived synthetic IPs, the documented
+# fallback — nix-darwin `system.rdmaLink.staticAddress` pins them).
+#
 # RDMA prerequisites (documented in the runbook, not automatable here):
-# `rdma_ctl enable` from macOS Recovery on BOTH Macs, Thunderbolt bridge
-# membership disabled for the RDMA link, and manual link IPs assigned once
-# via networksetup. Verify devices with `ibv_devices`.
+# `rdma_ctl enable` from macOS Recovery on BOTH Macs; nix-darwin's
+# `system.rdmaLink` detaches the cabled port from the Thunderbolt bridge at
+# activation. Verify devices with `ibv_devices`.
 #
 {
   config,
@@ -38,27 +48,12 @@ let
   stateFile = "${config.home.homeDirectory}/Library/Application Support/mlx-night/link-state";
 
   isCoordinator = ncfg.role == "coordinator";
-  peerIp = if isCoordinator then ncfg.linkIps.worker else ncfg.linkIps.coordinator;
+  isStatic = ncfg.linkDiscovery == "static";
+  staticPeerIp = if isCoordinator then ncfg.staticLinkIps.worker else ncfg.staticLinkIps.coordinator;
 
-  # MLX_IBV_DEVICES matrix: entry [i][j] names the RDMA device node i uses to
-  # reach node j (null on the diagonal). UNVALIDATED until first plug-in —
-  # confirm the device name against `ibv_devices` / `mlx.distributed_config`
-  # on plug night and override rdmaDevice if the cable landed on another port.
-  ibvDevicesFile = pkgs.writeText "mlx-night-ibv-devices.json" (
-    builtins.toJSON [
-      [
-        null
-        ncfg.rdmaDevice
-      ]
-      [
-        ncfg.rdmaDevice
-        null
-      ]
-    ]
-  );
-
-  # Inlined as ProgramArguments (no wrapper script) so lib/checks/mlx-night.nix
-  # can assert the exact serving invocation in pure eval.
+  # The serve invocation stays a plain args list (appended after the launcher)
+  # so lib/checks/mlx-night.nix can assert it in pure eval; the launcher only
+  # computes MLX_JACCL_COORDINATOR / MLX_IBV_DEVICES at runtime and execs it.
   nightRankArgs = [
     "${pkgs.uv}/bin/uvx"
     "--from"
@@ -79,7 +74,12 @@ let
   nightWatcherPkg = pkgs.writeShellApplication {
     name = "mlx-night-link-watcher";
     runtimeInputs = [ pkgs.curl ];
-    text = builtins.readFile ./scripts/night-link-watcher.sh;
+    text = builtins.readFile ./scripts/night-link-lib.sh + builtins.readFile ./scripts/night-link-watcher.sh;
+  };
+
+  nightRankLauncherPkg = pkgs.writeShellApplication {
+    name = "mlx-night-rank-launcher";
+    text = builtins.readFile ./scripts/night-link-lib.sh + builtins.readFile ./scripts/night-rank-launcher.sh;
   };
 in
 {
@@ -116,22 +116,54 @@ in
       description = "JACCL coordinator rendezvous port (MLX_JACCL_COORDINATOR).";
     };
 
-    linkIps = lib.mkOption {
+    linkDiscovery = lib.mkOption {
+      type = lib.types.enum [
+        "link-local"
+        "static"
+      ];
+      default = "link-local";
+      description = ''
+        How the two ends of the Thunderbolt cable address each other.
+        "link-local" (default): zero written IP — the cabled port is
+        auto-detected and its automatic IPv6 fe80:: is the identity; the peer
+        is discovered via all-nodes multicast. GATE: JACCL accepting a scoped
+        link-local rendezvous address is unvalidated until a supervised
+        cluster night. "static": the documented fallback — role-derived
+        synthetic IPs from `staticLinkIps` (pin them per host with
+        nix-darwin `system.rdmaLink.staticAddress`).
+      '';
+    };
+
+    staticLinkIps = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
       default = {
         # Synthetic point-to-point net for the Thunderbolt cable itself —
-        # module-defined defaults, not site topology. Assigned once per Mac
-        # via networksetup (runbook step); override only on subnet clash.
+        # module-defined defaults, not site topology. Only meaningful with
+        # linkDiscovery = "static"; override only on subnet clash.
         coordinator = "192.168.208.1";
         worker = "192.168.208.2";
       };
-      description = "Link addresses of the two ends of the Thunderbolt cable.";
+      description = "FALLBACK (linkDiscovery = \"static\"): link addresses of the two cable ends.";
+    };
+
+    interfaceOverride = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "en3";
+      description = ''
+        Cabled Thunderbolt port override. Default null = auto-detect (first
+        Thunderbolt port with an active link). Set only if more than one
+        Thunderbolt port is cabled and the wrong one wins.
+      '';
     };
 
     rdmaDevice = lib.mkOption {
-      type = lib.types.str;
-      default = "rdma_en2";
-      description = "RDMA device name for the Thunderbolt link (see `ibv_devices`; port-dependent).";
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        RDMA device override (see `ibv_devices`). Default null = derived at
+        runtime as rdma_<detected interface>.
+      '';
     };
 
     extraServerArgs = lib.mkOption {
@@ -176,7 +208,10 @@ in
         enable = true;
         config = {
           Label = rankLabel;
-          ProgramArguments = nightRankArgs;
+          # Launcher first: it discovers the link at runtime (iface, addresses,
+          # ibv device), exports MLX_JACCL_COORDINATOR / MLX_IBV_DEVICES, and
+          # execs the serve args that follow it.
+          ProgramArguments = [ (lib.getExe nightRankLauncherPkg) ] ++ nightRankArgs;
           RunAtLoad = false;
           KeepAlive = false;
           ThrottleInterval = 60;
@@ -185,10 +220,20 @@ in
           EnvironmentVariables = {
             HF_HOME = cfg.huggingFaceHome;
             MLX_RANK = if isCoordinator then "0" else "1";
-            MLX_JACCL_COORDINATOR = "${ncfg.linkIps.coordinator}:${toString ncfg.rendezvousPort}";
-            MLX_IBV_DEVICES = "${ibvDevicesFile}";
+            NIGHT_ROLE = ncfg.role;
+            NIGHT_LINK_DISCOVERY = ncfg.linkDiscovery;
+            NIGHT_RENDEZVOUS_PORT = toString ncfg.rendezvousPort;
             # Faster GPU/CPU synchronization for distributed decode.
             MLX_METAL_FAST_SYNCH = "1";
+          }
+          // lib.optionalAttrs isStatic {
+            NIGHT_STATIC_COORDINATOR_IP = ncfg.staticLinkIps.coordinator;
+          }
+          // lib.optionalAttrs (ncfg.interfaceOverride != null) {
+            NIGHT_IFACE_OVERRIDE = ncfg.interfaceOverride;
+          }
+          // lib.optionalAttrs (ncfg.rdmaDevice != null) {
+            NIGHT_RDMA_DEVICE = ncfg.rdmaDevice;
           };
           StandardOutPath = "${logDir}/night-rank.log";
           StandardErrorPath = "${logDir}/night-rank.error.log";
@@ -207,11 +252,17 @@ in
           ProcessType = "Background";
           EnvironmentVariables = {
             NIGHT_ROLE = ncfg.role;
-            NIGHT_PEER_IP = peerIp;
+            NIGHT_LINK_DISCOVERY = ncfg.linkDiscovery;
             NIGHT_RANK_LABEL = rankLabel;
             NIGHT_WARMUP_LABEL = warmupAgentLabel;
             NIGHT_DAY_PROXY = "http://127.0.0.1:${toString cfg.port}";
             NIGHT_STATE_FILE = stateFile;
+          }
+          // lib.optionalAttrs isStatic {
+            NIGHT_STATIC_PEER_IP = staticPeerIp;
+          }
+          // lib.optionalAttrs (ncfg.interfaceOverride != null) {
+            NIGHT_IFACE_OVERRIDE = ncfg.interfaceOverride;
           }
           // lib.optionalAttrs (ncfg.quiesceCommand != null) {
             NIGHT_QUIESCE_CMD = ncfg.quiesceCommand;

--- a/modules/mlx/scripts/night-link-lib.sh
+++ b/modules/mlx/scripts/night-link-lib.sh
@@ -12,8 +12,10 @@ night_detect_iface() {
     return 0
   fi
   local dev
+  # "Thunderbolt [0-9]" only: the virtual "Thunderbolt Bridge" port (device
+  # bridge0) also starts with "Thunderbolt" and must never be a candidate.
   for dev in $(/usr/sbin/networksetup -listallhardwareports \
-                | /usr/bin/awk '/^Hardware Port: Thunderbolt/{getline; print $2}'); do
+                | /usr/bin/awk '/^Hardware Port: Thunderbolt [0-9]/{getline; print $2}'); do
     if /sbin/ifconfig "$dev" 2>/dev/null | /usr/bin/grep -q "status: active"; then
       printf '%s\n' "$dev"
       return 0
@@ -34,7 +36,9 @@ night_peer_ll() {
   local iface="$1" own
   own="$(night_own_ll "$iface")"
   /sbin/ping6 -c 2 "ff02::1%$iface" > /dev/null 2>&1 || true
+  # Match the Netif column exactly — a substring test on %en2 would also
+  # match neighbors on en20/en21.
   /usr/sbin/ndp -an 2>/dev/null \
-    | /usr/bin/awk -v i="%$iface" -v own="$own" \
-        '$1 ~ /^fe80/ && index($1, i) && $1 != own { print $1; exit }'
+    | /usr/bin/awk -v iface="$iface" -v own="$own" \
+        '$1 ~ /^fe80/ && $3 == iface && $1 != own { print $1; exit }'
 }

--- a/modules/mlx/scripts/night-link-lib.sh
+++ b/modules/mlx/scripts/night-link-lib.sh
@@ -1,0 +1,40 @@
+# Shared night-link discovery helpers — concatenated ahead of the watcher and
+# the rank launcher by writeShellApplication (this file is not standalone).
+#
+# The Thunderbolt RDMA link carries no configured IP: the cabled port is
+# auto-detected and the interface's automatic IPv6 link-local (fe80::) is the
+# link identity, so moving the cable to another port needs no config edit.
+
+# First Thunderbolt port with an active link; honors NIGHT_IFACE_OVERRIDE.
+night_detect_iface() {
+  if [ -n "${NIGHT_IFACE_OVERRIDE:-}" ]; then
+    printf '%s\n' "$NIGHT_IFACE_OVERRIDE"
+    return 0
+  fi
+  local dev
+  for dev in $(/usr/sbin/networksetup -listallhardwareports \
+                | /usr/bin/awk '/^Hardware Port: Thunderbolt/{getline; print $2}'); do
+    if /sbin/ifconfig "$dev" 2>/dev/null | /usr/bin/grep -q "status: active"; then
+      printf '%s\n' "$dev"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# This host's link-local address on $1, WITH the %scope suffix macOS prints.
+night_own_ll() {
+  /sbin/ifconfig "$1" inet6 2>/dev/null \
+    | /usr/bin/awk '$1=="inet6" && $2 ~ /^fe80/{print $2; exit}'
+}
+
+# Peer's link-local on $1: solicit with all-nodes multicast (ff02::1), then
+# read the neighbor cache, excluding our own address. Empty output = no peer.
+night_peer_ll() {
+  local iface="$1" own
+  own="$(night_own_ll "$iface")"
+  /sbin/ping6 -c 2 "ff02::1%$iface" > /dev/null 2>&1 || true
+  /usr/sbin/ndp -an 2>/dev/null \
+    | /usr/bin/awk -v i="%$iface" -v own="$own" \
+        '$1 ~ /^fe80/ && index($1, i) && $1 != own { print $1; exit }'
+}

--- a/modules/mlx/scripts/night-link-watcher.sh
+++ b/modules/mlx/scripts/night-link-watcher.sh
@@ -1,29 +1,45 @@
 # Night-cluster link watcher — one state-machine tick per launchd interval.
 #
-# Detects the Thunderbolt point-to-point link by pinging the peer's link
-# address, then converges the night rank to match:
+# Detects the Thunderbolt point-to-point link by auto-detecting the cabled
+# port and discovering the peer's link-local address (or, in fallback mode,
+# pinging the static peer IP), then converges the night rank to match:
 #   link down -> up : quiesce day serving, start the night rank
 #   link up   -> up : ensure the rank is still running (crash recovery)
 #   link up -> down : stop the rank, restore day serving
 #
 # Consumed environment (set declaratively by the launchd agent):
-#   NIGHT_ROLE         coordinator | worker
-#   NIGHT_PEER_IP      link address of the other Mac
-#   NIGHT_RANK_LABEL   launchd label of the night rank agent
-#   NIGHT_WARMUP_LABEL launchd label of the day-serving warmup one-shot
-#   NIGHT_DAY_PROXY    day llama-swap base URL (coordinator only)
-#   NIGHT_STATE_FILE   where the last observed link state is kept
-#   NIGHT_QUIESCE_CMD  optional worker-side quiesce hook (run via sh -c)
-#   NIGHT_RESTORE_CMD  optional worker-side restore hook (run via sh -c)
+#   NIGHT_ROLE            coordinator | worker
+#   NIGHT_LINK_DISCOVERY  link-local (default) | static
+#   NIGHT_STATIC_PEER_IP  static-mode peer address (fallback mode only)
+#   NIGHT_IFACE_OVERRIDE  optional cabled-port override
+#   NIGHT_RANK_LABEL      launchd label of the night rank agent
+#   NIGHT_WARMUP_LABEL    launchd label of the day-serving warmup one-shot
+#   NIGHT_DAY_PROXY       day llama-swap base URL (coordinator only)
+#   NIGHT_STATE_FILE      where the last observed link state is kept
+#   NIGHT_QUIESCE_CMD     optional worker-side quiesce hook (run via sh -c)
+#   NIGHT_RESTORE_CMD     optional worker-side restore hook (run via sh -c)
+#
+# (night_detect_iface / night_peer_ll come from night-link-lib.sh, prepended
+# at build time.)
 
 mkdir -p "$(dirname "$NIGHT_STATE_FILE")"
 prev="down"
 [ -f "$NIGHT_STATE_FILE" ] && prev="$(cat "$NIGHT_STATE_FILE")"
 
-if /sbin/ping -c 1 -t 2 -q "$NIGHT_PEER_IP" > /dev/null 2>&1; then
-  cur="up"
-else
-  cur="down"
+cur="down"
+if iface="$(night_detect_iface)"; then
+  case "${NIGHT_LINK_DISCOVERY:-link-local}" in
+    static)
+      if /sbin/ping -c 1 -t 2 -q "$NIGHT_STATIC_PEER_IP" > /dev/null 2>&1; then
+        cur="up"
+      fi
+      ;;
+    *)
+      if [ -n "$(night_peer_ll "$iface")" ]; then
+        cur="up"
+      fi
+      ;;
+  esac
 fi
 
 uid="$(id -u)"

--- a/modules/mlx/scripts/night-rank-launcher.sh
+++ b/modules/mlx/scripts/night-rank-launcher.sh
@@ -1,0 +1,46 @@
+# Night-rank launcher — computes the JACCL distributed-init environment at
+# RUNTIME (interface + addresses are physical facts discovered from the cable,
+# never committed), then execs the mlx_lm.server rank passed as "$@".
+#
+# Consumed environment (set declaratively by the launchd agent):
+#   NIGHT_ROLE                   coordinator | worker
+#   NIGHT_LINK_DISCOVERY         link-local (default) | static
+#   NIGHT_RENDEZVOUS_PORT        JACCL rendezvous port
+#   NIGHT_STATIC_COORDINATOR_IP  static-mode coordinator address (fallback)
+#   NIGHT_IFACE_OVERRIDE         optional cabled-port override
+#   NIGHT_RDMA_DEVICE            optional ibv device override (default rdma_<iface>)
+
+iface="$(night_detect_iface)" || {
+  echo "night-rank: no cabled Thunderbolt port detected; refusing to start" >&2
+  exit 1
+}
+
+case "${NIGHT_LINK_DISCOVERY:-link-local}" in
+  static)
+    coord="$NIGHT_STATIC_COORDINATOR_IP"
+    ;;
+  *)
+    # GATE (unvalidated until a supervised cluster night): JACCL accepting a
+    # scoped link-local rendezvous address. If it rejects this, flip
+    # nightCluster.linkDiscovery to "static" — the documented fallback.
+    if [ "$NIGHT_ROLE" = "coordinator" ]; then
+      coord="$(night_own_ll "$iface")"
+    else
+      coord="$(night_peer_ll "$iface")"
+    fi
+    if [ -z "$coord" ]; then
+      echo "night-rank: no link-local $NIGHT_ROLE address resolvable on $iface" >&2
+      exit 1
+    fi
+    coord="[$coord]" # bracket the v6 literal for the :port join
+    ;;
+esac
+
+dev="${NIGHT_RDMA_DEVICE:-rdma_$iface}"
+matrix="$(/usr/bin/mktemp -t night-ibv)"
+printf '[[null, "%s"], ["%s", null]]\n' "$dev" "$dev" > "$matrix"
+
+export MLX_JACCL_COORDINATOR="$coord:$NIGHT_RENDEZVOUS_PORT"
+export MLX_IBV_DEVICES="$matrix"
+echo "night-rank: iface=$iface dev=$dev coordinator=$MLX_JACCL_COORDINATOR"
+exec "$@"

--- a/modules/mlx/scripts/night-rank-launcher.sh
+++ b/modules/mlx/scripts/night-rank-launcher.sh
@@ -37,7 +37,9 @@ case "${NIGHT_LINK_DISCOVERY:-link-local}" in
 esac
 
 dev="${NIGHT_RDMA_DEVICE:-rdma_$iface}"
-matrix="$(/usr/bin/mktemp -t night-ibv)"
+# Deterministic path, not mktemp: exec replaces this shell, so nothing could
+# clean a fresh temp file per launch; one stable per-user file self-overwrites.
+matrix="${TMPDIR:-/tmp}/mlx-night-ibv-$(id -u).json"
 printf '[[null, "%s"], ["%s", null]]\n' "$dev" "$dev" > "$matrix"
 
 export MLX_JACCL_COORDINATOR="$coord:$NIGHT_RENDEZVOUS_PORT"


### PR DESCRIPTION
Part of the cluster-run remediation (P3: RDMA link IP + interface hardcoded across two repos). Companion: nix-darwin PR reworking `system.rdmaLink` (auto-detect + detach, no address).

- Rank launcher discovers everything at runtime: cabled TB port (auto-detect, override available), own/peer IPv6 link-local (ff02::1 multicast → `ndp`), ibv device `rdma_<iface>`; computes `MLX_JACCL_COORDINATOR`/`MLX_IBV_DEVICES` and execs the unchanged `mlx_lm.server --pipeline` args.
- `linkDiscovery = "link-local" (default) | "static"` — static keeps the synthetic role-derived IPs as the documented fallback.
- Watcher link detection = iface active + peer discovered (no baked peer IP).
- The mlx cluster check under `lib/checks/` now asserts the launcher contract (no baked rendezvous address allowed).

**GATE:** JACCL accepting `[fe80::…%iface]:port` is unvalidated until the next supervised cluster window (follow-up issue). Verification so far: `nix flake check` green, shellcheck clean, and a **live run on the cabled MBP**: detected `en2`, resolved own fe80, discovered the Studio peer fe80 via multicast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuJXrGxy5PS1HwpUKBu8LY
