### PR TITLE
fix(mlx): default cluster-link discovery to static — JACCL rendezvous is IPv4-only

### DIFF
--- a/lib/checks/mlx-night.nix
+++ b/lib/checks/mlx-night.nix
@@ -21,8 +21,8 @@ in
       !(rankEnv ? MLX_JACCL_COORDINATOR)
       || throw "night: the JACCL rendezvous address is runtime-computed by the launcher, never baked into the env";
     assert
-      rankEnv.NIGHT_LINK_DISCOVERY == "link-local" && rankEnv.NIGHT_ROLE == "coordinator"
-      || throw "night: launcher inputs wrong (link discovery must default to link-local; role must reach the launcher)";
+      rankEnv.NIGHT_LINK_DISCOVERY == "static" && rankEnv.NIGHT_ROLE == "coordinator"
+      || throw "night: launcher inputs wrong (link discovery must default to static — JACCL rendezvous is IPv4-only, verified 2026-07-11; role must reach the launcher)";
     assert
       rankEnv.NIGHT_RENDEZVOUS_PORT == "11441"
       || throw "night: rendezvous port must reach the launcher env";
@@ -48,8 +48,11 @@ in
       watcher.StartInterval == 30 && watcher.RunAtLoad == true
       || throw "night: watcher must tick every 30s from load";
     assert
-      !(watcherEnv ? NIGHT_PEER_IP) && watcherEnv.NIGHT_LINK_DISCOVERY == "link-local"
-      || throw "night: watcher must use link-local peer discovery (no baked peer ip) by default";
+      !(watcherEnv ? NIGHT_PEER_IP) && watcherEnv.NIGHT_LINK_DISCOVERY == "static"
+      || throw "night: watcher must default to static link discovery (JACCL is IPv4-only) with the peer ip supplied as NIGHT_STATIC_PEER_IP";
+    assert
+      watcherEnv.NIGHT_STATIC_PEER_IP == "192.168.208.2"
+      || throw "night: coordinator watcher must ping the worker's static link ip, got ${watcherEnv.NIGHT_STATIC_PEER_IP}";
     assert
       watcherEnv.NIGHT_DAY_PROXY == "http://127.0.0.1:11434"
       || throw "night: watcher must quiesce the day proxy on its configured port";

--- a/modules/mlx/night-cluster.nix
+++ b/modules/mlx/night-cluster.nix
@@ -15,12 +15,14 @@
 # self-contained under launchd. --pipeline is required: the pinned mlx-lm
 # release ships PipelineMixin for glm4_moe but not tensor-parallel shard().
 #
-# Link identity is ZERO-CONFIG: the cabled Thunderbolt port is auto-detected
-# at runtime and its automatic IPv6 link-local (fe80::) is the address — no
-# IP is written in any repo (see the linkDiscovery option for the JACCL gate
-# + static fallback). RDMA prerequisites: `rdma_ctl enable` from Recovery on
-# BOTH Macs; nix-darwin `system.rdmaLink` detaches the cabled port from the
-# Thunderbolt bridge at activation. Verify devices with `ibv_devices`.
+# Link identity: the cabled Thunderbolt port is auto-detected at runtime —
+# moving the cable needs no config edit. The JACCL link-local gate was
+# VALIDATED 2026-07-11 and FAILED: the rendezvous parser is IPv4-only (every
+# IPv6 form, including [::1]:port, fails with "Can't parse address"), so
+# linkDiscovery defaults to "static" — role-derived synthetic IPv4 that the
+# nix-darwin night-link-prep daemon converges onto the cabled port (it also
+# detaches every RDMA-capable port from the Thunderbolt bridge). RDMA
+# prerequisite: `rdma_ctl enable` on BOTH Macs; verify with `ibv_devices`.
 #
 {
   config,
@@ -115,13 +117,14 @@ in
         "link-local"
         "static"
       ];
-      default = "link-local";
+      default = "static";
       description = ''
-        "link-local" (default): zero written IP — auto-detected port, IPv6
-        fe80:: identity, peer via all-nodes multicast. GATE: JACCL accepting
-        a scoped link-local rendezvous is unvalidated until a supervised
-        cluster night. "static": the fallback — role-derived synthetic IPs
-        from staticLinkIps (pin per host via rdmaLink.staticAddress).
+        "static" (default): role-derived synthetic IPs from staticLinkIps,
+        converged onto the cabled port by the nix-darwin night-link-prep
+        daemon. "link-local" is kept for a future mlx-lm: the JACCL gate was
+        validated 2026-07-11 and REJECTED — the rendezvous parser is
+        IPv4-only (even [::1]:port fails to parse), so link-local cannot
+        work on the pinned release.
       '';
     };
 

--- a/modules/mlx/scripts/night-rank-launcher.sh
+++ b/modules/mlx/scripts/night-rank-launcher.sh
@@ -15,14 +15,15 @@ iface="$(night_detect_iface)" || {
   exit 1
 }
 
-case "${NIGHT_LINK_DISCOVERY:-link-local}" in
+case "${NIGHT_LINK_DISCOVERY:-static}" in
   static)
     coord="$NIGHT_STATIC_COORDINATOR_IP"
     ;;
   *)
-    # GATE (unvalidated until a supervised cluster night): JACCL accepting a
-    # scoped link-local rendezvous address. If it rejects this, flip
-    # nightCluster.linkDiscovery to "static" — the documented fallback.
+    # GATE VALIDATED 2026-07-11 and REJECTED: the pinned mlx-lm's JACCL
+    # rendezvous parser is IPv4-only (even [::1]:port fails with "Can't
+    # parse address"), so this branch cannot work today. Kept for a future
+    # mlx-lm that learns IPv6 — fe80 reachability itself verified fine.
     if [ "$NIGHT_ROLE" = "coordinator" ]; then
       coord="$(night_own_ll "$iface")"
     else


### PR DESCRIPTION
## What

Flips the cluster module's `linkDiscovery` default from `link-local` to `static` and records the validation verdict in the module, launcher, and checks.

## Why

The gate #1192 left open ("JACCL accepting a scoped link-local rendezvous is unvalidated until a supervised cluster window") was closed today, live: **the pinned mlx-lm's JACCL rendezvous parser is IPv4-only.** Every IPv6 form fails with "Can't parse address" — scoped `[fe80::…%en2]:11441`, unscoped, and even `[::1]:11441`. fe80 reachability itself is fine (all-nodes multicast peer discovery answered at 0.07 ms across the cable), so the link-local branch is kept for a future mlx-lm release that learns IPv6.

Static addresses are converged onto the auto-detected cabled port by the nix-darwin link-prep daemon (dryvist/nix-darwin#1656), so the cable stays port-agnostic with zero manual steps. Verified live today: both role IPs converged automatically after a physical cable move, bidirectional ping ~0.5 ms.

Supersedes #1191 (written against pre-#1192 develop; closing).

## Verification

- `nix eval` of the mlx cluster check — all assertions pass against the static default.
- `nix flake check` — pass.
