### PR TITLE
feat(mlx): PD-guard — cap cluster-rank kickstarts and page on halt

### DIFF
--- a/modules/mlx/night-cluster.nix
+++ b/modules/mlx/night-cluster.nix
@@ -140,6 +140,27 @@ in
       description = "FALLBACK (linkDiscovery = \"static\"): link addresses of the two cable ends.";
     };
 
+    maxKickstarts = lib.mkOption {
+      type = lib.types.int;
+      default = 3;
+      description = ''
+        Consecutive failed rank starts before the watcher halts kickstarts
+        and pages once. Every failed distributed init leaks a kernel RDMA
+        Protection Domain and exhaustion is reboot-only (ml-explore/mlx#3207),
+        so an unbounded crash loop forces a reboot.
+      '';
+    };
+
+    alertUrlFile = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.config/mlx-night/alert-url";
+      description = ''
+        Untracked local file holding the notification URL (ntfy-style POST
+        target) for the halt page. The URL names internal topology, so it is
+        seeded out-of-band and never committed. Missing file = no page.
+      '';
+    };
+
     interfaceOverride = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
@@ -251,6 +272,8 @@ in
             NIGHT_WARMUP_LABEL = warmupAgentLabel;
             NIGHT_DAY_PROXY = "http://127.0.0.1:${toString cfg.port}";
             NIGHT_STATE_FILE = stateFile;
+            NIGHT_MAX_KICKSTARTS = toString ncfg.maxKickstarts;
+            NIGHT_ALERT_URL_FILE = ncfg.alertUrlFile;
           }
           // lib.optionalAttrs isStatic {
             NIGHT_STATIC_PEER_IP = staticPeerIp;

--- a/modules/mlx/scripts/night-link-watcher.sh
+++ b/modules/mlx/scripts/night-link-watcher.sh
@@ -18,6 +18,9 @@
 #   NIGHT_STATE_FILE      where the last observed link state is kept
 #   NIGHT_QUIESCE_CMD     optional worker-side quiesce hook (run via sh -c)
 #   NIGHT_RESTORE_CMD     optional worker-side restore hook (run via sh -c)
+#   NIGHT_MAX_KICKSTARTS  consecutive failed rank starts before halting
+#   NIGHT_ALERT_URL_FILE  local file holding an ntfy-style URL for the halt
+#                         alert (untracked — never commit the URL)
 #
 # (night_detect_iface / night_peer_ll come from night-link-lib.sh, prepended
 # at build time.)
@@ -55,14 +58,38 @@ if [ "$cur" = "up" ]; then
       sh -c "$NIGHT_QUIESCE_CMD" || true
     fi
   fi
-  # Converge every tick while the link is up: restarts a crashed rank without
-  # re-running the quiesce. launchd's ThrottleInterval bounds crash loops.
-  if ! launchctl print "gui/$uid/$NIGHT_RANK_LABEL" 2>/dev/null | grep -q "state = running"; then
-    echo "night-link: rank not running; kickstarting"
-    launchctl kickstart "gui/$uid/$NIGHT_RANK_LABEL" || true
+  # Converge every tick while the link is up: restart a crashed rank — but
+  # CAP the retries. Every failed `mx.distributed.init()` leaks a kernel
+  # RDMA Protection Domain and exhaustion is reboot-only (ml-explore/mlx
+  # #3207, exo-explore/exo#1847), so an unbounded crash loop turns one bad
+  # start into a forced reboot. After the cap: halt and page once.
+  kicks_file="$(dirname "$NIGHT_STATE_FILE")/rank-kickstarts"
+  halt_file="$(dirname "$NIGHT_STATE_FILE")/rank-halted"
+  if launchctl print "gui/$uid/$NIGHT_RANK_LABEL" 2>/dev/null | grep -q "state = running"; then
+    rm -f "$kicks_file" "$halt_file"
+  elif [ -f "$halt_file" ]; then
+    : # halted — no more PD-burning retries until link cycles or manual clear
+  else
+    kicks=0
+    [ -f "$kicks_file" ] && kicks="$(cat "$kicks_file")"
+    if [ "$kicks" -ge "${NIGHT_MAX_KICKSTARTS:-3}" ]; then
+      echo "night-link: rank failed $kicks consecutive starts; HALTING kickstarts (RDMA PD guard)"
+      touch "$halt_file"
+      if [ -f "${NIGHT_ALERT_URL_FILE:-}" ]; then
+        curl -fsS -m 10 -H "Priority: urgent" -H "Title: mlx-night rank halted (PD guard)" \
+          -d "$(hostname -s): night rank failed $kicks consecutive starts; kickstarts halted to protect RDMA protection domains. errno 60 = reboot needed. Clear: rm the rank-halted marker or replug the link." \
+          "$(cat "$NIGHT_ALERT_URL_FILE")" || true
+      fi
+    else
+      echo "night-link: rank not running; kickstarting (attempt $((kicks + 1)))"
+      launchctl kickstart "gui/$uid/$NIGHT_RANK_LABEL" || true
+      printf '%s\n' "$((kicks + 1))" > "$kicks_file"
+    fi
   fi
 elif [ "$prev" = "up" ]; then
   echo "night-link: up -> down ($NIGHT_ROLE); restoring day serving"
+  # A link cycle (replug) clears the PD-guard state for the next window.
+  rm -f "$(dirname "$NIGHT_STATE_FILE")/rank-kickstarts" "$(dirname "$NIGHT_STATE_FILE")/rank-halted"
   launchctl kill SIGTERM "gui/$uid/$NIGHT_RANK_LABEL" 2> /dev/null || true
   if [ "$NIGHT_ROLE" = "coordinator" ]; then
     # Re-warm the declared preload list through the existing warmup one-shot.


### PR DESCRIPTION
## What

The cluster-link watcher now caps consecutive rank kickstarts (a new max-kickstarts option, default 3) and sends ONE urgent page (ntfy-style POST to the URL in `alertUrlFile` — an untracked local file, so no internal topology is committed) before halting. Healthy rank or link replug clears the guard.

## Why

Live incident today: every failed `mx.distributed.init()` leaks a kernel RDMA Protection Domain, exhaustion is reboot-only (ml-explore/mlx#3207, exo-explore/exo#1847), and the watcher's unbounded crash-loop burned dozens of PDs — turning a startup race into a both-Macs reboot. This guard makes that impossible and pages the user immediately, with or without an agent session running.

## Verification

- Watcher script shellcheck-clean under the writeShellApplication preamble.
- `nix eval` of the mlx cluster check + `nix flake check` pass.
