### PR TITLE
fix(claude): loosen auto-mode classifier and disable autoresearch guard hooks

### DIFF
--- a/modules/claude/automode.nix
+++ b/modules/claude/automode.nix
@@ -37,6 +37,8 @@ in
   allow = [
     "$defaults"
     "Running `rm` to delete files inside the current working repository is routine and safe — allow without confirmation, including recursive deletion of ordinary subdirectories such as build outputs, caches, vendored dependencies, test fixtures, and git worktrees."
+    "Running inline interpreters for read-only inspection — `python -c`, `python3 -c`, `node -e`, `ruby -e`, `perl -e` — to parse JSON, read a config file, or compute and print a value is routine and safe; allow without confirmation. Only require confirmation when such a one-liner writes or deletes files, or sends data to a destination outside the working repository."
+    "Read-only compound shell chains that combine already-safe inspection tools (cd, ls, cat, head, tail, wc, sort, uniq, grep, rg, jq, `sed -n`, `awk` print, `find` without -delete/-exec, and git status/log/diff/show) with `&&` or `|` are routine and safe; allow without confirmation even though the combined command does not match a single narrow allow rule."
   ];
 
   soft_deny = [

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -33,6 +33,17 @@
   # See: https://code.claude.com/docs/en/agent-teams
   CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
 
+  # Disable the autoresearch plugin's PreToolUse block hooks (dangerous-cmd-block,
+  # scout-block, privacy-block). Those hooks raw-substring-match the command/path
+  # string on every Bash/Read/Edit/Write/Glob/Grep call and hard-deny false
+  # positives (e.g. "git checkout .github/..." contains "git checkout ."; any
+  # path containing "build/" or "env/" is blocked outright). The autoresearch:*
+  # skills keep working — only these three guard hooks are neutered. Read by
+  # node-hook-runner.sh, which forwards them into the hooks' clean `env -i`.
+  AR_DISABLE_DANGEROUS_CMD_BLOCK = "1";
+  AR_DISABLE_SCOUT_BLOCK = "1";
+  AR_DISABLE_PRIVACY_BLOCK = "1";
+
   # DEFAULT VALUES (upstream) - reference only, do not uncomment unless tuning
   # MAX_THINKING_TOKENS = "31999";
   # CLAUDE_CODE_MAX_OUTPUT_TOKENS = "32000";


### PR DESCRIPTION
## Summary
Forensic analysis of ~190 recent session transcripts identified two dominant sources of permission friction, both false positives with no security value:

- **Auto-mode classifier over-denial** (107 events): benign inline-interpreter reads (`python3 -c`, `node -e`) and read-only compound shell chains (`cd X && head Y`) don't match a single narrow allow rule, so they fall through to the classifier and get denied. Adds two `allow` prose entries (`$defaults` preserved) per https://code.claude.com/docs/en/auto-mode-config.
- **`autoresearch` plugin PreToolUse hooks**: `dangerous-cmd-block`/`scout-block`/`privacy-block` hard-deny on raw substring matches against the full command/path string, on every Bash/Read/Edit/Write/Glob/Grep call, regardless of whether an autoresearch iteration is active. Sets the hooks' own `AR_DISABLE_*` env vars to neuter just the three block hooks; the `autoresearch:*` skills keep working.

Deliberately out of scope (per owner decision): `defaultMode` stays `auto` (no `bypassPermissions`), `permissions.ask`/deny lists for package installs unchanged, and the `jacobpevans-cc-plugins` guard suite is untouched.

## Test plan
- [x] `nix flake check` passes
- [x] `nix fmt` clean
- [ ] After merge + rebuild: `claude auto-mode config` shows the two new `allow` entries; `python3 -c "..."` and a compound read chain run without a prompt; a Bash command whose string contains "force-push"-like phrasing is no longer hard-blocked by autoresearch

Assisted-by: Claude:opus-4-8