### PR TITLE
fix: update nix-claude-code flake input to current develop tip

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -540,11 +540,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783723192,
-        "narHash": "sha256-xclX8LzvWAmNWSFEisfaJWUg3f2emUJMUZ/zGlJQZMs=",
+        "lastModified": 1783853804,
+        "narHash": "sha256-T7osZbdTH1SGa8XzEvp9Du1F+Nv7NRxcBMFwmGfuZss=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "d63a213af4f2c90ce3d576a2aab0c3a3ff2e4b12",
+        "rev": "6a4a356b0c6e7b2d52c7cef5a33241a06317847d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Bump `nix-claude-code` flake input from a ~2-day-stale pin to its current `develop` tip.

## Notes
- No explicit ref/tag added — `nix-claude-code` has no ref in `flake.nix`, so it tracks its default branch; `flake.lock` is the sole source of truth for the resolved commit.
- `nix flake check` passes.

## Test plan
- [x] `nix flake update nix-claude-code`
- [x] `nix flake check`