### PR TITLE
revert: restore shellcheck linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ the MCP catalog is documented in [`modules/mcp/README.md`](modules/mcp/README.md
 ## Testing and validation
 
 ```bash
-nix flake check   # nixfmt, statix, deadnix, and full module evaluation
+nix flake check   # nixfmt, statix, deadnix, shellcheck, and full module evaluation
 nix fmt           # auto-fix formatting
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -149,7 +149,7 @@
       # comments — see that file. The public `nix-ai.lib.*` shape is unchanged.
       lib = import ./flake/lib.nix { inherit nixpkgs nix-claude-code homebrewNix; };
 
-      # Quality checks (formatting, linting, dead code, module-eval).
+      # Quality checks (formatting, linting, dead code, shellcheck, module-eval).
       #
       # Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds
       # from a single linux runner. All checks in lib/checks.nix are source-only

--- a/lib/checks/lint.nix
+++ b/lib/checks/lint.nix
@@ -32,15 +32,19 @@
     cd ${src}
     find . -name "*.sh" -not -path "./.git/*" -not -path "./result/*" -print0 | \
     xargs -0 bash -c '
+      failed=0
       for script in "$@"; do
         # Skip zsh scripts (shellcheck does not support them)
         if head -1 "$script" | grep -q "zsh"; then
           echo "Skipping zsh script: $script"
         else
           echo "Checking $script..."
-          ${pkgs.lib.getExe pkgs.shellcheck} --severity=warning --exclude=SC1091 "$script"
+          if ! ${pkgs.lib.getExe pkgs.shellcheck} --severity=warning --exclude=SC1091 "$script"; then
+            failed=1
+          fi
         fi
       done
+      exit "$failed"
     ' bash
     touch $out
   '';

--- a/lib/checks/lint.nix
+++ b/lib/checks/lint.nix
@@ -21,6 +21,30 @@
     touch $out
   '';
 
+  # Lint shell scripts with shellcheck
+  # Catches common bugs: unquoted variables, undefined vars, useless use of cat, etc.
+  # Excludes .git directories and nix store paths
+  # --severity=warning: Only fail on warning/error level (not info style suggestions)
+  # SC1091: Exclude "not following" errors for external sources (can't resolve in Nix sandbox)
+  # Excludes zsh scripts (shellcheck only supports sh/bash/dash/ksh)
+  # Uses find with -print0 and xargs -0 for robustness with filenames containing spaces and special characters
+  shellcheck = pkgs.runCommand "check-shellcheck" { } ''
+    cd ${src}
+    find . -name "*.sh" -not -path "./.git/*" -not -path "./result/*" -print0 | \
+    xargs -0 bash -c '
+      for script in "$@"; do
+        # Skip zsh scripts (shellcheck does not support them)
+        if head -1 "$script" | grep -q "zsh"; then
+          echo "Skipping zsh script: $script"
+        else
+          echo "Checking $script..."
+          ${pkgs.lib.getExe pkgs.shellcheck} --severity=warning --exclude=SC1091 "$script"
+        fi
+      done
+    ' bash
+    touch $out
+  '';
+
   # Guard: physical MLX model ids belong only in the runtime registry
   # (services.aiStack.defaultLocalModelId, sourced from AI_MODEL_LOCAL_LLM).
   # Every consumer references a capability role, never a hardcoded id — so a

--- a/modules/mcp/scripts/doppler-mcp.sh
+++ b/modules/mcp/scripts/doppler-mcp.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # doppler-mcp — wraps any command with Doppler secret injection.
 #
 # Fetches secrets from ai-ci-automation/prd at subprocess launch time.

--- a/modules/mcp/scripts/splunk-mcp-connect.sh
+++ b/modules/mcp/scripts/splunk-mcp-connect.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # splunk-mcp-connect — connects to the Splunk MCP Server via mcp-remote stdio proxy.
 #
 # Reads credentials from env (injected by doppler-mcp wrapper at MCP launch time).

--- a/modules/mlx/scripts/cluster-link-lib.sh
+++ b/modules/mlx/scripts/cluster-link-lib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared cluster-link discovery helpers — concatenated ahead of the watcher and
 # the rank launcher by writeShellApplication (this file is not standalone).
 #

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Cluster link watcher — one state-machine tick per launchd interval.
 #
 # Detects the Thunderbolt point-to-point link by auto-detecting the cabled

--- a/modules/mlx/scripts/cluster-rank-launcher.sh
+++ b/modules/mlx/scripts/cluster-rank-launcher.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Cluster-rank launcher — computes the JACCL distributed-init environment at
 # RUNTIME (interface + addresses are physical facts discovered from the cable,
 # never committed), then execs the mlx_lm.server rank passed as "$@".


### PR DESCRIPTION
Reverts #1206, which removed shellcheck under the mistaken belief it was a spell-checker.

shellcheck is a valuable shell static-analysis linter, not a spell-checker. The user reversed the removal decision, so this restores it:

- `nix flake check` shellcheck lint check in `lib/checks/lint.nix`
- `# shellcheck shell=bash` inline directives in `modules/mcp/scripts/doppler-mcp.sh` and `splunk-mcp-connect.sh`
- README and flake.nix references

This reverts commit 08fb7f11739059fca1071501b49fa4d620f20f9d.