### PR TITLE
chore(main): promote develop to main (remove legacy terragrunt tooling)

### DIFF
--- a/modules/ai-aliases.zsh
+++ b/modules/ai-aliases.zsh
@@ -18,10 +18,6 @@ alias claude-latest-d="claude-latest --dangerously-skip-permissions"
 #        d-claude -p "prompt"   # non-interactive
 alias d-claude="doppler run -p ai-ci-automation -c prd -- claude"
 
-# aws-vault terraform profile layered on top of d-claude. For infra-repo sessions
-# that need BOTH AWS credentials AND AI MCP secrets loaded.
-alias tf-claude="aws-vault exec terraform -- doppler run -p ai-ci-automation -c prd -- claude"
-
 # Doppler-wrapped agent CLIs — inject ai-ci-automation/prd secrets for
 # cloud-provider fallback paths (OPENAI_API_KEY, OPENROUTER_API_KEY,
 # DASHSCOPE_API_KEY, etc.). Default sessions use local MLX directly; no

--- a/modules/ai-shell.nix
+++ b/modules/ai-shell.nix
@@ -3,7 +3,7 @@
 # Appends AI-tool aliases to programs.zsh.initContent after nix-home's base
 # init block. lib.mkAfter ensures these entries load last so any collisions
 # with nix-home's aliases.nix win in our favor. The companion nix-home PR
-# removes d-claude/tf-claude from that file, but mkAfter keeps us safe
+# removes d-claude from that file, but mkAfter keeps us safe
 # during the transitional window.
 
 { lib, ... }:

--- a/modules/permissions/copilot-permissions-ask.nix
+++ b/modules/permissions/copilot-permissions-ask.nix
@@ -88,13 +88,9 @@ _:
   #   "shell(aws cloudformation delete-stack)"
   # ];
   #
-  # terraformDestructiveOperations = [
-  #   "shell(terraform apply)"
-  #   "shell(terraform destroy)"
-  #   "shell(terragrunt apply)"
-  #   "shell(terragrunt destroy)"
-  #   "shell(terragrunt run-all apply)"
-  #   "shell(terragrunt run-all destroy)"
+  # opentofuDestructiveOperations = [
+  #   "shell(tofu apply)"
+  #   "shell(tofu destroy)"
   # ];
   #
   # packageExecutionCommands = [


### PR DESCRIPTION
Promote #1210 (remove legacy terragrunt tooling) to production as part of the Terrakube migration. Merge-commit per git-flow.