### PR TITLE
fix(mlx): stock 35B fleet-brain timeout guard + resident profile

### DIFF
--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -105,9 +105,14 @@ in
     };
   };
 
-  # Stock sibling of the OptiQ brain. Parser anomaly: still qwen3_coder
-  # (predates the 2026-07-08 bench); flip to the family parser only with a
-  # bench on this variant. Thinking off by default (requests can opt in).
+  # Stock sibling of the OptiQ brain, and the live ai-default fleet brain
+  # (nix-ai#915). Parser anomaly: still qwen3_coder (predates the 2026-07-08
+  # bench); flip to the family parser only with a bench on this variant.
+  # Thinking off by default (requests can opt in). agentTimeout is REQUIRED
+  # here now that it fronts the fleet: without it the serve worker keeps the
+  # 300 s disconnect_guard, which aborted long cron generations mid-stream
+  # ("ABORTING orphaned request … in 300.4s") and surfaced to Hermes as a
+  # brain-unreachable event on 2026-07-14.
   qwen36-35b = {
     model = "mlx-community/Qwen3.6-35B-A3B-4bit";
     weightGb = 19.4;
@@ -120,8 +125,18 @@ in
       (builtins.toJSON {
         enable_thinking = false;
       })
-    ];
+    ]
+    ++ agentTimeout;
     classes = {
+      # Fleet-brain resident profile mirrors the OptiQ twin it replaces as
+      # ai-default: same weights (~19.4 GB) and same KV budget, so the resident
+      # footprint is unchanged. HIGH caps for 40-58K agentic contexts; 65536
+      # avoids the 32768 truncation/retry death-loop (see the OptiQ entry).
+      resident.flags = block512 // {
+        cacheMemoryMb = 16384;
+        maxNumSeqs = 8;
+        maxRequestTokens = 65536;
+      };
       swap.flags =
         block256
         // swapFlags


### PR DESCRIPTION
## Problem

The stock `Qwen3.6-35B-A3B-4bit` became the `ai-default` fleet brain (#915) but
its catalog entry never got `agentTimeout`, so its serve worker kept the 300s
disconnect_guard. Long agentic generations were aborted mid-stream ("ABORTING
orphaned request ... in 300.4s"), surfacing to the agent as a brain-unreachable
event (2026-07-14). It also only offered a `swap` class, so a restart cold-loads
~19GB on the first request (503 window).

## Fix

- Append `agentTimeout` to the entry so the guard chain (server 3600 > router
  2400 > client 1800) holds.
- Add a `resident` class profile mirroring the OptiQ twin it replaces (same
  ~19.4GB weights, same KV budget) so the host can preload it warm.

## Companion

Requires dryvist/nix-darwin `fix/hermes-35b-timeout-resident` (selects the
resident class + repoints the tool-calling role). Deploy is a Studio
`darwin-rebuild switch` (restarts serving briefly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)