### PR TITLE
fix(mlx): self-heal the listening-but-dead llama-swap zombie

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -31,6 +31,17 @@ let
   mlxWarmupPkg = pkgs.writeShellScriptBin "mlx-warmup" ''
     exec ${pkgs.python3}/bin/python3 ${./scripts/mlx-warmup.py} "$@"
   '';
+  # mlx-watchdog — periodic liveness probe that kickstarts the proxy when it
+  # panics into a listening-but-dead zombie (KeepAlive only catches process
+  # exit). writeShellApplication shellcheck-validates the script at eval time.
+  mlxWatchdogPkg = pkgs.writeShellApplication {
+    name = "mlx-watchdog";
+    runtimeInputs = with pkgs; [
+      curl
+      coreutils
+    ];
+    text = builtins.readFile ./scripts/mlx-watchdog.sh;
+  };
 
   # llama-swap proxy package — sits on the API port, manages vllm-mlx child processes.
   # Sourced from nixpkgs-unstable: 25.11-darwin froze it at v165 on 2025-09-22
@@ -204,6 +215,7 @@ in
       cfg
       vllmMlxPkg
       mlxWarmupPkg
+      mlxWatchdogPkg
       vllmMlxVersion
       parakeetMlxVersion
       mlxVlmVersion

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -18,6 +18,7 @@ let
     warmupAgentLabel
     apiUrl
     mlxWarmupPkg
+    mlxWatchdogPkg
     llamaSwapPkg
     llamaSwapConfigFile
     llamaSwapRuntimeConfigPath
@@ -106,6 +107,32 @@ in
           StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.error.log";
         };
       };
+
+      # Liveness watchdog: KeepAlive=true only restarts the proxy on process
+      # EXIT, so a llama-swap panic into a listening-but-dead zombie (socket
+      # open, answering nothing) is never caught -> connection-refused ->
+      # litellm MidStreamFallbackError until a human kickstarts it. This probes
+      # /v1/models every StartInterval and kickstarts the server agent on
+      # repeated failure. The script self-gates re-fires with a cooldown marker
+      # so a slow model reload is not restart-stormed (mlx-watchdog.sh).
+      agents.vllm-mlx-watchdog = {
+        enable = true;
+        config = {
+          Label = "dev.vllm-mlx.watchdog";
+          ProgramArguments = [ (lib.getExe mlxWatchdogPkg) ];
+          RunAtLoad = false;
+          # 60 s: a zombie is detected and kickstarted within one cron gap
+          # (crons fire every ~15 min), so the following tick finds it healthy.
+          StartInterval = 60;
+          ProcessType = "Background";
+          EnvironmentVariables = {
+            MLX_API_URL = apiUrl;
+            MLX_LAUNCHD_LABEL = launchAgentLabel;
+          };
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.error.log";
+        };
+      };
     };
 
     home = {
@@ -121,6 +148,8 @@ in
         ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log              :              644   3      10240 *     J
         ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.error.log :              644   3      10240 *     J
         ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.log       :              644   3      10240 *     J
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.error.log :            644   3      10240 *     J
+        ${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.log     :              644   3      10240 *     J
       '';
 
       # ==========================================================================

--- a/modules/mlx/packages.nix
+++ b/modules/mlx/packages.nix
@@ -21,6 +21,7 @@ let
     cfg
     vllmMlxPkg
     mlxWarmupPkg
+    mlxWatchdogPkg
     vllmMlxVersion
     parakeetMlxVersion
     mlxVlmVersion
@@ -194,6 +195,11 @@ in
             echo "vllm-mlx ready (''${elapsed}s)"
           '';
         })
+
+        # mlx-watchdog — one probe-and-maybe-kickstart cycle for the zombie
+        # self-heal (also run every 60s by the vllm-mlx-watchdog LaunchAgent).
+        # On PATH for manual break-fix / testing.
+        mlxWatchdogPkg
 
         # ======================================================================
         # Model Inventory

--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -1,0 +1,65 @@
+# mlx-watchdog — self-heal the listening-but-dead llama-swap zombie.
+#
+# The vllm-mlx LaunchAgent uses KeepAlive=true, which only restarts the proxy on
+# process EXIT. But llama-swap can panic (`sync: WaitGroup is reused before
+# previous Wait has returned`) into a process that is still ALIVE and still
+# holding the listen socket, yet answers nothing — a zombie. launchd never
+# notices (no exit), so the socket stays open, every request gets
+# connection-refused / a hung stream, and litellm surfaces
+# MidStreamFallbackError until a human kickstarts it. This probe closes that gap:
+# it health-checks the proxy's own /v1/models endpoint and, on repeated failure,
+# kickstarts the server LaunchAgent — the sanctioned Mac serving-host break-fix.
+#
+# Health signal choice: /v1/models is answered by llama-swap itself from its
+# static config, WITHOUT loading a model, so it stays up during a normal model
+# swap. A failure there means the proxy — not a worker — is dead. That is the
+# exact zombie signature, and it avoids the cost/side-effects of a real
+# completion probe.
+#
+# Loop-cadence (durable min-interval marker): the scheduler is launchd's
+# StartInterval, but a 70 GB model reload takes 20-60 s, so a naive probe would
+# see "still down" and kickstart again mid-reload, never recovering. A cooldown
+# marker written AFTER each kickstart gates re-firing: a storming scheduler
+# no-ops, a genuinely-still-dead proxy is retried only once the cooldown lapses.
+
+set -euo pipefail
+
+health_url="${MLX_API_URL:?MLX_API_URL unset}/models"
+label="${MLX_LAUNCHD_LABEL:?MLX_LAUNCHD_LABEL unset}"
+marker="${MLX_WATCHDOG_MARKER:-${HOME}/Library/Caches/vllm-mlx/watchdog-last-kick}"
+# Cooldown >= ThrottleInterval (120 s) + headroom for the largest resident
+# model's cold load, so one kickstart gets a full recovery window before the
+# next is allowed.
+cooldown="${MLX_WATCHDOG_COOLDOWN:-180}"
+probe_timeout="${MLX_WATCHDOG_PROBE_TIMEOUT:-15}"
+
+mkdir -p "$(dirname "$marker")"
+
+# Cadence gate FIRST: if we kickstarted within the cooldown, the proxy may still
+# be reloading — do nothing (including no log noise) rather than re-kick it.
+now="$(date +%s)"
+last="$(cat "$marker" 2>/dev/null || echo 0)"
+if (( now - last < cooldown )); then
+  exit 0
+fi
+
+probe() { curl -sf --max-time "$probe_timeout" "$health_url" >/dev/null 2>&1; }
+
+# Healthy proxy answers immediately. One transient miss (a brief hiccup under
+# load) must not trigger a restart, so require two consecutive failures.
+if probe; then
+  exit 0
+fi
+sleep 3
+if probe; then
+  exit 0
+fi
+
+# Zombie confirmed. launchctl is a system binary (absolute path — not on the
+# sanitized writeShellApplication PATH). `id` comes from coreutils.
+echo "$(date -u +%FT%TZ) mlx-watchdog: ${health_url} unreachable x2 -> kickstart ${label}" >&2
+/bin/launchctl kickstart -k "gui/$(id -u)/${label}" || true
+
+# Marker written AFTER the work: a crashed run does not suppress the retry; only
+# a successful kickstart starts the cooldown.
+printf '%s\n' "$now" > "$marker"


### PR DESCRIPTION
## Problem

The `vllm-mlx` LaunchAgent uses `KeepAlive=true`, which only restarts the proxy on process **exit**. llama-swap can panic (`sync: WaitGroup is reused before previous Wait has returned`) into a process that stays **alive** and holds the listen socket but answers nothing — a zombie launchd never notices. Result: connection-refused on every request → litellm `MidStreamFallbackError` → Hermes crons fail, until a human kickstarts it. This is a recurring homelab outage signature.

## Fix

A `vllm-mlx-watchdog` LaunchAgent (`StartInterval` 60s) runs `mlx-watchdog.sh`:
- Probes the proxy's own `/v1/models` (answered from static config **without** loading a model, so it survives a normal model swap — a failure there means the *proxy*, not a worker, is dead).
- Two consecutive failures → `launchctl kickstart -k` the server agent. Health, not PID.
- **Loop-cadence**: a cooldown marker written *after* each kickstart gates re-firing, so a 20-60s model reload isn't restart-stormed. A storming scheduler no-ops; a genuinely-dead proxy is retried once the cooldown lapses.
- `mlx-watchdog` is also on PATH for manual break-fix.

## Verification
- `nix flake check` clean; `nix fmt` clean.
- `writeShellApplication` shellcheck-clean and builds.
- Smoke test covers all three paths: zombie → double-probe + kickstart + marker; cooldown → instant no-op; healthy → clean exit, no kickstart.

Runtime validation (kickstart actually recovering a wedged proxy) requires `darwin-rebuild switch` on each Mac serving host — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)