### PR TITLE
fix(mlx): make the zombie watchdog CI-clean (statix + shellcheck)

### DIFF
--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -39,98 +39,100 @@ in
       # emergency cache clear; programs.mlx.gpuMemoryUtilization) plus
       # --cache-memory-mb and --auto-unload-idle-seconds (set in the generated
       # config). programs.mlx.memoryHardLimitGb remains declarative intent only.
-      agents.vllm-mlx = {
-        enable = true;
-        config = {
-          Label = launchAgentLabel;
-          ProgramArguments = [
-            (lib.getExe llamaSwapPkg)
-            "--config"
-            llamaSwapRuntimeConfigPath
-            "--watch-config"
-            "--listen"
-            "${cfg.host}:${toString cfg.port}"
-          ];
-          RunAtLoad = true;
-          KeepAlive = true;
-          # 2 min throttle — 70GB model loads take 20-60s, prevents rapid crash-restart loops (closes #256)
-          ThrottleInterval = 120;
-          # Interactive by default — Background QoS clamps Metal decode ~8x
-          # (see options-runtime.nix processType). OOM backstop is the RSS
-          # hard limit, not Jetsam eligibility.
-          ProcessType = cfg.processType;
-          # Do not abandon the process group; ensure child vllm-mlx processes
-          # are terminated when launchd stops the proxy.
-          AbandonProcessGroup = false;
-          EnvironmentVariables = {
-            HF_HOME = cfg.huggingFaceHome;
-          }
-          // lib.optionalAttrs cfg.telemetry.enable {
-            # Standard OTel env vars inherited by llama-swap and its vllm-mlx children.
-            # The OTEL Collector at :30317 fans out to Cribl/Splunk and (optionally)
-            # to Galileo — see docs/adr/0003-galileo-ai-observability.md.
-            # Trace emission from vllm-mlx 0.2.9 is best-effort; the collector's
-            # routing connector is the primary gate, not the agent env.
-            OTEL_SERVICE_NAME = "vllm-mlx";
-            OTEL_EXPORTER_OTLP_ENDPOINT = cfg.telemetry.otlpEndpoint;
-            OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
-            OTEL_RESOURCE_ATTRIBUTES = "service.namespace=mlx,deployment.environment=homelab";
+      agents = {
+        vllm-mlx = {
+          enable = true;
+          config = {
+            Label = launchAgentLabel;
+            ProgramArguments = [
+              (lib.getExe llamaSwapPkg)
+              "--config"
+              llamaSwapRuntimeConfigPath
+              "--watch-config"
+              "--listen"
+              "${cfg.host}:${toString cfg.port}"
+            ];
+            RunAtLoad = true;
+            KeepAlive = true;
+            # 2 min throttle — 70GB model loads take 20-60s, prevents rapid crash-restart loops (closes #256)
+            ThrottleInterval = 120;
+            # Interactive by default — Background QoS clamps Metal decode ~8x
+            # (see options-runtime.nix processType). OOM backstop is the RSS
+            # hard limit, not Jetsam eligibility.
+            ProcessType = cfg.processType;
+            # Do not abandon the process group; ensure child vllm-mlx processes
+            # are terminated when launchd stops the proxy.
+            AbandonProcessGroup = false;
+            EnvironmentVariables = {
+              HF_HOME = cfg.huggingFaceHome;
+            }
+            // lib.optionalAttrs cfg.telemetry.enable {
+              # Standard OTel env vars inherited by llama-swap and its vllm-mlx children.
+              # The OTEL Collector at :30317 fans out to Cribl/Splunk and (optionally)
+              # to Galileo — see docs/adr/0003-galileo-ai-observability.md.
+              # Trace emission from vllm-mlx 0.2.9 is best-effort; the collector's
+              # routing connector is the primary gate, not the agent env.
+              OTEL_SERVICE_NAME = "vllm-mlx";
+              OTEL_EXPORTER_OTLP_ENDPOINT = cfg.telemetry.otlpEndpoint;
+              OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
+              OTEL_RESOURCE_ATTRIBUTES = "service.namespace=mlx,deployment.environment=homelab";
+            };
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log";
           };
-          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.log";
-          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx.error.log";
         };
-      };
 
-      # One-shot warmup job: wait for the proxy to answer, then fault each
-      # preloaded model with a 1-token chat completion so the weights are
-      # resident at boot instead of on first user request. Also kickstarted
-      # by mlx-default.sh after every proxy restart (via MLX_WARMUP_LABEL) —
-      # this is the ONLY preload path; llama-swap's hooks.on_startup.preload
-      # is deliberately not emitted (its request shape 404s vllm-mlx, #1175).
-      agents.vllm-mlx-warmup = {
-        enable = true;
-        config = {
-          Label = warmupAgentLabel;
-          ProgramArguments = [ (lib.getExe mlxWarmupPkg) ];
-          RunAtLoad = true;
-          KeepAlive = {
-            SuccessfulExit = false;
+        # One-shot warmup job: wait for the proxy to answer, then fault each
+        # preloaded model with a 1-token chat completion so the weights are
+        # resident at boot instead of on first user request. Also kickstarted
+        # by mlx-default.sh after every proxy restart (via MLX_WARMUP_LABEL) —
+        # this is the ONLY preload path; llama-swap's hooks.on_startup.preload
+        # is deliberately not emitted (its request shape 404s vllm-mlx, #1175).
+        vllm-mlx-warmup = {
+          enable = true;
+          config = {
+            Label = warmupAgentLabel;
+            ProgramArguments = [ (lib.getExe mlxWarmupPkg) ];
+            RunAtLoad = true;
+            KeepAlive = {
+              SuccessfulExit = false;
+            };
+            ThrottleInterval = 120;
+            ProcessType = "Background";
+            EnvironmentVariables = {
+              MLX_API_URL = apiUrl;
+              MLX_PRELOAD_MODELS = lib.concatStringsSep " " cfg.preload;
+              MLX_PRELOAD_MODELS_JSON = builtins.toJSON cfg.preload;
+            };
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.error.log";
           };
-          ThrottleInterval = 120;
-          ProcessType = "Background";
-          EnvironmentVariables = {
-            MLX_API_URL = apiUrl;
-            MLX_PRELOAD_MODELS = lib.concatStringsSep " " cfg.preload;
-            MLX_PRELOAD_MODELS_JSON = builtins.toJSON cfg.preload;
-          };
-          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.log";
-          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-warmup.error.log";
         };
-      };
 
-      # Liveness watchdog: KeepAlive=true only restarts the proxy on process
-      # EXIT, so a llama-swap panic into a listening-but-dead zombie (socket
-      # open, answering nothing) is never caught -> connection-refused ->
-      # litellm MidStreamFallbackError until a human kickstarts it. This probes
-      # /v1/models every StartInterval and kickstarts the server agent on
-      # repeated failure. The script self-gates re-fires with a cooldown marker
-      # so a slow model reload is not restart-stormed (mlx-watchdog.sh).
-      agents.vllm-mlx-watchdog = {
-        enable = true;
-        config = {
-          Label = "dev.vllm-mlx.watchdog";
-          ProgramArguments = [ (lib.getExe mlxWatchdogPkg) ];
-          RunAtLoad = false;
-          # 60 s: a zombie is detected and kickstarted within one cron gap
-          # (crons fire every ~15 min), so the following tick finds it healthy.
-          StartInterval = 60;
-          ProcessType = "Background";
-          EnvironmentVariables = {
-            MLX_API_URL = apiUrl;
-            MLX_LAUNCHD_LABEL = launchAgentLabel;
+        # Liveness watchdog: KeepAlive=true only restarts the proxy on process
+        # EXIT, so a llama-swap panic into a listening-but-dead zombie (socket
+        # open, answering nothing) is never caught -> connection-refused ->
+        # litellm MidStreamFallbackError until a human kickstarts it. This probes
+        # /v1/models every StartInterval and kickstarts the server agent on
+        # repeated failure. The script self-gates re-fires with a cooldown marker
+        # so a slow model reload is not restart-stormed (mlx-watchdog.sh).
+        vllm-mlx-watchdog = {
+          enable = true;
+          config = {
+            Label = "dev.vllm-mlx.watchdog";
+            ProgramArguments = [ (lib.getExe mlxWatchdogPkg) ];
+            RunAtLoad = false;
+            # 60 s: a zombie is detected and kickstarted within one cron gap
+            # (crons fire every ~15 min), so the following tick finds it healthy.
+            StartInterval = 60;
+            ProcessType = "Background";
+            EnvironmentVariables = {
+              MLX_API_URL = apiUrl;
+              MLX_LAUNCHD_LABEL = launchAgentLabel;
+            };
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.error.log";
           };
-          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.log";
-          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.error.log";
         };
       };
     };

--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -1,18 +1,18 @@
-# mlx-watchdog — self-heal the listening-but-dead llama-swap zombie.
+# mlx-watchdog - self-heal the listening-but-dead llama-swap zombie.
 #
 # The vllm-mlx LaunchAgent uses KeepAlive=true, which only restarts the proxy on
 # process EXIT. But llama-swap can panic (`sync: WaitGroup is reused before
 # previous Wait has returned`) into a process that is still ALIVE and still
-# holding the listen socket, yet answers nothing — a zombie. launchd never
+# holding the listen socket, yet answers nothing - a zombie. launchd never
 # notices (no exit), so the socket stays open, every request gets
 # connection-refused / a hung stream, and litellm surfaces
 # MidStreamFallbackError until a human kickstarts it. This probe closes that gap:
 # it health-checks the proxy's own /v1/models endpoint and, on repeated failure,
-# kickstarts the server LaunchAgent — the sanctioned Mac serving-host break-fix.
+# kickstarts the server LaunchAgent - the sanctioned Mac serving-host break-fix.
 #
 # Health signal choice: /v1/models is answered by llama-swap itself from its
 # static config, WITHOUT loading a model, so it stays up during a normal model
-# swap. A failure there means the proxy — not a worker — is dead. That is the
+# swap. A failure there means the proxy - not a worker - is dead. That is the
 # exact zombie signature, and it avoids the cost/side-effects of a real
 # completion probe.
 #
@@ -36,7 +36,7 @@ probe_timeout="${MLX_WATCHDOG_PROBE_TIMEOUT:-15}"
 mkdir -p "$(dirname "$marker")"
 
 # Cadence gate FIRST: if we kickstarted within the cooldown, the proxy may still
-# be reloading — do nothing (including no log noise) rather than re-kick it.
+# be reloading - do nothing (including no log noise) rather than re-kick it.
 now="$(date +%s)"
 last="$(cat "$marker" 2>/dev/null || echo 0)"
 if (( now - last < cooldown )); then
@@ -55,7 +55,7 @@ if probe; then
   exit 0
 fi
 
-# Zombie confirmed. launchctl is a system binary (absolute path — not on the
+# Zombie confirmed. launchctl is a system binary (absolute path - not on the
 # sanitized writeShellApplication PATH). `id` comes from coreutils.
 echo "$(date -u +%FT%TZ) mlx-watchdog: ${health_url} unreachable x2 -> kickstart ${label}" >&2
 /bin/launchctl kickstart -k "gui/$(id -u)/${label}" || true


### PR DESCRIPTION
The watchdog (#1221) landed on develop but the promotion (#1222) surfaced two Nix Validate failures the develop PR didn't run:

- **check-shellcheck**: em-dash (U+2014) in `mlx-watchdog.sh` comments → CI's C-locale shellcheck can't encode it (`commitBuffer: invalid argument`). Now ASCII-only.
- **check-statix**: three `agents.<name>` keys tripped W20 (repeated keys) → nested under one `agents = { … }` (statix's suggested fix, semantically identical).

Verified locally with the exact tools: `statix check` CLEAN, `LC_ALL=C shellcheck -s bash` CLEAN (reproduces then clears the CI error). Unblocks promotion #1222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)