### PR TITLE
fix(mlx): add shebang to mlx-watchdog.sh (shellcheck SC2148)

### DIFF
--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # mlx-watchdog - self-heal the listening-but-dead llama-swap zombie.
 #
 # The vllm-mlx LaunchAgent uses KeepAlive=true, which only restarts the proxy on


### PR DESCRIPTION
Third and final CI fix for the zombie watchdog. `check-shellcheck` runs shellcheck **without** `-s`, so the no-shebang body tripped SC2148 (unknown target shell) — my earlier local `shellcheck -s bash` masked it. Added `#!/usr/bin/env bash` to match every sibling `writeShellApplication` body. Verified: `shellcheck` (no -s, the CI invocation) CLEAN.

Unblocks promotion #1222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)