### PR TITLE
fix(mlx): guard watchdog marker against corrupt content

### DIFF
--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -40,6 +40,10 @@ mkdir -p "$(dirname "$marker")"
 # be reloading - do nothing (including no log noise) rather than re-kick it.
 now="$(date +%s)"
 last="$(cat "$marker" 2>/dev/null || echo 0)"
+# A corrupt/partial marker write (non-integer content) would crash the
+# arithmetic below under set -e ("value too great for base"); an empty file is
+# already treated as 0 by (( )). Coerce anything non-numeric back to 0.
+[[ "$last" =~ ^[0-9]+$ ]] || last=0
 if (( now - last < cooldown )); then
   exit 0
 fi


### PR DESCRIPTION
Addresses the Gemini review thread on #1222. A non-integer marker (corrupt/partial write) crashes `(( now - last < cooldown ))` under `set -e`. Verified precisely: **empty** is already 0-safe in `(( ))`, but **garbage** (`17abc`) crashes with `value too great for base` — so the guard coerces any non-numeric content to 0. Valid ints preserved; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)