### PR TITLE
fix(skills): source shared plugin skills directly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -420,15 +420,15 @@
     "jacobpevans-cc-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1783096239,
-        "narHash": "sha256-9fK/q7nQRyRxu3GOf+JzhrdwNZ00lcs7YnBUIIZafFE=",
-        "owner": "JacobPEvans",
+        "lastModified": 1784062929,
+        "narHash": "sha256-aTE2Rrkabc/LiQfqZBQiB9y/yne5vJKpXrvWXJLpgt8=",
+        "owner": "dryvist",
         "repo": "claude-code-plugins",
-        "rev": "281ab4d7f780e39f53ca2a77b7858f593e6a941e",
+        "rev": "0b39041e8c9ed555c62667e89eb72abc5dcef0cd",
         "type": "github"
       },
       "original": {
-        "owner": "JacobPEvans",
+        "owner": "dryvist",
         "repo": "claude-code-plugins",
         "type": "github"
       }
@@ -526,7 +526,9 @@
           "home-manager"
         ],
         "huggingface-skills": "huggingface-skills",
-        "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
+        "jacobpevans-cc-plugins": [
+          "jacobpevans-cc-plugins"
+        ],
         "karpathy-skills": "karpathy-skills_2",
         "lunar-claude": "lunar-claude",
         "nixpkgs": [
@@ -540,11 +542,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783853804,
-        "narHash": "sha256-T7osZbdTH1SGa8XzEvp9Du1F+Nv7NRxcBMFwmGfuZss=",
+        "lastModified": 1783966074,
+        "narHash": "sha256-1s/OyTEQS566RL4+Hwrf+I6HzYkRTb/HefHxhYfinew=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "6a4a356b0c6e7b2d52c7cef5a33241a06317847d",
+        "rev": "7b2bfdfc37745f58404b82054071f0686e74370c",
         "type": "github"
       },
       "original": {
@@ -641,6 +643,7 @@
         "dashmotion": "dashmotion",
         "fabric-src": "fabric-src",
         "home-manager": "home-manager",
+        "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "karpathy-skills": "karpathy-skills",
         "last30days-skill": "last30days-skill",
         "nix-claude-code": "nix-claude-code",

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,13 @@
       flake = false;
     };
 
+    # Canonical dryvist plugin and cross-tool skill source. Retain the input
+    # name for compatibility; non-Claude harnesses consume it directly.
+    jacobpevans-cc-plugins = {
+      url = "github:dryvist/claude-code-plugins";
+      flake = false;
+    };
+
     # Declarative Claude Code module. Owns programs.claude.* schema,
     # marketplace catalog, synthetic marketplace derivations, lib helpers,
     # and the byte-equivalence CI fixture. The 20 marketplace inputs that
@@ -37,6 +44,7 @@
         home-manager.follows = "home-manager";
         ai-assistant-instructions.follows = "ai-assistant-instructions";
         claude-code-plugins.follows = "claude-code-plugins";
+        jacobpevans-cc-plugins.follows = "jacobpevans-cc-plugins";
         # nix-claude-code injects fabric-src as the module arg that our
         # fabric-ai package consumes in the composed home config. Pin it to
         # our own fabric-src so the built source matches lib/versions.nix
@@ -113,6 +121,7 @@
       nixpkgs-unstable,
       home-manager,
       ai-assistant-instructions,
+      jacobpevans-cc-plugins,
       nix-claude-code,
       karpathy-skills,
       fabric-src,
@@ -134,6 +143,7 @@
       homeManagerModules = import ./flake/home-manager-modules.nix {
         inherit
           ai-assistant-instructions
+          jacobpevans-cc-plugins
           nix-claude-code
           karpathy-skills
           nixpkgs-unstable

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -1,5 +1,6 @@
 {
   ai-assistant-instructions,
+  jacobpevans-cc-plugins,
   nix-claude-code,
   karpathy-skills,
   nixpkgs-unstable,
@@ -30,7 +31,6 @@ let
       claude-code-workflows
       claude-plugins-official
       claude-skills
-      jacobpevans-cc-plugins
       lunar-claude
       obsidian-skills
       openai-codex
@@ -39,6 +39,7 @@ let
       visual-explainer-marketplace
       wakatime
       ;
+    inherit jacobpevans-cc-plugins;
     inherit karpathy-skills;
     inherit dashmotion;
     inherit ponytail;

--- a/lib/checks/agent-skills.nix
+++ b/lib/checks/agent-skills.nix
@@ -88,5 +88,8 @@ in
     assert
       builtins.elem ".agents/skills/autoresearch" managedSkillEntries
       || throw "autoresearch skill not discovered from its flake input";
+    assert
+      builtins.elem ".agents/skills/premium-agent-orchestration" managedSkillEntries
+      || throw "premium-agent-orchestration skill not discovered from the direct plugin input";
     helpers.mkMarker "check-agent-skills-home-files" "Agent Skills home.file wiring: ${toString (builtins.length managedSkillEntries)} managed skill entries";
 }


### PR DESCRIPTION
## Summary
- Make `nix-ai` directly own the `dryvist/claude-code-plugins` skill source.
- Deliver its skills through the generic agent-skills registry, including Codex.

## Changes
- Add the canonical plugin source as a top-level `nix-ai` input and pass it to shared Home Manager modules.
- Make `nix-claude-code` follow that canonical input, removing the stale duplicate lock node while keeping Codex skill discovery independent of the Claude layer.
- Add a regression assertion for `premium-agent-orchestration` in generated shared-skill entries.
- Close superseded dryvist/nix-darwin#1701 and remove its remote branch.

## Test Plan
- [x] Resolve the generated `premium-agent-orchestration` entry from the direct source.
- [x] `nix flake check --no-build`
- [x] `git diff --check`
- [ ] Linux CI evaluates Linux-only derivations; macOS all-systems evaluation remains blocked by pre-existing Fabric and Antigravity invalid-store-path failures.

Refs: dryvist/nix-darwin#1701