### PR TITLE
feat(opencode): render shared MCP servers via shared mcp client helper

### DIFF
--- a/lib/checks/mcp.nix
+++ b/lib/checks/mcp.nix
@@ -20,6 +20,7 @@ let
     antigravity-cli = hmConfig.config.programs.antigravity-cli.mcpServerNames;
     antigravity-ide = hmConfig.config.programs.antigravity-ide.mcpServerNames;
     qwen-code = hmConfig.config.programs.qwen-code.mcpServerNames;
+    opencode = hmConfig.config.programs.opencode.mcpServerNames;
   };
   rendererMismatches = builtins.filter (name: rendererNames.${name} != cfg.enabledServerNames) (
     builtins.attrNames rendererNames
@@ -36,5 +37,5 @@ in
     assert
       rendererMismatches == [ ]
       || throw "MCP renderer parity mismatch: ${builtins.toJSON rendererMismatches}; shared=${builtins.toJSON cfg.enabledServerNames}; renderers=${builtins.toJSON rendererNames}";
-    helpers.mkMarker "check-shared-mcp-renderer-parity" "Shared MCP renderer parity verified for Claude, Codex, Antigravity CLI/IDE, and Qwen";
+    helpers.mkMarker "check-shared-mcp-renderer-parity" "Shared MCP renderer parity verified for Claude, Codex, Antigravity CLI/IDE, Qwen, and OpenCode";
 }

--- a/modules/antigravity-cli/options.nix
+++ b/modules/antigravity-cli/options.nix
@@ -6,6 +6,8 @@
 { lib, ... }:
 
 let
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+
   componentModule = lib.types.submodule {
     options = {
       name = lib.mkOption { type = lib.types.str; };
@@ -226,18 +228,7 @@ in
       };
     };
 
-    # MCP servers to exclude from shared definitions
-    excludedMcpServers = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Additional MCP servers to exclude from the shared cross-agent profile for Antigravity only.";
-    };
-
-    mcpServerNames = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      readOnly = true;
-      internal = true;
-      description = "Names of MCP servers emitted to Antigravity settings.json.";
-    };
-  };
+    # excludedMcpServers + mcpServerNames come from the shared MCP client helper.
+  }
+  // mcpClient.mkClientOptions "Antigravity CLI";
 }

--- a/modules/antigravity-cli/settings.nix
+++ b/modules/antigravity-cli/settings.nix
@@ -26,6 +26,8 @@ let
   };
   inherit (aiCommon) permissions formatters;
 
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+
   defaultTrustedFolders = [
     "${homeDir}/.config/nix"
     "${homeDir}/.config"
@@ -45,13 +47,11 @@ let
 
   mergedSandboxAllowedPaths = lib.unique (defaultSandboxAllowedPaths ++ cfg.sandboxAllowedPaths);
 
-  mcpServers =
-    lib.mapAttrs' (name: server: lib.nameValuePair name (formatters.utils.normalizeMcpServer server))
-      (
-        lib.filterAttrs (
-          name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-        ) config.programs.aiMcp.enabledServers
-      );
+  mcpServers = mcpClient.renderServers {
+    inherit (config.programs.aiMcp) enabledServers;
+    excluded = cfg.excludedMcpServers;
+    normalize = formatters.utils.normalizeMcpServer;
+  };
 
   # Policy Engine: generate TOML rules from shared permissions
   policyRules =

--- a/modules/antigravity-ide/default.nix
+++ b/modules/antigravity-ide/default.nix
@@ -21,17 +21,17 @@ let
   };
   inherit (aiCommon) permissions formatters;
 
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+
   # Format permissions for Antigravity Desktop app (permissionGrants)
   # The format is "command(cmd)"
   allowedCommands = formatters."antigravity-ide".formatAllowed permissions;
 
-  mcpServers =
-    lib.mapAttrs' (name: server: lib.nameValuePair name (formatters.utils.normalizeMcpServer server))
-      (
-        lib.filterAttrs (
-          name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-        ) config.programs.aiMcp.enabledServers
-      );
+  mcpServers = mcpClient.renderServers {
+    inherit (config.programs.aiMcp) enabledServers;
+    excluded = cfg.excludedMcpServers;
+    normalize = formatters.utils.normalizeMcpServer;
+  };
 
   mcpConfig = {
     inherit mcpServers;
@@ -78,19 +78,8 @@ in
       description = "Default artifact review mode.";
     };
 
-    excludedMcpServers = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Additional MCP servers to exclude from the shared cross-agent profile for Antigravity IDE only.";
-    };
-
-    mcpServerNames = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      readOnly = true;
-      internal = true;
-      description = "Names of MCP servers emitted to Antigravity IDE mcp_config.json.";
-    };
-  };
+  }
+  // mcpClient.mkClientOptions "Antigravity IDE";
 
   config = lib.mkMerge [
     {

--- a/modules/codex/options.nix
+++ b/modules/codex/options.nix
@@ -6,6 +6,7 @@
 { lib, ... }:
 
 let
+  mcpClient = import ../mcp/client.nix { inherit lib; };
   hookType = lib.types.nullOr (lib.types.either lib.types.path lib.types.lines);
   nullableStr = lib.types.nullOr lib.types.str;
   nullableReasoningEffort = lib.types.nullOr (
@@ -117,18 +118,7 @@ in
       description = "Default approval policy for Codex sessions";
     };
 
-    # MCP servers to exclude from shared definitions
-    excludedMcpServers = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Additional MCP servers to exclude from the shared cross-agent profile for Codex only.";
-    };
-
-    mcpServerNames = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      readOnly = true;
-      internal = true;
-      description = "Names of MCP servers emitted to Codex config.toml.";
-    };
-  };
+    # excludedMcpServers + mcpServerNames come from the shared MCP client helper.
+  }
+  // mcpClient.mkClientOptions "Codex";
 }

--- a/modules/codex/settings.nix
+++ b/modules/codex/settings.nix
@@ -20,6 +20,8 @@ let
   };
   inherit (aiCommon) permissions formatters;
 
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+
   # Mirror upstream home-manager programs.codex path logic so rules/config.toml stay co-located.
   packageVersion = if cfg.package != null then lib.getVersion cfg.package else "0.2.0";
   isTomlConfig = lib.versionAtLeast packageVersion "0.2.0";
@@ -74,11 +76,11 @@ let
       name: value: lib.elem name allowedKeys && value != null && value != [ ] && value != { }
     ) server;
 
-  mcpServers = lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeMcpServer server)) (
-    lib.filterAttrs (
-      name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-    ) config.programs.aiMcp.enabledServers
-  );
+  mcpServers = mcpClient.renderServers {
+    inherit (config.programs.aiMcp) enabledServers;
+    excluded = cfg.excludedMcpServers;
+    normalize = normalizeMcpServer;
+  };
 
   optionalValue = key: value: lib.optionalAttrs (value != null) { ${key} = value; };
 

--- a/modules/mcp/client.nix
+++ b/modules/mcp/client.nix
@@ -1,0 +1,34 @@
+# Shared MCP client helpers
+#
+# Every AI client module renders the same shared catalog into its own config
+# format: filter out the per-tool excludes, then run a tool-specific
+# normalizer. This centralizes that filter/render step and the two duplicated
+# option definitions (excludedMcpServers + mcpServerNames) so each client only
+# supplies its normalizer.
+{ lib }:
+{
+  # programs.aiMcp.enabledServers is already filtered for disabled/global-exclude
+  # (modules/mcp/default.nix) — only the per-tool exclude list applies here.
+  renderServers =
+    {
+      enabledServers,
+      excluded ? [ ],
+      normalize,
+    }:
+    lib.mapAttrs (_: normalize) (lib.filterAttrs (name: _: !lib.elem name excluded) enabledServers);
+
+  mkClientOptions = tool: {
+    excludedMcpServers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional MCP servers to exclude from the shared cross-agent profile for ${tool} only.";
+    };
+
+    mcpServerNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Names of MCP servers emitted to ${tool}'s config; read-only.";
+    };
+  };
+}

--- a/modules/opencode/default.nix
+++ b/modules/opencode/default.nix
@@ -20,9 +20,37 @@ let
   aiCommon = import ../common { inherit lib config nix-claude-code; };
   permission = aiCommon.formatters.opencode.formatPermission aiCommon.permissions;
 
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+
+  # opencode.json uses a local/remote-tagged MCP schema: local servers carry a
+  # single `command` array (argv0 included) and `environment`; remote servers
+  # carry `url` and optional `headers`. `enabled` defaults true, so it is
+  # omitted. Verified against https://opencode.ai/config.json.
+  normalizeMcpServer =
+    server:
+    if server.url != null then
+      {
+        type = "remote";
+        inherit (server) url;
+      }
+      // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
+    else
+      {
+        type = "local";
+        command = [ server.command ] ++ server.args;
+      }
+      // lib.optionalAttrs (server.env != { }) { environment = server.env; };
+
+  mcpServers = mcpClient.renderServers {
+    inherit (config.programs.aiMcp) enabledServers;
+    excluded = cfg.excludedMcpServers;
+    normalize = normalizeMcpServer;
+  };
+
   settings = {
     "$schema" = "https://opencode.ai/config.json";
     inherit permission;
+    mcp = mcpServers;
   };
 
   mdFiles =
@@ -47,12 +75,20 @@ in
   # module owns the option namespace (same pattern as antigravity-cli).
   disabledModules = [ "programs/opencode.nix" ];
 
-  config = lib.mkIf cfg.enable {
-    home.file = {
-      ".config/opencode/opencode.json".text = builtins.toJSON (
-        lib.recursiveUpdate settings cfg.extraSettings
-      );
+  config = lib.mkMerge [
+    # Read-only introspection option set unconditionally so module evaluation
+    # (and the shared MCP renderer-parity check) succeeds even when
+    # programs.opencode.enable = false.
+    {
+      programs.opencode.mcpServerNames = lib.attrNames mcpServers;
     }
-    // lib.foldl' (acc: dir: acc // mkCommandLinks dir) { } cfg.commandDirs;
-  };
+    (lib.mkIf cfg.enable {
+      home.file = {
+        ".config/opencode/opencode.json".text = builtins.toJSON (
+          lib.recursiveUpdate settings cfg.extraSettings
+        );
+      }
+      // lib.foldl' (acc: dir: acc // mkCommandLinks dir) { } cfg.commandDirs;
+    })
+  ];
 }

--- a/modules/opencode/options.nix
+++ b/modules/opencode/options.nix
@@ -1,5 +1,8 @@
 # OpenCode Module Options
 { lib, ... }:
+let
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+in
 {
   options.programs.opencode = {
     enable = lib.mkEnableOption "OpenCode (sst/opencode terminal agent)";
@@ -15,5 +18,6 @@
       default = { };
       description = "Attrs merged into ~/.config/opencode/opencode.json (wins over module defaults).";
     };
-  };
+  }
+  // mcpClient.mkClientOptions "OpenCode";
 }

--- a/modules/qwen-code/options.nix
+++ b/modules/qwen-code/options.nix
@@ -3,6 +3,9 @@
 #
 { lib, ... }:
 
+let
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+in
 {
   options.programs.qwen-code = {
     enable = lib.mkEnableOption "Qwen Code (Alibaba terminal coding agent)";
@@ -44,17 +47,6 @@
       '';
     };
 
-    excludedMcpServers = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Additional MCP servers to exclude from the shared cross-agent profile for Qwen Code only.";
-    };
-
-    mcpServerNames = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      readOnly = true;
-      internal = true;
-      description = "Names of MCP servers emitted to Qwen settings.json.";
-    };
-  };
+  }
+  // mcpClient.mkClientOptions "Qwen Code";
 }

--- a/modules/qwen-code/settings.nix
+++ b/modules/qwen-code/settings.nix
@@ -29,6 +29,8 @@ let
   homeDir = config.home.homeDirectory;
   inherit (config.services.aiStack) models resolvedLlmEndpoint llmEndpoint;
 
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+
   # Endpoint + API-key source both follow services.aiStack.llmEndpoint. Local
   # (llama-swap) is an open loopback hop, so a dummy key satisfies the schema.
   # The router is bearer-gated: point qwen-code's envKey at OPENAI_API_KEY,
@@ -69,11 +71,11 @@ let
           ;
       };
 
-  mcpServers = lib.mapAttrs' (name: server: lib.nameValuePair name (normalizeMcpServer server)) (
-    lib.filterAttrs (
-      name: server: !(server.disabled or false) && !(lib.elem name cfg.excludedMcpServers)
-    ) config.programs.aiMcp.enabledServers
-  );
+  mcpServers = mcpClient.renderServers {
+    inherit (config.programs.aiMcp) enabledServers;
+    excluded = cfg.excludedMcpServers;
+    normalize = normalizeMcpServer;
+  };
 
   baseSettings = {
     inherit mcpServers;


### PR DESCRIPTION
## Summary
- Closes the biggest cross-tool parity gap: OpenCode imported the shared MCP module but rendered **zero** MCP servers into `opencode.json`; it now renders the full shared catalog (`mcp` key, verified against the live opencode config schema: local `command[]`/`environment`, remote `url`/`headers`).
- DRY: extracts the identical filter/render wrapper + `excludedMcpServers`/`mcpServerNames` option pair (copy-pasted across codex, qwen-code, antigravity-cli, antigravity-ide) into `modules/mcp/client.nix`. Per-tool normalizers and key allowlists stay per-tool. The per-site `disabled` re-check was dead code (`enabledServers` is pre-filtered) and is dropped.
- OpenCode joins the `shared-mcp-renderer-parity` regression check so this gap can't silently reopen.

## Validation
- `nix fmt` clean; `nix flake check` passes.
- Both MCP regression asserts force-evaluated locally (checks are gated to x86_64-linux; asserts hold — OpenCode's rendered server names equal the shared enabled set).
- statix + deadnix clean on all changed files.

## Notes
- Internal read-only `mcpServerNames` descriptions are unified by the shared helper (previously each named its own config file); user-facing `excludedMcpServers` descriptions preserved per-tool.
- Runtime `darwin-rebuild` verification tracked separately in-session; `excludedMcpServers` is the escape hatch if opencode's ~15 stdio server spawns prove heavy at launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmXShXB13r16uQypEXTevB