### PR TITLE
feat(qwen-code): wire shared permissions and AGENTS.md context

### DIFF
--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -172,6 +172,7 @@ in
     _module.args = {
       inherit
         ai-assistant-instructions
+        nix-claude-code
         marketplaceInputs
         ;
     };

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -81,6 +81,7 @@ in
 // (import ./checks/claude.nix { inherit pkgs hmConfig; })
 // (import ./checks/agent-skills.nix { inherit pkgs hmConfig; })
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })
+// (import ./checks/qwen-code.nix { inherit pkgs hmConfig; })
 // (import ./checks/antigravity-cli.nix { inherit pkgs hmConfig; })
 // (import ./checks/mcp.nix { inherit pkgs hmConfig; })
 // (import ./checks/autonomous-profile.nix { inherit pkgs; })

--- a/lib/checks/qwen-code.nix
+++ b/lib/checks/qwen-code.nix
@@ -1,0 +1,46 @@
+# Qwen Code module regression tests
+{ pkgs, hmConfig }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+  cfg = hmConfig.config.programs.qwen-code;
+in
+{
+  # Verify all expected Qwen Code option paths exist.
+  qwen-code-options-regression = helpers.mkOptionsRegression {
+    label = "Qwen Code";
+    checkName = "check-qwen-code-options-regression";
+    inherit cfg;
+    expectedOptions = [
+      "contextFileNames"
+      "enable"
+      "excludedMcpServers"
+      "extraSettings"
+      "installVia"
+      "mcpServerNames"
+      "model"
+    ];
+  };
+
+  # Verify evaluated config values match expected defaults.
+  qwen-code-defaults-regression = helpers.mkDefaultsRegression {
+    label = "Qwen Code";
+    checkName = "check-qwen-code-defaults-regression";
+    checks = [
+      {
+        name = "qwen-code.enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "qwen-code.model";
+        actual = cfg.model;
+        expected = "coding";
+      }
+      {
+        name = "qwen-code.contextFileNames";
+        actual = cfg.contextFileNames;
+        expected = [ "AGENTS.md" ];
+      }
+    ];
+  };
+}

--- a/modules/common/formatters.nix
+++ b/modules/common/formatters.nix
@@ -16,6 +16,7 @@ let
   copilot = import ./formatters/copilot.nix { inherit lib flattenCommands; };
   codex = import ./formatters/codex.nix { inherit lib flattenCommands; };
   opencode = import ./formatters/opencode.nix { inherit lib flattenCommands; };
+  qwen = import ./formatters/qwen.nix { inherit lib flattenCommands; };
 in
 {
   inherit
@@ -24,6 +25,7 @@ in
     copilot
     codex
     opencode
+    qwen
     utils
     ;
 

--- a/modules/common/formatters/qwen.nix
+++ b/modules/common/formatters/qwen.nix
@@ -1,0 +1,20 @@
+# Qwen Code Formatter
+#
+# Maps the shared permission engine onto qwen-code's `permissions` schema:
+# allow/ask/deny arrays of Claude-compatible rules. We emit one Bash(<cmd> *)
+# rule per shared command; qwen enforces deny > ask > allow precedence itself.
+# Only Bash command rules are mapped — qwen's builtin tool names and its
+# prefix-less WebFetch(host) syntax differ from Claude, so those are skipped.
+{ lib, flattenCommands }:
+{
+  formatPermissions =
+    permissions:
+    let
+      rules = cmds: map (cmd: "Bash(${cmd} *)") (flattenCommands cmds);
+    in
+    {
+      allow = rules permissions.allow;
+      ask = rules permissions.ask;
+      deny = rules permissions.deny;
+    };
+}

--- a/modules/qwen-code/README.md
+++ b/modules/qwen-code/README.md
@@ -17,6 +17,11 @@ OpenAI/Anthropic/Gemini-compatible endpoint. Apache-2.0.
 - MCP servers rendered from the shared `programs.aiMcp.enabledServers`
   profile, with `programs.qwen-code.excludedMcpServers` reserved for
   Qwen-only compatibility gaps.
+- `permissions` allow/ask/deny rules and `context.fileName`
+  (`AGENTS.md`) generated from the shared permission engine, matching
+  Codex and Antigravity. Only Bash command rules map across — Qwen's
+  builtin tool names and prefix-less `WebFetch(host)` syntax differ, so
+  Claude-specific extras are skipped.
 - Shared skills linked from `~/.agents/skills` into `~/.qwen/skills`,
   matching Codex and Antigravity rather than maintaining a separate
   skill tree.

--- a/modules/qwen-code/options.nix
+++ b/modules/qwen-code/options.nix
@@ -47,6 +47,13 @@ in
       '';
     };
 
+    contextFileNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      internal = true;
+      description = "Context file names emitted to Qwen Code settings.json; read-only.";
+    };
+
   }
   // mcpClient.mkClientOptions "Qwen Code";
 }

--- a/modules/qwen-code/settings.nix
+++ b/modules/qwen-code/settings.nix
@@ -21,6 +21,7 @@
   pkgs,
   config,
   lib,
+  nix-claude-code,
   ...
 }:
 
@@ -28,6 +29,11 @@ let
   cfg = config.programs.qwen-code;
   homeDir = config.home.homeDirectory;
   inherit (config.services.aiStack) models resolvedLlmEndpoint llmEndpoint;
+
+  aiCommon = import ../common {
+    inherit lib config nix-claude-code;
+  };
+  inherit (aiCommon) permissions formatters;
 
   mcpClient = import ../mcp/client.nix { inherit lib; };
 
@@ -80,6 +86,12 @@ let
   baseSettings = {
     inherit mcpServers;
 
+    # Auto-approve / prompt / block rules from the shared permission engine.
+    permissions = formatters.qwen.formatPermissions permissions;
+
+    # Load repo AGENTS.md as instruction context, matching the other agents.
+    context.fileName = [ "AGENTS.md" ];
+
     modelProviders = [
       {
         name = providerKey;
@@ -118,7 +130,10 @@ in
 {
   config = lib.mkMerge [
     {
-      programs.qwen-code.mcpServerNames = lib.attrNames mcpServers;
+      programs.qwen-code = {
+        contextFileNames = baseSettings.context.fileName;
+        mcpServerNames = lib.attrNames mcpServers;
+      };
     }
     (lib.mkIf cfg.enable {
       home = {


### PR DESCRIPTION
## Summary
- Closes the last cross-tool parity gap from this session's audit: qwen-code was the only MCP-enabled harness with **neither** permission rules **nor** instruction-context wiring.
- Maps the shared permission engine (`nix-claude-code.lib.permissions`) onto qwen's native `permissions` schema via a new `modules/common/formatters/qwen.nix` (allow 318 / ask 113 / deny 99 Bash rules). Bash command rules only — qwen's builtin tool names and prefix-less `WebFetch(host)` syntax differ from Claude's, so those are intentionally not mapped (caveat documented in the formatter header and module README).
- Loads `AGENTS.md` via `context.fileName`, matching the codex/antigravity peer pattern.
- Adds read-only `contextFileNames` introspection + `lib/checks/qwen-code.nix` regression checks (options + defaults, asserting the AGENTS.md wiring).

## Validation
- `nix fmt` clean; `nix flake check` passes.
- Force-evaluated drvPaths of the new qwen-code checks and the shared-mcp-renderer-parity check — all asserts hold.
- Runtime verification via darwin-rebuild override tracked in-session (follows merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmXShXB13r16uQypEXTevB