### PR TITLE
fix(mcp): make splunk-mcp-connect pass shellcheck SC2016

### DIFF
--- a/modules/mcp/scripts/splunk-mcp-connect.sh
+++ b/modules/mcp/scripts/splunk-mcp-connect.sh
@@ -33,7 +33,7 @@ fi
 bao_addr="${bao_addr%/}"
 
 login_response="$($JQ_BIN -nc --arg role_id "$role_id" --arg secret_id "$secret_id" \
-  '{role_id: $role_id, secret_id: $secret_id}' | \
+  "{role_id: \$role_id, secret_id: \$secret_id}" | \
   $CURL_BIN -fsS --max-time 10 \
     -H "Content-Type: application/json" --data @- \
     "$bao_addr/v1/auth/approle/login" 2>/dev/null)" \


### PR DESCRIPTION
## Summary

#1230's `splunk-mcp-connect` script fails shellcheck SC2016 inside `writeShellApplication` at **consumer** build time — every `darwin-rebuild` against current develop fails on `splunk-mcp-connect.drv`. nix-ai CI doesn't build `homeManagerModules`, so the break was invisible here.

Real fix (no shellcheck disable): double-quote the jq program with escaped `\$` so jq still sees `$role_id`/`$secret_id` as jq variables. Functionally identical.

## Verification

- `nix build .#darwinConfigurations.jevans-mbp.system --override-input nix-ai <this worktree>` in nix-darwin: previously failed on SC2016, now builds clean.
- `nix fmt` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoDD4HtJ5VD338N6CKEdxP