### PR TITLE
docs: mark home-manager as the single instruction delivery pipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,30 @@ inputs.nix-ai.inputs.home-manager.follows = "home-manager";
 
 ## Separation Guidelines
 
+### Instruction delivery (single pipe)
+
+home-manager is the single canonical delivery pipe for agent instructions from
+`ai-assistant-instructions`. It delivers the always-on core (`soul.md`) plus the
+path-scoped tier rules flat to `~/.claude/rules/`; Claude Code's native loader
+then honors each file's `paths:` frontmatter (present = path-scoped, absent =
+always-on). The `on-demand/` tier is a subdir that discovery skips by design —
+read by path when needed, never delivered. The one sanctioned fallback for a
+non-Nix machine is cloning `ai-assistant-instructions` and reading `AGENTS.md` +
+`agentsmd/rules/` directly (as that repo's own CLAUDE.md instructs). The
+CI-sparse-checkout, Obsidian-submodule, and copy-paste "pipes" are not sync
+mechanisms and do not exist — do not add a second delivery path.
+
+### nix-ai vs nix-claude-code boundary
+
+`nix-claude-code` = the Claude Code option schema, settings/permission renderer,
+permission data, and marketplace catalog (the "what the config looks like").
+`nix-ai` = discovery, consumption, MCP, plugin tiers, MLX, and the glue that
+feeds `ai-assistant-instructions` content through nix-claude-code's options (the
+"what content flows and how"). Tiered rule delivery (top-level delivered,
+`on-demand/` not) is a property of nix-ai's `discoverMarkdownFiles`, using
+nix-claude-code's `rules` option verbatim. Mirror in
+[nix-claude-code `AGENTS.md`](https://github.com/JacobPEvans/nix-claude-code/blob/main/AGENTS.md).
+
 ### What belongs here (nix-ai)
 
 - AI CLI tools (Claude Code, Antigravity, Codex, Copilot, qwen-code, cecli)

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -43,7 +43,10 @@ let
   inherit (aiCommon) permissions;
   inherit (aiCommon) formatters;
 
-  # Dynamic discovery helper — finds all .md files in a directory
+  # Dynamic discovery helper — finds all .md files in a directory.
+  # Non-recursive by design: the `type == "regular"` filter skips subdirectories,
+  # so nested tiers like `agentsmd/rules/on-demand/` are NOT discovered. Keep it
+  # this way — do not make readDir recurse (see rules.fromFlakeInputs below).
   discoverMarkdownFiles =
     dir:
     let
@@ -168,6 +171,12 @@ in
       (mkSourceEntries "${ai-assistant-instructions}/agentsmd/agents" aiAgents)
       ++ (mkSourceEntries "${claude-cookbooks}/.claude/agents" cbAgents);
 
+    # home-manager is the single canonical delivery pipe for agent instructions.
+    # Non-recursive discovery delivers only top-level `agentsmd/rules/*.md` flat to
+    # `~/.claude/rules/`: the always-on `soul.md` core plus path-scoped tier rules
+    # whose `paths:` frontmatter Claude Code's native loader honors. The opt-in
+    # `agentsmd/rules/on-demand/` tier lives in a subdir that discovery skips on
+    # purpose — it is read by path, never delivered. Do not make discovery recurse.
     rules.fromFlakeInputs = mkSourceEntries "${ai-assistant-instructions}/agentsmd/rules" aiRules;
 
     rules.local = {


### PR DESCRIPTION
## What

Documents the single delivery-pipe decision for agent instructions and adds a protective comment so future edits do not make rule discovery recurse. Docs/comment only — no logic change.

### nix-ai code comment (`modules/claude-config.nix`)
- `discoverMarkdownFiles`: notes the non-recursive `type == "regular"` filter is intentional and skips nested tiers like `agentsmd/rules/on-demand/`.
- `rules.fromFlakeInputs`: home-manager is the single canonical pipe; delivers only top-level `agentsmd/rules/*.md` flat to `~/.claude/rules/` (always-on `soul.md` core + path-scoped tier rules whose `paths:` frontmatter Claude Code honors); `on-demand/` is opt-in, read by path, never delivered.

### nix-ai `CLAUDE.md`
- New "Instruction delivery (single pipe)" subsection; the one sanctioned non-Nix fallback is cloning `ai-assistant-instructions` and reading `AGENTS.md` + `agentsmd/rules/` directly.
- New "nix-ai vs nix-claude-code boundary" (C6) subsection, mirrored in nix-claude-code `AGENTS.md`.

## Validation

`nix flake check` — exit 0 (all checks green). `nix fmt` introduced no drift.

Companion PR: dryvist/nix-claude-code (C6 boundary mirror).