### PR TITLE
feat(mcp): add Zammad MCP catalog entry (basher83/Zammad-MCP)

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -62,6 +62,12 @@
   # renovate: datasource=pypi depName=unifi-mcp-server
   unifiMcpServer = "0.2.5";
 
+  # MCP servers (uvx from git — not published to PyPI or npm)
+  # Consumed as git+https://github.com/basher83/zammad-mcp.git@v<version>; the
+  # upstream tag is v-prefixed, this pin stays bare like fabric below.
+  # renovate: datasource=github-tags depName=basher83/Zammad-MCP
+  zammadMcp = "1.1.0";
+
   # MLX inference stack (pypi)
   # 0.4.0 adds GPT-OSS/harmony prompt rendering for tool calls (required to
   # serve gpt-oss models with working tool calling) and requires

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -38,6 +38,7 @@ let
   gwsMcpVersion = versions.gwsMcp;
   unifiMcpServerVersion = versions.unifiMcpServer;
   vikunjaMcpVersion = versions.vikunjaMcp;
+  zammadMcpVersion = versions.zammadMcp;
 in
 {
   # ================================================================
@@ -232,6 +233,30 @@ in
     args = [
       "bunx"
       "@democratize-technology/vikunja-mcp@${vikunjaMcpVersion}"
+    ];
+    disabled = true;
+  };
+
+  # ================================================================
+  # Zammad - self-hosted help desk / ticketing (Zammad MCP, task #12)
+  # ================================================================
+  # Source: https://github.com/basher83/Zammad-MCP (not on PyPI/npm; launched
+  # via uvx straight from the pinned git tag, entry point `mcp-zammad`). Covers
+  # ticket/user/organization/attachment tools plus queue resources — the
+  # surface the Hermes zammad-incidents loop drives. Requires ZAMMAD_URL
+  # (instance API base, ends in /api/v1) and ZAMMAD_HTTP_TOKEN (a Zammad API
+  # token) — injected at launch by doppler-mcp from ai-ci-automation/prd, same
+  # pattern as vikunja/google-workspace. Canonical token home is the secrets
+  # engine's secret/ai/mcp/zammad (ZAMMAD_MCP_URL + ZAMMAD_MCP_TOKEN fields).
+  # Ships disabled — the host opt-in + Doppler seeding follow Zammad's deploy
+  # (task #10); enabling before that would spawn a failing server.
+  zammad = {
+    command = "doppler-mcp";
+    args = [
+      "uvx"
+      "--from"
+      "git+https://github.com/basher83/zammad-mcp.git@v${zammadMcpVersion}"
+      "mcp-zammad"
     ];
     disabled = true;
   };


### PR DESCRIPTION
## What

Adds a **disabled-by-default** Zammad MCP server to the MCP catalog so a host can later opt in to help-desk/ticketing tools (tickets, users, organizations, attachments, queue resources) — the surface the Hermes zammad-incidents loop drives.

- `modules/mcp/catalog.nix` — new `zammad` entry.
- `lib/versions.nix` — new `zammadMcp = "1.1.0"` pin, Renovate-tracked.

## How

Follows the `vikunja` / `google-workspace` shape exactly:

- **Launch:** `doppler-mcp uvx --from git+https://github.com/basher83/zammad-mcp.git@v1.1.0 mcp-zammad`. The server is **not** published to PyPI or npm, so it's launched straight from the pinned git tag; entry point is `mcp-zammad`.
- **Credentials:** `doppler-mcp` injects `ZAMMAD_URL` (instance API base, ends in `/api/v1`) and `ZAMMAD_HTTP_TOKEN` (a Zammad API token) from `ai-ci-automation/prd` at launch — no secrets in the catalog. Canonical token home is the secrets engine's `secret/ai/mcp/zammad` (`ZAMMAD_MCP_URL` + `ZAMMAD_MCP_TOKEN` fields).
- **Version pin:** the upstream tag is `v`-prefixed; the pin stays bare (`1.1.0`) like `fabric`, and the catalog constructs `@v${zammadMcpVersion}`. Tracked via `datasource=github-tags depName=basher83/Zammad-MCP` (the repo publishes tags, not GitHub releases).

## Deliberately deferred

- **No host opt-in in nix-darwin.** Zammad isn't deployed yet (see the Zammad first-deploy work); enabling this entry before the server exists would spawn a failing MCP process. The opt-in and the Doppler seeding of `ZAMMAD_URL` / `ZAMMAD_HTTP_TOKEN` follow Zammad's deploy.

## Validation

- `nix fmt` — clean (0 changed).
- `nix flake check` — passes.
- `nix eval` of the `zammad` catalog entry confirms it resolves to the expected command/args with the `@v1.1.0` git ref and `disabled = true`.

Does **not** enable the server or touch nix-darwin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TduAFRb5WCmy1crcz8jSrQ