### PR TITLE
fix(mlx): reap orphaned workers on proxy start, probe serving not liveness

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -56,9 +56,10 @@ let
   # keeps a restart an actual remedy. Rationale in llama-swap-launch.sh.
   llamaSwapLaunchPkg = pkgs.writeShellApplication {
     name = "llama-swap-launch";
+    # No procps: pgrep/pkill are called by absolute path (see the script) —
+    # Darwin's procps ships only ps/sysctl/top/watch.
     runtimeInputs = [
       llamaSwapPkg
-      pkgs.procps
       pkgs.coreutils
     ];
     text = builtins.readFile ./scripts/llama-swap-launch.sh;

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -31,14 +31,16 @@ let
   mlxWarmupPkg = pkgs.writeShellScriptBin "mlx-warmup" ''
     exec ${pkgs.python3}/bin/python3 ${./scripts/mlx-warmup.py} "$@"
   '';
-  # mlx-watchdog — periodic liveness probe that kickstarts the proxy when it
-  # panics into a listening-but-dead zombie (KeepAlive only catches process
-  # exit). writeShellApplication shellcheck-validates the script at eval time.
+  # mlx-watchdog — periodic serving probe that kickstarts the proxy when it is up
+  # but not serving (KeepAlive only catches process exit). Probes a real
+  # completion: every observed failure mode still answers /v1/models with 200.
+  # writeShellApplication shellcheck-validates the script at eval time.
   mlxWatchdogPkg = pkgs.writeShellApplication {
     name = "mlx-watchdog";
     runtimeInputs = with pkgs; [
       curl
       coreutils
+      jq
     ];
     text = builtins.readFile ./scripts/mlx-watchdog.sh;
   };
@@ -47,6 +49,20 @@ let
   # Sourced from nixpkgs-unstable: 25.11-darwin froze it at v165 on 2025-09-22
   # with no backports while unstable kept moving (currently v211). See nix-ai#801.
   llamaSwapPkg = nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system}.llama-swap;
+
+  # Proxy launcher — reaps orphaned vllm-mlx workers, then execs llama-swap.
+  # A worker outliving its proxy keeps its engine port bound, which makes every
+  # subsequent start fail on bind and 429 forever; reaping on the way up is what
+  # keeps a restart an actual remedy. Rationale in llama-swap-launch.sh.
+  llamaSwapLaunchPkg = pkgs.writeShellApplication {
+    name = "llama-swap-launch";
+    runtimeInputs = [
+      llamaSwapPkg
+      pkgs.procps
+      pkgs.coreutils
+    ];
+    text = builtins.readFile ./scripts/llama-swap-launch.sh;
+  };
 
   apiUrl = "http://${cfg.host}:${toString cfg.port}/v1";
   launchAgentLabel = "dev.vllm-mlx.server";
@@ -223,6 +239,7 @@ in
       launchAgentLabel
       warmupAgentLabel
       llamaSwapPkg
+      llamaSwapLaunchPkg
       llamaSwapConfigFile
       llamaSwapConfigAttrs
       llamaSwapRuntimeConfigPath

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -19,7 +19,7 @@ let
     apiUrl
     mlxWarmupPkg
     mlxWatchdogPkg
-    llamaSwapPkg
+    llamaSwapLaunchPkg
     llamaSwapConfigFile
     llamaSwapRuntimeConfigPath
     ;
@@ -45,7 +45,7 @@ in
           config = {
             Label = launchAgentLabel;
             ProgramArguments = [
-              (lib.getExe llamaSwapPkg)
+              (lib.getExe llamaSwapLaunchPkg)
               "--config"
               llamaSwapRuntimeConfigPath
               "--watch-config"
@@ -60,8 +60,11 @@ in
             # (see options-runtime.nix processType). OOM backstop is the RSS
             # hard limit, not Jetsam eligibility.
             ProcessType = cfg.processType;
-            # Do not abandon the process group; ensure child vllm-mlx processes
-            # are terminated when launchd stops the proxy.
+            # Do not abandon the process group. This is necessary but NOT
+            # sufficient: workers are spawned through `uv tool uvx`, so the real
+            # engine is a grandchild and has been observed surviving a stop
+            # (re-parented to init) still holding its port. llama-swap-launch.sh
+            # reaps those on the way back up — that is the load-bearing half.
             AbandonProcessGroup = false;
             EnvironmentVariables = {
               HF_HOME = cfg.huggingFaceHome;
@@ -109,15 +112,19 @@ in
           };
         };
 
-        # Liveness watchdog: KeepAlive=true only restarts the proxy on process
-        # EXIT, so a llama-swap panic into a listening-but-dead zombie (socket
-        # open, answering nothing) is never caught -> connection-refused ->
-        # litellm MidStreamFallbackError until a human kickstarts it. This probes
-        # /v1/models every StartInterval and kickstarts the server agent on
-        # repeated failure. The script self-gates re-fires with a cooldown marker
-        # so a slow model reload is not restart-stormed (mlx-watchdog.sh).
+        # Serving watchdog: KeepAlive=true only restarts the proxy on process
+        # EXIT, so every "up but not serving" mode is invisible to launchd — a
+        # llama-swap zombie, a wedged batch scheduler answering 200 with zero
+        # tokens, or a port-holding orphan making the proxy 429 everything. All
+        # three keep /v1/models green, so this probes a REAL completion every
+        # StartInterval and kickstarts the server agent when no token comes back.
+        # The script self-gates re-fires with a cooldown marker so a slow model
+        # reload is not restart-stormed (mlx-watchdog.sh).
         vllm-mlx-watchdog = {
-          enable = true;
+          # The probe generates against the first preloaded (resident) model, so
+          # with nothing preloaded every probe would cold-load a worker — worse
+          # than no watchdog. Such a host has no resident serving to guard.
+          enable = cfg.preload != [ ];
           config = {
             Label = "dev.vllm-mlx.watchdog";
             ProgramArguments = [ (lib.getExe mlxWatchdogPkg) ];
@@ -129,6 +136,9 @@ in
             EnvironmentVariables = {
               MLX_API_URL = apiUrl;
               MLX_LAUNCHD_LABEL = launchAgentLabel;
+              # Probe the first resident model: it is warm by construction, so a
+              # failure means "not serving", never "cold load in progress".
+              MLX_WATCHDOG_PROBE_MODEL = lib.head cfg.preload;
             };
             StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.log";
             StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vllm-mlx/vllm-mlx-watchdog.error.log";

--- a/modules/mlx/scripts/llama-swap-launch.sh
+++ b/modules/mlx/scripts/llama-swap-launch.sh
@@ -19,29 +19,33 @@
 
 set -euo pipefail
 
+# pgrep/pkill are called by absolute path because on Darwin nixpkgs' procps is
+# Apple's, shipping only ps/sysctl/top/watch — a runtimeInputs dependency would
+# resolve to nothing under writeShellApplication's sanitized PATH. Same reason
+# mlx-watchdog.sh calls /bin/launchctl by path.
 pattern='vllm-mlx serve'
 
 reap() {
-  pgrep -f "$pattern" >/dev/null 2>&1 || return 0
+  /usr/bin/pgrep -f "$pattern" >/dev/null 2>&1 || return 0
 
   echo "$(date -u +%FT%TZ) llama-swap-launch: reaping orphaned workers matching '${pattern}'" >&2
-  pkill -f "$pattern" || true
+  /usr/bin/pkill -f "$pattern" || true
 
   # Give them a graceful window, then escalate. A wedged engine (the
   # broadcast_shapes batch-scheduler hang) ignores SIGTERM, and it is exactly
   # the case that must not survive into the new proxy's port.
   for _ in $(seq 1 10); do
-    pgrep -f "$pattern" >/dev/null 2>&1 || return 0
+    /usr/bin/pgrep -f "$pattern" >/dev/null 2>&1 || return 0
     sleep 1
   done
 
-  pkill -9 -f "$pattern" || true
+  /usr/bin/pkill -9 -f "$pattern" || true
   sleep 2
 }
 
 reap
 
-if pgrep -f "$pattern" >/dev/null 2>&1; then
+if /usr/bin/pgrep -f "$pattern" >/dev/null 2>&1; then
   # Never exec into a guaranteed bind failure: exiting non-zero makes launchd
   # retry after ThrottleInterval, which is a real recovery path. Starting anyway
   # would just resume the 429 crash-loop this script exists to prevent.

--- a/modules/mlx/scripts/llama-swap-launch.sh
+++ b/modules/mlx/scripts/llama-swap-launch.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# llama-swap-launch - reap orphaned engine workers, then exec the proxy.
+#
+# Why this exists: launchd stops the llama-swap proxy, but the vllm-mlx workers
+# it spawned are launched through `uv tool uvx`, which puts the real engine two
+# levels down. Those grandchildren survive the stop (re-parented to init) despite
+# AbandonProcessGroup=false, and they keep HOLDING THEIR LISTEN PORT. The
+# replacement proxy then starts a fresh worker that dies instantly on
+# `[Errno 48] address already in use`, so KeepAlive restart-loops forever and the
+# proxy answers every completion with 429 while /v1/models still returns 200.
+# Observed 2026-07-16: a kickstart left an orphan holding :11439 and the serving
+# host was down ~1.5 h with no signal. See Zammad (AI/LLM Serving).
+#
+# The invariant that makes this safe: llama-swap is the ONLY thing that spawns
+# vllm-mlx workers, so at proxy-start time a live worker is by definition an
+# orphan of a previous proxy — never one this proxy needs. Reaping here makes
+# every start path (boot, KeepAlive restart, kickstart) self-cleaning, which is
+# what turns a restart back into an actual remedy.
+
+set -euo pipefail
+
+pattern='vllm-mlx serve'
+
+reap() {
+  pgrep -f "$pattern" >/dev/null 2>&1 || return 0
+
+  echo "$(date -u +%FT%TZ) llama-swap-launch: reaping orphaned workers matching '${pattern}'" >&2
+  pkill -f "$pattern" || true
+
+  # Give them a graceful window, then escalate. A wedged engine (the
+  # broadcast_shapes batch-scheduler hang) ignores SIGTERM, and it is exactly
+  # the case that must not survive into the new proxy's port.
+  for _ in $(seq 1 10); do
+    pgrep -f "$pattern" >/dev/null 2>&1 || return 0
+    sleep 1
+  done
+
+  pkill -9 -f "$pattern" || true
+  sleep 2
+}
+
+reap
+
+if pgrep -f "$pattern" >/dev/null 2>&1; then
+  # Never exec into a guaranteed bind failure: exiting non-zero makes launchd
+  # retry after ThrottleInterval, which is a real recovery path. Starting anyway
+  # would just resume the 429 crash-loop this script exists to prevent.
+  echo "$(date -u +%FT%TZ) llama-swap-launch: workers survived SIGKILL, refusing to start" >&2
+  exit 1
+fi
+
+exec llama-swap "$@"

--- a/modules/mlx/scripts/llama-swap-launch.sh
+++ b/modules/mlx/scripts/llama-swap-launch.sh
@@ -11,11 +11,14 @@
 # Observed 2026-07-16: a kickstart left an orphan holding :11439 and the serving
 # host was down ~1.5 h with no signal. See Zammad (AI/LLM Serving).
 #
-# The invariant that makes this safe: llama-swap is the ONLY thing that spawns
-# vllm-mlx workers, so at proxy-start time a live worker is by definition an
-# orphan of a previous proxy — never one this proxy needs. Reaping here makes
-# every start path (boot, KeepAlive restart, kickstart) self-cleaning, which is
-# what turns a restart back into an actual remedy.
+# The invariant that makes this safe is TIMING, not process ancestry: this runs
+# before the proxy exists, and llama-swap is the only thing that spawns workers,
+# so any worker alive right now belongs to a proxy that is already gone. Note
+# ancestry cannot be the test — llama-swap spawns workers detached, so a healthy
+# worker's top process already reports PPID 1 exactly like an orphan does.
+#
+# Reaping here makes every start path (boot, KeepAlive restart, kickstart)
+# self-cleaning, which is what turns a restart back into an actual remedy.
 
 set -euo pipefail
 

--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -59,10 +59,15 @@ fi
 # finish_reason are both untrustworthy here (mode 2 above), so completion_tokens
 # is the only assertion worth making.
 probe() {
-  local body
+  local request body
+  # Build the body with jq so a model id carrying quotes/backslashes cannot
+  # produce invalid JSON — that would fail the probe for a reason unrelated to
+  # serving health and kickstart a perfectly good proxy.
+  request="$(jq -nc --arg model "$probe_model" \
+    '{model: $model, messages: [{role: "user", content: "ping"}], max_tokens: 4}')" || return 1
   body="$(curl -s --max-time "$probe_timeout" \
     -H 'Content-Type: application/json' \
-    -d "{\"model\":\"${probe_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":4}" \
+    -d "$request" \
     "${api_url}/chat/completions" 2>/dev/null)" || return 1
   jq -e '(.usage.completion_tokens // 0) >= 1' >/dev/null 2>&1 <<<"$body"
 }

--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
-# mlx-watchdog - self-heal the listening-but-dead llama-swap zombie.
+# mlx-watchdog - self-heal a serving host that is up but not serving.
 #
-# The vllm-mlx LaunchAgent uses KeepAlive=true, which only restarts the proxy on
-# process EXIT. But llama-swap can panic (`sync: WaitGroup is reused before
-# previous Wait has returned`) into a process that is still ALIVE and still
-# holding the listen socket, yet answers nothing - a zombie. launchd never
-# notices (no exit), so the socket stays open, every request gets
-# connection-refused / a hung stream, and litellm surfaces
-# MidStreamFallbackError until a human kickstarts it. This probe closes that gap:
-# it health-checks the proxy's own /v1/models endpoint and, on repeated failure,
-# kickstarts the server LaunchAgent - the sanctioned Mac serving-host break-fix.
+# KeepAlive=true only restarts the proxy on process EXIT, so every failure that
+# leaves a live-but-useless proxy is invisible to launchd. Three such modes have
+# been observed on this host, and NONE of them show at /v1/models:
 #
-# Health signal choice: /v1/models is answered by llama-swap itself from its
-# static config, WITHOUT loading a model, so it stays up during a normal model
-# swap. A failure there means the proxy - not a worker - is dead. That is the
-# exact zombie signature, and it avoids the cost/side-effects of a real
-# completion probe.
+#   1. llama-swap panics into a listening-but-dead zombie (socket open, answers
+#      nothing) -> connection refused / hung streams.
+#   2. The vllm-mlx batch scheduler wedges and then answers EVERY completion with
+#      HTTP 200, finish_reason "error" and zero tokens. litellm even remaps that
+#      finish_reason to "stop" downstream, so it looks like a normal answer.
+#   3. An orphaned worker holds the engine port, so each fresh worker dies on
+#      bind and the proxy 429s every completion (fixed at the source by
+#      llama-swap-launch.sh, which reaps orphans before the proxy starts).
+#
+# /v1/models is answered by llama-swap itself from static config, without a
+# model, so it returned 200 throughout all three - including a ~1.5 h total
+# outage. It cannot be the health signal. The only thing that separates "serving"
+# from merely "up" is a real completion that yields a token, so that is what this
+# probes. Cost is one <=4-token generation per StartInterval against an
+# already-resident model - cheap next to another silent multi-hour outage.
+# See Zammad (AI/LLM Serving).
 #
 # Loop-cadence (durable min-interval marker): the scheduler is launchd's
 # StartInterval, but a 70 GB model reload takes 20-60 s, so a naive probe would
@@ -25,14 +30,16 @@
 
 set -euo pipefail
 
-health_url="${MLX_API_URL:?MLX_API_URL unset}/models"
+api_url="${MLX_API_URL:?MLX_API_URL unset}"
 label="${MLX_LAUNCHD_LABEL:?MLX_LAUNCHD_LABEL unset}"
+probe_model="${MLX_WATCHDOG_PROBE_MODEL:?MLX_WATCHDOG_PROBE_MODEL unset}"
 marker="${MLX_WATCHDOG_MARKER:-${HOME}/Library/Caches/vllm-mlx/watchdog-last-kick}"
-# Cooldown >= ThrottleInterval (120 s) + headroom for the largest resident
-# model's cold load, so one kickstart gets a full recovery window before the
-# next is allowed.
-cooldown="${MLX_WATCHDOG_COOLDOWN:-180}"
-probe_timeout="${MLX_WATCHDOG_PROBE_TIMEOUT:-15}"
+# Cooldown covers ThrottleInterval (120 s) plus a full cold load of the largest
+# resident model, so one kickstart gets a real recovery window before the next.
+cooldown="${MLX_WATCHDOG_COOLDOWN:-600}"
+# A cold load legitimately holds a completion open for minutes; a short timeout
+# turns every normal model swap into a false positive.
+probe_timeout="${MLX_WATCHDOG_PROBE_TIMEOUT:-240}"
 
 mkdir -p "$(dirname "$marker")"
 
@@ -48,21 +55,33 @@ if (( now - last < cooldown )); then
   exit 0
 fi
 
-probe() { curl -sf --max-time "$probe_timeout" "$health_url" >/dev/null 2>&1; }
+# Healthy iff the response carries at least one generated token. HTTP status and
+# finish_reason are both untrustworthy here (mode 2 above), so completion_tokens
+# is the only assertion worth making.
+probe() {
+  local body
+  body="$(curl -s --max-time "$probe_timeout" \
+    -H 'Content-Type: application/json' \
+    -d "{\"model\":\"${probe_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":4}" \
+    "${api_url}/chat/completions" 2>/dev/null)" || return 1
+  jq -e '(.usage.completion_tokens // 0) >= 1' >/dev/null 2>&1 <<<"$body"
+}
 
-# Healthy proxy answers immediately. One transient miss (a brief hiccup under
-# load) must not trigger a restart, so require two consecutive failures.
+# One transient miss (a hiccup under load, or a swap-in) must not trigger a
+# restart, so require two consecutive failures.
 if probe; then
   exit 0
 fi
-sleep 3
+sleep 5
 if probe; then
   exit 0
 fi
 
-# Zombie confirmed. launchctl is a system binary (absolute path - not on the
-# sanitized writeShellApplication PATH). `id` comes from coreutils.
-echo "$(date -u +%FT%TZ) mlx-watchdog: ${health_url} unreachable x2 -> kickstart ${label}" >&2
+# Confirmed not serving. launchctl is a system binary (absolute path - not on the
+# sanitized writeShellApplication PATH). `id` comes from coreutils. The kickstart
+# is a real remedy only because llama-swap-launch.sh reaps orphaned workers on
+# the way back up; without that, mode 3 restart-loops forever.
+echo "$(date -u +%FT%TZ) mlx-watchdog: ${probe_model} produced no tokens x2 -> kickstart ${label}" >&2
 /bin/launchctl kickstart -k "gui/$(id -u)/${label}" || true
 
 # Marker written AFTER the work: a crashed run does not suppress the retry; only


### PR DESCRIPTION
## Problem

A stopped proxy leaves its `vllm-mlx` worker alive. Workers are spawned through `uv tool uvx`, so the engine is a grandchild that survives the stop (re-parented to init) despite `AbandonProcessGroup = false` — observed live: the worker's parent is already PID 1 while the proxy still runs.

The orphan keeps its engine port bound, so every replacement worker dies instantly on `[Errno 48] address already in use`, `KeepAlive` restart-loops, and the proxy 429s every completion. `/v1/models` stays 200 throughout, so nothing detected it.

Measured impact: ~1.5 h of zero serving on the Mac serving host with no alert. The kickstart remedy *caused* it — killing the proxy is exactly what orphans the worker.

## Fix

- `llama-swap-launch.sh` reaps leftover workers, then execs the proxy. Safe because llama-swap is the only spawner: a worker alive at proxy-start is by definition an orphan of a previous proxy. Every start path (boot, KeepAlive, kickstart) is now self-cleaning — this is what makes a restart an actual remedy instead of a permanent wedge. If workers survive SIGKILL it exits non-zero rather than exec into a guaranteed bind failure, letting launchd retry after ThrottleInterval.
- The watchdog probes a real completion and asserts `completion_tokens >= 1`. All three observed not-serving modes (llama-swap zombie; wedged batch scheduler answering 200/zero tokens, which litellm remaps to `finish_reason: stop`; port-holding orphan 429ing) keep `/v1/models` green — liveness there was never a serving signal. Cooldown raised 180s → 600s and probe timeout 15s → 240s so a cold load is never a false positive; the agent disables itself when nothing is preloaded (no resident model = every probe would cold-load).

## Verification

- `shellcheck` clean on both scripts (also enforced at eval time by `writeShellApplication`).
- `nix-instantiate --parse` OK on both changed modules; `nix flake check --no-build` passes (note: it reports `homeManagerModules` as unchecked, so the module eval is proven by the Studio rebuild, not by this check).
- Reap pattern verified against the live process tree: matches the uv wrapper + engine, does not match the proxy.
- Root cause confirmed live: killing the orphan freed :11439 and the host served an 8-token completion immediately after.

Refs #1234. Incident: Zammad (AI/LLM Serving).