### PR TITLE
feat(mlx): add defaultRepetitionPenalty to keep batches uniform

### DIFF
--- a/modules/mlx/options-batching.nix
+++ b/modules/mlx/options-batching.nix
@@ -19,6 +19,30 @@
       description = "Enable continuous batching. Better throughput across concurrent requests.";
     };
 
+    # defaultRepetitionPenalty — server-side default
+    # (--default-repetition-penalty).
+    #
+    # A BATCH-SAFETY control, not a quality knob. In mlx_lm's batch generator,
+    # a request carrying no logits processor gets padded with a null entry
+    # instead of an empty list, and the decode step iterates that entry
+    # blindly. One request bearing a processor, alongside another lacking one,
+    # kills the scheduler thread on a type error — every completion on that
+    # worker afterwards hangs or comes back empty until the worker is killed.
+    #
+    # A repetition penalty IS a logits processor. Injecting it per-request at
+    # a router mixes penalized traffic with penalty-free callers (health
+    # probes, direct clients), and that mix wedges the engine. Setting it here
+    # applies it to EVERY request the worker sees, making batches uniform by
+    # construction regardless of caller. Uniformity is the property that
+    # matters, not the value. Prefer this over router-side injection.
+    # See dryvist/nix-ai#1234.
+    defaultRepetitionPenalty = lib.mkOption {
+      type = lib.types.nullOr (lib.types.numbers.between 1.0 2.0);
+      default = null;
+      example = 1.05;
+      description = "Server-side default repetition penalty applied to every request (vllm-mlx --default-repetition-penalty). Set this instead of injecting a per-request penalty at the router: a penalty is a logits processor, and mixing processor-ful with processor-free requests in one batch wedges mlx_lm's batch generator (nix-ai#1234). Null = upstream default (no penalty), which is uniform and therefore also safe.";
+    };
+
     # maxNumSeqs — Max concurrent sequences (--max-num-seqs).
     # Default: 4 — bounds memory pressure when continuousBatching is on. With
     # 32GB cache + prefix sharing, 4 concurrent sequences fit comfortably even

--- a/modules/mlx/options-batching.nix
+++ b/modules/mlx/options-batching.nix
@@ -35,7 +35,7 @@
     # applies it to EVERY request the worker sees, making batches uniform by
     # construction regardless of caller. Uniformity is the property that
     # matters, not the value. Prefer this over router-side injection.
-    # See dryvist/nix-ai#1234.
+    # See nix-ai#1234.
     defaultRepetitionPenalty = lib.mkOption {
       type = lib.types.nullOr (lib.types.numbers.between 1.0 2.0);
       default = null;

--- a/modules/mlx/vllm-cmd.nix
+++ b/modules/mlx/vllm-cmd.nix
@@ -23,6 +23,7 @@ rec {
     "autoUnloadIdleSeconds"
     "enableMetrics"
     "continuousBatching"
+    "defaultRepetitionPenalty"
     "enablePrefixCaching"
     "pagedKvCache"
     "pagedCacheBlockSize"
@@ -65,6 +66,13 @@ rec {
         ]
         ++ lib.optionals c.enableMetrics [ "--enable-metrics" ]
         ++ lib.optionals c.continuousBatching [ "--continuous-batching" ]
+        # Applied server-side so every request carries the same logits
+        # processor — a batch mixing penalized with penalty-free requests
+        # wedges mlx_lm's generator. Rationale in options-batching.nix.
+        ++ lib.optionals (c.defaultRepetitionPenalty != null) [
+          "--default-repetition-penalty"
+          (toString c.defaultRepetitionPenalty)
+        ]
         ++ lib.optionals c.enablePrefixCaching [ "--enable-prefix-cache" ]
         ++ lib.optionals c.pagedKvCache [ "--use-paged-cache" ]
         ++ lib.optionals (c.pagedKvCache && c.pagedCacheBlockSize != null) [


### PR DESCRIPTION
Adds `programs.mlx.defaultRepetitionPenalty`, emitting vllm-mlx's `--default-repetition-penalty`. This is **batch safety, not tuning** — very likely the root cause of #1234.

## The mechanism (read from the installed sources, not inferred)

vllm-mlx builds a request's processors from its penalty (`scheduler.py`); a penalty-free request gets an **empty list**:

```python
rep_penalty = request.sampling_params.repetition_penalty
combined_lp = []
if rep_penalty and rep_penalty != 1.0:
    combined_lp.extend(make_logits_processors(repetition_penalty=rep_penalty))
lp = combined_lp
```

`mlx_lm`'s `BatchedGenerator.extend` then pads processor-free entries with **`None`**, not `[]`:

```python
if not any(self.logits_processors):
    self.logits_processors = [None] * len(self.uids)
logits_processors = (batch.logits_processors
    if any(batch.logits_processors) else [None] * len(batch.uids))
```

…and the decode step iterates it unconditionally:

```python
for processor in self.logits_processors[e]:   # TypeError: 'NoneType' object is not iterable
```

So as soon as **one** request in a batch carries a penalty while another does not, the scheduler thread dies and every completion on that worker hangs or returns empty until it is killed. Observed **26,916 times** in the serving host's log.

## Why our traffic hits it exactly

The router injects `repetition_penalty: 1.05` on the `ai-default` alias, while health probes send bare requests. Continuous batching co-schedules them → mixed batch → wedge. **The monitoring meant to catch the wedge is itself a trigger** — including the completion probe added in #1260.

## The fix

`server.py` resolves the request's penalty to `_default_repetition_penalty` when the caller omits one. Setting it server-side therefore gives **every** request a processor, so the mixed-batch path is unreachable regardless of caller — uniformity by construction, rather than asking every client to remember. Per-model divergence is safe: each model is its own worker, so batches never mix across models.

Prefer this over router-side injection; the option docs say so at the definition.

## Verification

- Serve command renders: `... --continuous-batching --default-repetition-penalty 1.050000 --max-num-seqs 8`
- `nix-instantiate --parse` OK on both changed modules.
- Null default = upstream behavior (no penalty), which is uniform and therefore also safe — so this is a no-op for hosts that don't set it.

Refs #1234. Pairs with #1260 (which guarantees recovery when a wedge does fire); this removes the trigger.