### PR TITLE
fix(mcp): stop disabling TLS verification in splunk-mcp-connect

### DIFF
--- a/modules/mcp/scripts/splunk-mcp-connect.sh
+++ b/modules/mcp/scripts/splunk-mcp-connect.sh
@@ -57,9 +57,11 @@ esac
 
 # These exports exist only in this wrapper and its MCP child. The AppRole,
 # OpenBao token, and Splunk values are never exported to the parent shell.
+# TLS verification stays ON: the MCP endpoint is fronted by the ingress with a
+# publicly-trusted cert chain. If verification ever fails here, fix the served
+# certificate — never re-add NODE_TLS_REJECT_UNAUTHORIZED=0.
 export SPLUNK_MCP_URL="$splunk_mcp_url"
 export SPLUNK_MCP_TOKEN="$splunk_mcp_token"
-export NODE_TLS_REJECT_UNAUTHORIZED=0
 
 # exec: the MCP child replaces this shell, so signals propagate directly and
 # no idle bash lingers for the connection's lifetime.


### PR DESCRIPTION
## Summary
- Removes `NODE_TLS_REJECT_UNAUTHORIZED=0` from `splunk-mcp-connect.sh`. This disabled certificate verification for every Mac MCP client connecting to the Splunk MCP endpoint — a standing MITM exposure.
- Verified live before removal: the MCP endpoint's ingress vhost presents a full, valid Let's Encrypt chain, and `curl https://<ingress-vhost>/services/mcp` passes TLS verification with default trust (405 on GET = handshake OK). Node/bun's bundled CA store trusts the same roots, so the bypass was unnecessary.
- Adds a comment pinning the policy: if verification fails on this path, fix the served certificate — never re-add the bypass.

## Context
The Hermes-side Splunk MCP TLS failure (self-signed chain seen from inside the homelab) is a separate network-path problem, diagnosed and filed as https://github.com/dryvist/ansible-proxmox-ai/issues/16. This PR only removes the Mac-side bypass, which live probing proved dead weight.

## Validation
- `shellcheck` clean; `nix fmt` no-op; `nix flake check` passes.
- Runtime: after merge/rebuild, the splunk MCP server should connect identically (endpoint chain verifies with default trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmXShXB13r16uQypEXTevB