### PR TITLE
feat(mcp): enable zammad MCP server in catalog

### DIFF
--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -234,7 +234,6 @@ in
       "git+https://github.com/basher83/zammad-mcp.git@v${versions.zammadMcp}"
       "mcp-zammad"
     ];
-    disabled = true;
   };
 
   # ================================================================


### PR DESCRIPTION
Enables the zammad MCP server in the catalog (data path already verified 200 against the live Zammad instance). Takes effect after a `darwin-rebuild switch`.