### PR TITLE
feat(automode): homelab-gated allow rules for the classifier

### DIFF
--- a/modules/claude/automode.nix
+++ b/modules/claude/automode.nix
@@ -39,7 +39,8 @@ in
     "Running `rm` to delete files inside the current working repository is routine and safe — allow without confirmation, including recursive deletion of ordinary subdirectories such as build outputs, caches, vendored dependencies, test fixtures, and git worktrees."
     "Running inline interpreters for read-only inspection — `python -c`, `python3 -c`, `node -e`, `ruby -e`, `perl -e` — to parse JSON, read a config file, or compute and print a value is routine and safe; allow without confirmation. Only require confirmation when such a one-liner writes or deletes files, or sends data to a destination outside the working repository."
     "Read-only compound shell chains that combine already-safe inspection tools (cd, ls, cat, head, tail, wc, sort, uniq, grep, rg, jq, `sed -n`, `awk` print, `find` without -delete/-exec, and git status/log/diff/show) with `&&` or `|` are routine and safe; allow without confirmation even though the combined command does not match a single narrow allow rule."
-  ];
+  ]
+  ++ lib.optionals (homelab.enable or false) (homelab.allowRules or [ ]);
 
   soft_deny = [
     "$defaults"

--- a/modules/maintainer-profile.nix
+++ b/modules/maintainer-profile.nix
@@ -65,6 +65,19 @@ in
               describe your own infrastructure footprint here.
             '';
           };
+
+          allowRules = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = ''
+              Prose auto-permit rules appended to Claude auto-mode's `allow`
+              when `homelab.enable` is true. Use for infrastructure actions the
+              default soft-block list would otherwise stop but that your own
+              tooling already gates (e.g. an IaC apply, or a secrets engine
+              that enforces its own access separation). Empty by default so a
+              fresh consumer keeps the neutral classifier.
+            '';
+          };
         };
 
         telemetry = {


### PR DESCRIPTION
Adds `homelab.allowRules` to the maintainer profile, mirroring the existing `environmentRules`. Prose auto-permit rules appended to the auto-mode classifier's `allow` list only when `homelab.enable` is true; empty by default so a fresh consumer keeps the neutral classifier. Values live in the consumer profile (nix-darwin), not this module.

Motivation: the classifier is a convenience gate, not the security boundary — for actions whose real access control lives elsewhere (an IaC apply the operator authorized; a secrets engine that enforces its own AppRole separation and rejections), the classifier should not re-litigate. This gives those a declarative home.

Verified: `nix flake check` clean; `nix eval` confirms an allowRule appears in `allow` when homelab.enable is true and is absent otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)