### PR TITLE
chore: inherit Codex workflow credentials

### DIFF
--- a/.github/workflows/ai-pr-care.yml
+++ b/.github/workflows/ai-pr-care.yml
@@ -5,7 +5,7 @@
 #   refreshed per head SHA.
 #
 # Gates in the reusable workflows keep non-matching PRs at github-script cost.
-# Permissions are job-scoped and the secret is passed explicitly (zizmor:
+# Permissions are job-scoped and credentials are passed explicitly (zizmor:
 # excessive-permissions, secrets-inherit). No concurrency block on purpose: a
 # caller sharing the reusable workflow's exact concurrency group causes an
 # opaque 0-job startup_failure.
@@ -26,6 +26,7 @@ jobs:
     uses: dryvist/ai-workflows/.github/workflows/cc-dep-review.yml@main
     secrets:
       GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   release-notes:
     permissions:
@@ -35,3 +36,4 @@ jobs:
     uses: dryvist/ai-workflows/.github/workflows/cc-release-notes.yml@main
     secrets:
       GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   best-practices:
-    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   hygiene:
-    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -17,5 +17,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@main
     secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
## Summary

Adopt the provider-neutral inherited AI workflow contract on the integration branch.

## Changes

- Forward `OPENAI_API_KEY` from explicit reusable-workflow callers.
- Move stale `ai-workflows@v0.31` references to the supported `@main` channel.
- Keep `GH_ACTION_AI_AGENT` as the organization-level provider selector.

## Test Plan

- Validate modified workflows with `actionlint`.
- Confirm CI, OSV, AI merge gate, and CodeQL checks pass.

Refs: dryvist/ai-workflows#352