### PR TITLE
fix(mlx): grep absolute paths + orchestrator robustness nits

### DIFF
--- a/modules/mlx/scripts/cluster-join.sh
+++ b/modules/mlx/scripts/cluster-join.sh
@@ -75,7 +75,7 @@ link_prep_ok() {
   [ -n "$dev" ] || return 1
   [ "$dev" = "bridge0" ] && return 1
   # port must not be a bridge0 member (re-enslavement is the classic prep loss)
-  if /sbin/ifconfig bridge0 2>/dev/null | grep -qw "member: $dev"; then
+  if /sbin/ifconfig bridge0 2>/dev/null | /usr/bin/grep -qw "member: $dev"; then
     return 1
   fi
   # port must have carrier: cluster-detach admin-downs the link but leaves the
@@ -109,7 +109,7 @@ repair_link_direct() {
   local dev active=""
   while IFS= read -r dev; do
     [ -n "$dev" ] || continue
-    if /sbin/ifconfig bridge0 2>/dev/null | grep -q "member: $dev "; then
+    if /sbin/ifconfig bridge0 2>/dev/null | /usr/bin/grep -qw "member: $dev"; then
       sudo -n /sbin/ifconfig bridge0 deletem "$dev" > /dev/null 2>&1 || true
     fi
     sudo -n /sbin/ifconfig "$dev" up > /dev/null 2>&1 || true
@@ -264,7 +264,7 @@ else
   running_since=0
   stable_ok=false
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    if /bin/launchctl print "gui/$uid/${CLUSTER_RANK_LABEL}" 2> /dev/null | grep -q "state = running" &&
+    if /bin/launchctl print "gui/$uid/${CLUSTER_RANK_LABEL}" 2> /dev/null | /usr/bin/grep -q "state = running" &&
       /usr/bin/pgrep -f 'mlx_lm.server' > /dev/null 2>&1; then
       [ "$running_since" -eq 0 ] && running_since="$(date +%s)"
       if [ $(($(date +%s) - running_since)) -ge "$stable" ]; then

--- a/orchestrator/src/orchestrator/prompts.py
+++ b/orchestrator/src/orchestrator/prompts.py
@@ -40,7 +40,7 @@ def load_prompt_resource(resource: str) -> str:
 
     prompt_path = Path(prompt_dir) / f"{resource_name}.md"
     try:
-        content = prompt_path.read_text()
+        content = prompt_path.read_text(encoding="utf-8")
     except FileNotFoundError:
         msg = f"Prompt resource not found: {resource} ({prompt_path})"
         raise FileNotFoundError(msg) from None

--- a/orchestrator/src/orchestrator/workflows/nodes.py
+++ b/orchestrator/src/orchestrator/workflows/nodes.py
@@ -65,8 +65,8 @@ def _make_llm_call_node(
     model = cfg.get("model", "mlx-community/Qwen3.5-35B-A3B-4bit")
     system_prompt = cfg.get("system_prompt")
     if system_prompt is None:
-        prompt_resource = cfg.get(
-            "system_prompt_resource", DEFAULT_SYSTEM_PROMPT_RESOURCE,
+        prompt_resource = (
+            cfg.get("system_prompt_resource") or DEFAULT_SYSTEM_PROMPT_RESOURCE
         )
         system_prompt = load_prompt_resource(prompt_resource)
     temperature = float(cfg.get("temperature", 0.7))


### PR DESCRIPTION
Follow-up addressing valid review nits surfaced by gemini during the develop→main promotion re-review (#1287), fixed for real on develop rather than resolved-without-fixing.

**fix(mlx)** — `cluster-join.sh`: `grep` is neither in `runtimeInputs` (curl/jq/coreutils) nor part of coreutils, so bare `grep` rode the ambient PATH — the same hermeticity gap already closed for `sed`. Now `/usr/bin/grep` at all three sites, matching every other absolute-pathed system binary in the script. Line-112 membership test tightened to `-qw` to match line 78.

**fix(orchestrator)** — `prompts.py` reads with `encoding="utf-8"`; `nodes.py` uses `cfg.get("system_prompt_resource") or DEFAULT` so an explicit `None`/`""` in config falls back instead of crashing `load_prompt_resource`.

**Validation:** cluster-join `writeShellApplication` builds (in-build shellcheck), `check-shellcheck` passes whole-tree, `ruff check` clean on both Python files, `nix flake check` evals clean.

Once merged, promotion #1287 absorbs these and its re-review threads resolve as fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)