### PR TITLE
fix(mlx): drop reasoning parser from 80B-Instruct catalog entry

### DIFF
--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -25,6 +25,14 @@ let
     "--reasoning-parser"
     "qwen3"
   ];
+  # Instruct (non-thinking) variants must NOT carry a reasoning parser: it
+  # classifies the entire non-streaming completion as reasoning and strips it
+  # (empty content, "Thinking-only response" under agent harnesses) while
+  # streaming still works — the 2026-07-20 Hermes outage signature.
+  qwenMoeInstructParser = [
+    "--tool-call-parser"
+    "hermes"
+  ];
   # Guard chain: server 3600 > router 2400 > client 1800 (lifts the
   # 300 s disconnect_guard).
   agentTimeout = [
@@ -187,7 +195,7 @@ in
   qwen3-next-80b-instruct = {
     model = "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit";
     weightGb = 42.0;
-    args = qwenMoeGeneralParser ++ agentTimeout;
+    args = qwenMoeInstructParser ++ agentTimeout;
     classes = {
       resident.flags = block512 // {
         cacheMemoryMb = 16384;


### PR DESCRIPTION
## Summary

- `--reasoning-parser qwen3` on the non-thinking `Qwen3-Next-80B-A3B-Instruct-4bit` strips every non-streaming completion to empty content (the parser classifies the whole output as reasoning), while streaming still works. This was the root cause of the Hermes agent producing only failure notices.
- Adds `qwenMoeInstructParser` (hermes tool-call parser, no reasoning parser) and switches the 80B-Instruct entry to it. Thinking variants keep `qwenMoeGeneralParser` unchanged. Coder-30B was already reasoning-parser-free.
- Validated live: with the reasoning parser removed from the generated llama-swap config, agent runs immediately returned real content (finish_reason stop, non-empty message).

## Test plan

- [x] `nix flake check` clean
- [x] Live-config equivalent already serving successfully on jevans-ms

Zammad: AI/LLM Serving INC (Hermes non-streaming outage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yh8vodT7vPhGKbZNRtoAy