### PR TITLE
feat(mlx): generation-parity preflight with auto-heal in cluster-join

### DIFF
--- a/modules/mlx/cluster-mode.nix
+++ b/modules/mlx/cluster-mode.nix
@@ -98,6 +98,7 @@ let
         curl
         jq
         coreutils
+        git # generation-parity preflight (ls-remote + auto-heal pull)
       ];
       text = lib.concatStringsSep "\n" (
         lib.mapAttrsToList (k: v: "export ${k}=${lib.escapeShellArg v}") env
@@ -123,6 +124,8 @@ let
   clusterJoinEnv =
     clusterCommonEnv
     // {
+      CLUSTER_GENERATION_REPO_URL = ncfg.generationRepoUrl;
+      CLUSTER_FLAKE_DIR = ncfg.generationFlakeDir;
       CLUSTER_JOIN_SWAP_THRESHOLD_MB = toString ncfg.joinSwapThresholdMb;
       CLUSTER_JOIN_TIMEOUT_SECS = toString ncfg.joinTimeoutSecs;
       CLUSTER_QUIESCE_GRACE_SECS = toString ncfg.quiesceGraceSecs;

--- a/modules/mlx/options-cluster.nix
+++ b/modules/mlx/options-cluster.nix
@@ -128,6 +128,29 @@
     };
 
     # --- cluster-join / cluster-detach lifecycle-command tunables ------------
+    generationRepoUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "https://github.com/dryvist/nix-darwin";
+      description = ''
+        Flake repo whose origin/main is the deploy source of truth for the
+        cluster-join generation-parity preflight: every node must run a system
+        generation stamped with that branch's HEAD revision before any
+        clustering config begins (two nodes both at remote HEAD are identical
+        by construction). Empty string disables the preflight.
+      '';
+    };
+
+    generationFlakeDir = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "/Users/me/git/public/nix/nix-darwin/main";
+      description = ''
+        Local nix-darwin flake checkout cluster-join auto-heals generation
+        drift from (ff-only pull of main, then darwin-rebuild switch). Empty
+        disables auto-heal: drift then fails the join with instructions.
+      '';
+    };
+
     joinSwapThresholdMb = lib.mkOption {
       type = lib.types.int;
       default = 8000;

--- a/modules/mlx/scripts/cluster-join.sh
+++ b/modules/mlx/scripts/cluster-join.sh
@@ -23,6 +23,10 @@
 #   CLUSTER_STATE_FILE          watcher link-state file (locates the marker dir)
 #   CLUSTER_WIRED_LIMIT_MB      optional cluster wired ceiling (exact-value grant)
 #   CLUSTER_DAY_WIRED_LIMIT_MB  day ceiling (unused here; carried for symmetry)
+#   CLUSTER_GENERATION_REPO_URL flake repo URL whose origin/main is the deploy
+#                             source of truth for generation parity (step 0);
+#                             empty disables the preflight
+#   CLUSTER_FLAKE_DIR           local flake checkout used to auto-heal drift
 #   CLUSTER_JOIN_SWAP_THRESHOLD_MB  refuse to load above this vm.swapusage used (MB)
 #   CLUSTER_JOIN_TIMEOUT_SECS   bound on the block-until-serving wait
 #   CLUSTER_QUIESCE_GRACE_SECS  grace before reaping orphaned day-serve engines
@@ -59,6 +63,45 @@ fail() {
   echo "cluster-join: FAIL: $*" >&2
   exit 1
 }
+
+# --- step 0: nix generation parity preflight --------------------------------
+# Every node must run the exact same committed system generation before any
+# clustering config begins: mixed generations mean mismatched mlx/JACCL stacks
+# on the two ranks — the untestable config-parity variable behind the
+# INC-17070 deadlock family. Parity is judged against the shared deploy branch
+# (origin main of the flake repo) rather than peer SSH: two nodes both at
+# remote HEAD are identical by construction, and a node behind HEAD is healed
+# by rebuilding locally. Unreachable remote only WARNS (offline joins stay
+# possible); a dirty/unstamped local generation always fails.
+if [ -n "${CLUSTER_GENERATION_REPO_URL:-}" ]; then
+  local_rev="$(/run/current-system/sw/bin/darwin-version --json 2>/dev/null |
+    jq -r '.configurationRevision // empty')"
+  remote_rev="$(git ls-remote "$CLUSTER_GENERATION_REPO_URL" refs/heads/main 2>/dev/null |
+    cut -f1)"
+  if [ -z "$remote_rev" ]; then
+    echo "cluster-join: WARN generation parity unverified (deploy branch unreachable)" >&2
+  elif [ -z "$local_rev" ]; then
+    fail "system generation carries no configurationRevision (dirty or unstamped build) — darwin-rebuild switch from a clean committed checkout before clustering"
+  elif [ "$local_rev" != "$remote_rev" ]; then
+    flake_dir="${CLUSTER_FLAKE_DIR:-}"
+    [ -d "$flake_dir" ] ||
+      fail "generation drift (local ${local_rev:0:12} != deploy ${remote_rev:0:12}) and no flake checkout at '$flake_dir' to auto-heal from"
+    echo "cluster-join: generation drift (local ${local_rev:0:12} != deploy ${remote_rev:0:12}); auto-healing"
+    [ "$(git -C "$flake_dir" branch --show-current)" = "main" ] ||
+      fail "flake checkout $flake_dir is not on main — cannot auto-heal safely; align it and re-run"
+    git -C "$flake_dir" pull --ff-only origin main ||
+      fail "auto-heal could not fast-forward $flake_dir to deploy HEAD"
+    sudo /run/current-system/sw/bin/darwin-rebuild switch --flake "$flake_dir" ||
+      fail "auto-heal rebuild failed"
+    local_rev="$(/run/current-system/sw/bin/darwin-version --json 2>/dev/null |
+      jq -r '.configurationRevision // empty')"
+    [ "$local_rev" = "$remote_rev" ] ||
+      fail "still off deploy HEAD after auto-heal (local ${local_rev:0:12}) — investigate before clustering"
+    echo "cluster-join: generation parity restored (${local_rev:0:12})"
+  else
+    echo "cluster-join: generation parity OK (${local_rev:0:12} = deploy HEAD)"
+  fi
+fi
 
 # --- step 1: verify/repair link prep on THIS node --------------------------
 # Prep is healthy when the node's own static link IP is aliased on a physical


### PR DESCRIPTION
## Summary

- cluster-join gains a step-0 preflight: the node's `darwin-version` `configurationRevision` must equal the deploy branch HEAD (`origin/main` of the flake repo, `git ls-remote`, no peer-SSH dependency). Two nodes both at remote HEAD are on the exact same generation by construction.
- Auto-heal: on drift, ff-only pull of the local flake checkout (`clusterMode.generationFlakeDir`) + `darwin-rebuild switch`, then re-verify. Dirty/unstamped generation fails closed; unreachable remote warns (offline joins stay possible); checkout not on `main` fails rather than mutating the operator's branch.
- New options `clusterMode.generationRepoUrl` (default dryvist/nix-darwin; empty disables) and `clusterMode.generationFlakeDir` (empty disables auto-heal only).

Requires the companion nix-darwin change stamping `system.configurationRevision` — until that deploys, the preflight fails closed with a clear message (by design: unstamped generations are unverifiable).

## Test plan

- [x] `nix flake check` clean (shellcheck + statix + regression tests)
- [x] `cluster-mode.nix` stays under the 12KB file-size cap (11,814 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yh8vodT7vPhGKbZNRtoAy