### PR TITLE
fix(mlx): bound how often warmup re-acquires the concurrency slot

### DIFF
--- a/lib/checks/mlx-warmup.nix
+++ b/lib/checks/mlx-warmup.nix
@@ -26,7 +26,7 @@
     # check would stop testing anything.
     export MLX_WARMUP_LAST_ATTEMPT_MARKER="$TMPDIR/warmup-last-attempt"
     export MLX_WARMUP_MIN_INTERVAL_SECONDS=0
-    bash ${./scripts/mlx-warmup-failure-bound.sh}
+    ${pkgs.bash}/bin/bash ${./scripts/mlx-warmup-failure-bound.sh}
   '';
 
   mlx-warmup-min-interval = pkgs.runCommand "check-mlx-warmup-min-interval" { } ''
@@ -43,6 +43,6 @@
     # A large window so the immediate 2nd invocation is unambiguously inside
     # it regardless of how long this check's own steps take to run.
     export MLX_WARMUP_MIN_INTERVAL_SECONDS=1000
-    bash ${./scripts/mlx-warmup-min-interval.sh}
+    ${pkgs.bash}/bin/bash ${./scripts/mlx-warmup-min-interval.sh}
   '';
 }

--- a/lib/checks/mlx-warmup.nix
+++ b/lib/checks/mlx-warmup.nix
@@ -1,15 +1,14 @@
-# Deterministic contract for the warmup restart-livelock fix: a warmup cycle
-# that can never reach the API (unreachable here) must give up after
-# MLX_WARMUP_MAX_CONSECUTIVE_FAILURES consecutive cycles by exiting 0 — which
-# KeepAlive.SuccessfulExit=false in launchd.nix reads as "stop restarting" —
-# instead of exiting 1 forever and re-acquiring the model's llama-swap
-# concurrency slot on every restart. See modules/mlx/scripts/mlx-warmup.py.
+# Deterministic contracts for the warmup restart-livelock fix and its
+# re-invocation bound. Test bodies live in ./scripts/ per this repo's
+# inline-script policy for .nix files; each script's own header explains
+# what it guards. See modules/mlx/scripts/mlx-warmup.py.
 { pkgs, src }:
 {
   mlx-warmup-failure-bound = pkgs.runCommand "check-mlx-warmup-failure-bound" { } ''
     export PATH=${pkgs.python3}/bin:${pkgs.coreutils}/bin:${pkgs.gnugrep}/bin
     export HOME="$TMPDIR/home"
     mkdir -p "$HOME"
+    export MLX_WARMUP_SCRIPT=${src}/modules/mlx/scripts/mlx-warmup.py
     # Port 1 is a reserved/privileged port nothing will ever have bound, so
     # this connection refuses instantly on any host regardless of sandbox
     # network policy — a fast, deterministic stand-in for "proxy unreachable".
@@ -21,32 +20,29 @@
     # sleep — keeps this check fast instead of timing-dependent.
     export MLX_WARMUP_TIMEOUT_SECONDS=0
     export MLX_WARMUP_MAX_CONSECUTIVE_FAILURES=3
+    # This check exercises the failure-streak bound with 4 back-to-back
+    # invocations by design; the separate min-interval bound (tested in
+    # mlx-warmup-min-interval below) would otherwise skip runs 2-4 and this
+    # check would stop testing anything.
+    export MLX_WARMUP_LAST_ATTEMPT_MARKER="$TMPDIR/warmup-last-attempt"
+    export MLX_WARMUP_MIN_INTERVAL_SECONDS=0
+    bash ${./scripts/mlx-warmup-failure-bound.sh}
+  '';
 
-    python3 ${src}/modules/mlx/scripts/mlx-warmup.py > "$TMPDIR/run1.log" 2>&1 && exit1=0 || exit1=$?
-    test "$exit1" -eq 1
-    test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 1
-    grep -q 'WARMUP FAILED (1/3 consecutive)' "$TMPDIR/run1.log"
-
-    python3 ${src}/modules/mlx/scripts/mlx-warmup.py > "$TMPDIR/run2.log" 2>&1 && exit2=0 || exit2=$?
-    test "$exit2" -eq 1
-    test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 2
-    grep -q 'WARMUP FAILED (2/3 consecutive)' "$TMPDIR/run2.log"
-
-    # THE regression this check guards: the 3rd consecutive failure must give
-    # up (exit 0) rather than restart forever. An unbounded/reverted restart
-    # loop would exit 1 here too, and this assertion would fail.
-    python3 ${src}/modules/mlx/scripts/mlx-warmup.py > "$TMPDIR/run3.log" 2>&1 && exit3=0 || exit3=$?
-    test "$exit3" -eq 0
-    test ! -e "$MLX_WARMUP_FAIL_MARKER"
-    grep -q 'WARMUP GIVING UP after 3 consecutive failed cycles' "$TMPDIR/run3.log"
-
-    # A give-up is a resolved outcome, not a permanent one: the next
-    # legitimate trigger (e.g. after a real proxy restart) gets a fresh
-    # budget instead of starting pre-exhausted.
-    python3 ${src}/modules/mlx/scripts/mlx-warmup.py > "$TMPDIR/run4.log" 2>&1 && exit4=0 || exit4=$?
-    test "$exit4" -eq 1
-    test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 1
-
-    touch "$out"
+  mlx-warmup-min-interval = pkgs.runCommand "check-mlx-warmup-min-interval" { } ''
+    export PATH=${pkgs.python3}/bin:${pkgs.coreutils}/bin:${pkgs.gnugrep}/bin
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+    export MLX_WARMUP_SCRIPT=${src}/modules/mlx/scripts/mlx-warmup.py
+    export MLX_API_URL="http://127.0.0.1:1/v1"
+    export MLX_PRELOAD_MODELS_JSON='["test-model"]'
+    export MLX_WARMUP_FAIL_MARKER="$TMPDIR/warmup-failures"
+    export MLX_WARMUP_LAST_ATTEMPT_MARKER="$TMPDIR/warmup-last-attempt"
+    export MLX_WARMUP_TIMEOUT_SECONDS=0
+    export MLX_WARMUP_MAX_CONSECUTIVE_FAILURES=3
+    # A large window so the immediate 2nd invocation is unambiguously inside
+    # it regardless of how long this check's own steps take to run.
+    export MLX_WARMUP_MIN_INTERVAL_SECONDS=1000
+    bash ${./scripts/mlx-warmup-min-interval.sh}
   '';
 }

--- a/lib/checks/scripts/mlx-warmup-failure-bound.sh
+++ b/lib/checks/scripts/mlx-warmup-failure-bound.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Test body for the mlx-warmup-failure-bound check (lib/checks/mlx-warmup.nix).
+# Extracted to its own file per this repo's inline-script policy for .nix
+# files. MLX_WARMUP_SCRIPT and the MLX_WARMUP_* / MLX_* env vars are set by
+# the calling derivation; $out and $TMPDIR come from the Nix build env.
+set -euo pipefail
+
+out="${out:?out not set (expected from the Nix build environment)}"
+
+python3 "$MLX_WARMUP_SCRIPT" > "$TMPDIR/run1.log" 2>&1 && exit1=0 || exit1=$?
+test "$exit1" -eq 1
+test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 1
+grep -q 'WARMUP FAILED (1/3 consecutive)' "$TMPDIR/run1.log"
+
+python3 "$MLX_WARMUP_SCRIPT" > "$TMPDIR/run2.log" 2>&1 && exit2=0 || exit2=$?
+test "$exit2" -eq 1
+test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 2
+grep -q 'WARMUP FAILED (2/3 consecutive)' "$TMPDIR/run2.log"
+
+# THE regression this check guards: the 3rd consecutive failure must give up
+# (exit 0) rather than restart forever. An unbounded/reverted restart loop
+# would exit 1 here too, and this assertion would fail.
+python3 "$MLX_WARMUP_SCRIPT" > "$TMPDIR/run3.log" 2>&1 && exit3=0 || exit3=$?
+test "$exit3" -eq 0
+test ! -e "$MLX_WARMUP_FAIL_MARKER"
+grep -q 'WARMUP GIVING UP after 3 consecutive failed cycles' "$TMPDIR/run3.log"
+
+# A give-up is a resolved outcome, not a permanent one: the next legitimate
+# trigger (e.g. after a real proxy restart) gets a fresh budget instead of
+# starting pre-exhausted.
+python3 "$MLX_WARMUP_SCRIPT" > "$TMPDIR/run4.log" 2>&1 && exit4=0 || exit4=$?
+test "$exit4" -eq 1
+test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 1
+
+touch "$out"

--- a/lib/checks/scripts/mlx-warmup-min-interval.sh
+++ b/lib/checks/scripts/mlx-warmup-min-interval.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Test body for the mlx-warmup-min-interval check (lib/checks/mlx-warmup.nix).
+# Extracted to its own file per this repo's inline-script policy for .nix
+# files. MLX_WARMUP_SCRIPT and the MLX_WARMUP_* / MLX_* env vars are set by
+# the calling derivation; $out and $TMPDIR come from the Nix build env.
+#
+# Deterministic contract for the re-invocation bound (the kickstart-bypass
+# gap): `launchctl kickstart -k` bypasses ThrottleInterval entirely, so
+# something that calls it in a tight loop (observed: cluster-link-watcher.sh
+# re-triggering restore_normal_serving() on every failed rendezvous cycle)
+# must not be able to make mlx-warmup.py re-acquire the preloaded model's
+# llama-swap concurrency slot on every single call. MLX_WARMUP_MIN_INTERVAL_SECONDS
+# bounds that independent of the failure-streak logic in mlx-warmup-failure-bound.sh
+# and independent of exit status. See mlx-warmup.py's RE-INVOCATION BOUND.
+set -euo pipefail
+
+out="${out:?out not set (expected from the Nix build environment)}"
+
+# 1st invocation: no marker yet, so it proceeds and (API unreachable) fails
+# the cycle normally, stamping both markers.
+python3 "$MLX_WARMUP_SCRIPT" > "$TMPDIR/run1.log" 2>&1 && exit1=0 || exit1=$?
+test "$exit1" -eq 1
+test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 1
+test -e "$MLX_WARMUP_LAST_ATTEMPT_MARKER"
+
+# THE regression this check guards: an immediate re-invocation (simulating an
+# external kickstart -k storm) must be skipped rather than attempted — exit
+# 0, no HTTP attempt, and critically the failure streak is left untouched (a
+# skip is not a failure and must not be conflated with one).
+python3 "$MLX_WARMUP_SCRIPT" > "$TMPDIR/run2.log" 2>&1 && exit2=0 || exit2=$?
+test "$exit2" -eq 0
+test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 1
+grep -q 'Skipping warm attempt' "$TMPDIR/run2.log"
+
+# Once the interval has elapsed (simulated by backdating the marker rather
+# than sleeping, to keep this check fast), the next invocation must proceed
+# normally again.
+echo "0" > "$MLX_WARMUP_LAST_ATTEMPT_MARKER"
+python3 "$MLX_WARMUP_SCRIPT" > "$TMPDIR/run3.log" 2>&1 && exit3=0 || exit3=$?
+test "$exit3" -eq 1
+test "$(<"$MLX_WARMUP_FAIL_MARKER")" = 2
+grep -q 'WARMUP FAILED (2/3 consecutive)' "$TMPDIR/run3.log"
+
+touch "$out"

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -31,6 +31,14 @@ let
   # get scanned and come back empty), an underestimate would not be. See
   # scripts/llama-swap-reap.sh for what these protect and why.
   workerPortCount = builtins.length (builtins.attrNames allModels);
+  # Restart/re-attempt throttle shared by both agents below: 120s covers a
+  # 70GB model load (20-60s) with margin, and is also the min-interval floor
+  # handed to mlx-warmup.py (MLX_WARMUP_MIN_INTERVAL_SECONDS) so an external
+  # `launchctl kickstart -k` — which bypasses ThrottleInterval entirely, that
+  # is its whole purpose — cannot re-acquire the warmup concurrency slot any
+  # faster than launchd's own restart already paces it. One number, two
+  # enforcement points, so they cannot drift apart.
+  restartThrottleSeconds = 120;
 in
 {
   config = lib.mkIf cfg.enable {
@@ -70,8 +78,8 @@ in
             ];
             RunAtLoad = true;
             KeepAlive = true;
-            # 2 min throttle — 70GB model loads take 20-60s, prevents rapid crash-restart loops (closes #256)
-            ThrottleInterval = 120;
+            # 70GB model loads take 20-60s, prevents rapid crash-restart loops (closes #256)
+            ThrottleInterval = restartThrottleSeconds;
             # Interactive by default — Background QoS clamps Metal decode ~8x
             # (see options-runtime.nix processType). OOM backstop is the RSS
             # hard limit, not Jetsam eligibility.
@@ -120,7 +128,18 @@ in
         # deliberate give-up, not a success) so this stops restarting it
         # rather than re-acquiring the model's concurrency slot forever. See
         # mlx-warmup.py's MAX_CONSECUTIVE_FAILURES for the restart-livelock
-        # fix itself; ThrottleInterval below only paces each individual retry.
+        # fix itself; ThrottleInterval below only paces launchd's OWN restarts.
+        #
+        # ThrottleInterval does NOT pace an external `launchctl kickstart -k`
+        # of this label — bypassing the throttle is what kickstart -k is FOR.
+        # Both cluster-link-helpers.sh (restore_normal_serving) and
+        # mlx-default.sh kickstart this agent directly, and a caller that
+        # retries a failing operation in a loop and calls
+        # restore_normal_serving() on every attempt re-triggers a full warm
+        # cycle every time with no cooldown from launchd's side at all. See
+        # mlx-warmup.py's RE-INVOCATION BOUND (MLX_WARMUP_MIN_INTERVAL_SECONDS
+        # below) for the fix — a second, independent bound on how often this
+        # process will actually attempt a warm, regardless of trigger.
         mlx-model-server-warmup = {
           enable = true;
           config = {
@@ -130,10 +149,11 @@ in
             KeepAlive = {
               SuccessfulExit = false;
             };
-            ThrottleInterval = 120;
+            ThrottleInterval = restartThrottleSeconds;
             ProcessType = "Background";
             EnvironmentVariables = {
               MLX_API_URL = apiUrl;
+              MLX_WARMUP_MIN_INTERVAL_SECONDS = toString restartThrottleSeconds;
               MLX_PRELOAD_MODELS = lib.concatStringsSep " " cfg.preload;
               MLX_PRELOAD_MODELS_JSON = builtins.toJSON cfg.preload;
               MLX_WARMUP_TIMEOUT_SECONDS = toString warmupTimeoutSeconds;

--- a/modules/mlx/scripts/mlx-warmup.py
+++ b/modules/mlx/scripts/mlx-warmup.py
@@ -23,6 +23,24 @@ streak is tracked in FAIL_MARKER — a plain integer file, one process's
 memory does not survive its own restart — mirroring mlx-watchdog.sh's own
 fail_marker/read_int convention so there is one established pattern for
 "bounded consecutive failures" in this module, not two.
+
+RE-INVOCATION BOUND (the kickstart-bypass gap): the restart bound above only
+covers launchd's OWN KeepAlive restarts, which are paced by the LaunchAgent's
+ThrottleInterval. `launchctl kickstart -k` is a SEPARATE trigger that exists
+specifically to force an immediate (re)start regardless of throttle state, and
+this process is kickstarted that way by more than just launchd itself — e.g.
+modules/mlx/scripts/cluster-link-helpers.sh's restore_normal_serving() and
+mlx-default.sh both do it. A caller that retries a failing operation in a
+tight loop and calls restore_normal_serving() on every attempt (observed:
+cluster-link-watcher.sh's peer-rendezvous-absent standdown, which has no cap
+of its own on that path) re-triggers a full warm cycle every time, and every
+cycle — successful or not — holds the preloaded model's llama-swap
+concurrency slot for as long as the warm takes. MIN_INTERVAL_SECONDS bounds
+how often this process will actually attempt a warm, independent of exit
+status and independent of who is asking, mirroring ThrottleInterval's own
+value (modules/mlx/launchd.nix) so there is one source of truth. A caller
+that needs the model sooner still gets it: llama-swap loads any named model
+on demand for a real request regardless of whether this background job ran.
 """
 
 from __future__ import annotations
@@ -54,6 +72,18 @@ FAIL_MARKER = Path(
         str(Path.home() / "Library/Caches/mlx-model-server/warmup-failures"),
     )
 )
+# Fallback cooldown when MLX_WARMUP_MIN_INTERVAL_SECONDS is unset: matches the
+# ThrottleInterval default on the LaunchAgent (modules/mlx/launchd.nix) so a
+# manual/non-Nix run behaves like the deployed one. See the module docstring's
+# RE-INVOCATION BOUND section for why this exists separately from
+# MAX_CONSECUTIVE_FAILURES.
+DEFAULT_MIN_INTERVAL_SECONDS = 120
+LAST_ATTEMPT_MARKER = Path(
+    os.environ.get(
+        "MLX_WARMUP_LAST_ATTEMPT_MARKER",
+        str(Path.home() / "Library/Caches/mlx-model-server/warmup-last-attempt"),
+    )
+)
 
 
 def read_int(path: Path) -> int:
@@ -66,6 +96,23 @@ def read_int(path: Path) -> int:
 
 def clear_failure_streak() -> None:
     FAIL_MARKER.unlink(missing_ok=True)
+
+
+def seconds_since_last_attempt() -> float | None:
+    """None means "no recorded attempt" (first run, or a corrupt marker) —
+    treated as "cooldown already elapsed" by the caller."""
+    try:
+        return time.time() - float(LAST_ATTEMPT_MARKER.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def record_attempt_start() -> None:
+    """Stamped right before this process actually tries to reach the API —
+    not on a skip — so a min-interval violation is measured start-to-start
+    regardless of how the previous attempt ended."""
+    LAST_ATTEMPT_MARKER.parent.mkdir(parents=True, exist_ok=True)
+    LAST_ATTEMPT_MARKER.write_text(f"{time.time()}\n")
 
 
 def record_cycle_failure(reason: str, max_consecutive: int) -> int:
@@ -210,6 +257,12 @@ def main() -> int:
         default=int(os.environ.get("MLX_WARMUP_MAX_CONSECUTIVE_FAILURES", MAX_CONSECUTIVE_FAILURES)),
         help="Give up (exit 0, stop restarting) after this many consecutive full-cycle failures",
     )
+    parser.add_argument(
+        "--min-interval",
+        type=int,
+        default=int(os.environ.get("MLX_WARMUP_MIN_INTERVAL_SECONDS", DEFAULT_MIN_INTERVAL_SECONDS)),
+        help="Minimum seconds between warm attempts, regardless of trigger or outcome (see RE-INVOCATION BOUND)",
+    )
     args = parser.parse_args()
 
     api_url = os.environ.get("MLX_API_URL")
@@ -222,6 +275,18 @@ def main() -> int:
         print("No preload models configured; nothing to warm.")
         clear_failure_streak()
         return 0
+
+    since_last = seconds_since_last_attempt()
+    if since_last is not None and since_last < args.min_interval:
+        print(
+            f"Skipping warm attempt: the last one started {since_last:.1f}s ago, "
+            f"under the {args.min_interval}s minimum interval. Not a failure — a "
+            "real request to a preloaded model still loads it on demand; this "
+            "only bounds how often this background job re-acquires the "
+            "concurrency slot when something kickstarts it repeatedly."
+        )
+        return 0
+    record_attempt_start()
 
     deadline = time.monotonic() + args.timeout
     models_url = f"{api_url.rstrip('/')}/models"


### PR DESCRIPTION
## Summary

- `launchctl kickstart -k` bypasses `ThrottleInterval` by design (that's its whole purpose), and `dev.mlx-model-server.warmup` is kickstarted directly by more than launchd's own `KeepAlive`: `cluster-link-helpers.sh`'s `restore_normal_serving()` and `mlx-default.sh` both call it. A caller that retries a failing operation in a loop and calls `restore_normal_serving()` on every attempt (observed live: `cluster-link-watcher.sh`'s peer-rendezvous-absent standdown, which has no cap of its own on that specific path) re-triggers a full warm cycle every time, and every cycle — successful or not — holds the preloaded model's llama-swap concurrency slot for as long as the warm takes.
- The existing restart-livelock fix (#1425, merged 2026-07-26) already bounds *consecutive failures* via `MAX_CONSECUTIVE_FAILURES`/`FAIL_MARKER`, and that bound is working correctly — verified live, no regression there. It does not bound *re-invocation rate* for cycles that eventually succeed, which is the gap this closes: a re-invocation storm where each cycle succeeds (just slowly, because the model had to reload) is invisible to a failure-streak counter.
- `mlx-warmup.py` now tracks the last attempt's start time (`LAST_ATTEMPT_MARKER`, mirroring `FAIL_MARKER`'s convention) and skips a re-attempt inside `MLX_WARMUP_MIN_INTERVAL_SECONDS`, independent of exit status. Default mirrors the LaunchAgent's `ThrottleInterval` (120s — both now read from one `restartThrottleSeconds` binding in `launchd.nix`) so there is one source of truth instead of two numbers that could drift. A skip is not a failure and does not touch the failure streak.
- A skip does not leave a real request stranded: llama-swap loads any named model on demand regardless of whether this background optimisation job ran.

## What was deliberately NOT done

- Not touching `modules/mlx/scripts/cluster-link-watcher.sh`. That script's pair-wide-standdown path (peer-rendezvous-absent branch) has no cap analogous to `CLUSTER_MAX_KICKSTARTS` on its `restore_normal_serving()` call, which is the actual external trigger driving the repeated re-invocation observed live tonight. That's cluster rank-formation logic — a bigger, separate, riskier change (every failed rank start leaks a reboot-only RDMA protection domain) that deserves its own dedicated review, not a rider on this PR. Reported separately.
- Not reversing #1425's failure-streak design — extending it, via an independent bound with its own marker and its own reasoning for why `ThrottleInterval` alone doesn't cover this path.

## Test plan

- [x] Both check scripts run directly with system python3 (same scenario the Nix checks exercise): `mlx-warmup-failure-bound.sh` still passes with `MLX_WARMUP_MIN_INTERVAL_SECONDS=0` (proves the new gate doesn't interfere with the existing failure-streak check's 4 back-to-back invocations); `mlx-warmup-min-interval.sh` passes standalone (1st attempt proceeds and fails, immediate 2nd is skipped with the failure streak untouched, 3rd after a backdated marker proceeds and fails again).
- [x] `python3 -m py_compile` + `ast.parse` on `mlx-warmup.py`.
- [x] `nix flake show --system x86_64-linux` evaluates both `checks.x86_64-linux.mlx-warmup-failure-bound` and `checks.x86_64-linux.mlx-warmup-min-interval` with no eval errors (this Mac has no registered Linux builder, so CI is the first environment that can actually build them — same limitation #1425 noted).
- [x] `nixfmt` / `statix` / `deadnix` clean on every changed `.nix` file.
- [x] `shellcheck` clean on both new scripts (fixed one `SC2154` on `$out` using the `${var:?message}` idiom already established elsewhere in this module, e.g. `mlx-watchdog.sh`).
- [x] `pre-commit run` clean on every changed/added file.
- [ ] CI green on this PR.

https://claude.ai/code/session_01MrWxkxkRYGSDxvAPYWvFkg